### PR TITLE
chore: ignore SPECS.md in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# macOS
+.DS_Store
+
+# Node
+node_modules/
+
+# Expo
+.expo/
+.expo-shared/
+
+# Build outputs
+dist/
+build/
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Local development overrides
+.env
+
+# Ignore internal planning docs
+SPECS.md


### PR DESCRIPTION
This PR adds SPECS.md to .gitignore as internal-only plan documentation per workflow rules. resolves #1