### PR TITLE
Add entries.date column and decouple logged day from timestamp

### DIFF
--- a/src/components/CalendarPicker.tsx
+++ b/src/components/CalendarPicker.tsx
@@ -1,0 +1,272 @@
+import React, { useState, useMemo } from "react";
+import {
+    View,
+    Text,
+    Pressable,
+    Modal,
+    StyleSheet,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { colors, spacing, borderRadius, fontSize } from "@/src/utils/theme";
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const MONTH_NAMES = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+];
+
+interface CalendarPickerProps {
+    visible: boolean;
+    selectedDate: Date;
+    onSelect: (date: Date) => void;
+    onClose: () => void;
+}
+
+function isSameDay(a: Date, b: Date) {
+    return (
+        a.getFullYear() === b.getFullYear() &&
+        a.getMonth() === b.getMonth() &&
+        a.getDate() === b.getDate()
+    );
+}
+
+function getMonthGrid(year: number, month: number) {
+    const first = new Date(year, month, 1);
+    // Monday = 0, Sunday = 6
+    const startDay = (first.getDay() + 6) % 7;
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+    const cells: (number | null)[] = [];
+    for (let i = 0; i < startDay; i++) cells.push(null);
+    for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+    // Pad to complete last row
+    while (cells.length % 7 !== 0) cells.push(null);
+    return cells;
+}
+
+export default function CalendarPicker({
+    visible,
+    selectedDate,
+    onSelect,
+    onClose,
+}: CalendarPickerProps) {
+    const [viewYear, setViewYear] = useState(selectedDate.getFullYear());
+    const [viewMonth, setViewMonth] = useState(selectedDate.getMonth());
+
+    // Reset view when opening
+    React.useEffect(() => {
+        if (visible) {
+            setViewYear(selectedDate.getFullYear());
+            setViewMonth(selectedDate.getMonth());
+        }
+    }, [visible, selectedDate]);
+
+    const cells = useMemo(() => getMonthGrid(viewYear, viewMonth), [viewYear, viewMonth]);
+    const today = useMemo(() => new Date(), []);
+
+    function prevMonth() {
+        if (viewMonth === 0) {
+            setViewMonth(11);
+            setViewYear((y) => y - 1);
+        } else {
+            setViewMonth((m) => m - 1);
+        }
+    }
+
+    function nextMonth() {
+        if (viewMonth === 11) {
+            setViewMonth(0);
+            setViewYear((y) => y + 1);
+        } else {
+            setViewMonth((m) => m + 1);
+        }
+    }
+
+    function selectDay(day: number) {
+        onSelect(new Date(viewYear, viewMonth, day));
+    }
+
+    function goToToday() {
+        const now = new Date();
+        onSelect(now);
+    }
+
+    return (
+        <Modal
+            visible={visible}
+            transparent
+            animationType="fade"
+            onRequestClose={onClose}
+        >
+            <Pressable style={styles.backdrop} onPress={onClose}>
+                <Pressable style={styles.card} onPress={() => { }}>
+                    {/* Month/year header */}
+                    <View style={styles.header}>
+                        <Pressable onPress={prevMonth} hitSlop={12}>
+                            <Ionicons
+                                name="chevron-back"
+                                size={22}
+                                color={colors.text}
+                            />
+                        </Pressable>
+                        <Text style={styles.monthTitle}>
+                            {MONTH_NAMES[viewMonth]} {viewYear}
+                        </Text>
+                        <Pressable onPress={nextMonth} hitSlop={12}>
+                            <Ionicons
+                                name="chevron-forward"
+                                size={22}
+                                color={colors.text}
+                            />
+                        </Pressable>
+                    </View>
+
+                    {/* Day-of-week labels */}
+                    <View style={styles.row}>
+                        {DAY_LABELS.map((d) => (
+                            <View key={d} style={styles.cell}>
+                                <Text style={styles.dayLabel}>{d}</Text>
+                            </View>
+                        ))}
+                    </View>
+
+                    {/* Day grid */}
+                    {Array.from(
+                        { length: cells.length / 7 },
+                        (_, weekIdx) => (
+                            <View key={weekIdx} style={styles.row}>
+                                {cells
+                                    .slice(weekIdx * 7, weekIdx * 7 + 7)
+                                    .map((day, cellIdx) => {
+                                        if (day === null) {
+                                            return (
+                                                <View
+                                                    key={cellIdx}
+                                                    style={styles.cell}
+                                                />
+                                            );
+                                        }
+                                        const cellDate = new Date(
+                                            viewYear,
+                                            viewMonth,
+                                            day,
+                                        );
+                                        const isSelected = isSameDay(
+                                            cellDate,
+                                            selectedDate,
+                                        );
+                                        const isToday = isSameDay(
+                                            cellDate,
+                                            today,
+                                        );
+                                        return (
+                                            <Pressable
+                                                key={cellIdx}
+                                                style={[
+                                                    styles.cell,
+                                                    isSelected &&
+                                                    styles.selectedCell,
+                                                ]}
+                                                onPress={() => selectDay(day)}
+                                            >
+                                                <Text
+                                                    style={[
+                                                        styles.dayText,
+                                                        isToday &&
+                                                        styles.todayText,
+                                                        isSelected &&
+                                                        styles.selectedText,
+                                                    ]}
+                                                >
+                                                    {day}
+                                                </Text>
+                                            </Pressable>
+                                        );
+                                    })}
+                            </View>
+                        ),
+                    )}
+
+                    {/* Today button */}
+                    <Pressable style={styles.todayButton} onPress={goToToday}>
+                        <Text style={styles.todayButtonText}>Today</Text>
+                    </Pressable>
+                </Pressable>
+            </Pressable>
+        </Modal>
+    );
+}
+
+const CELL_SIZE = 40;
+
+const styles = StyleSheet.create({
+    backdrop: {
+        flex: 1,
+        backgroundColor: "rgba(0,0,0,0.35)",
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    card: {
+        backgroundColor: colors.surface,
+        borderRadius: borderRadius.lg,
+        padding: spacing.md,
+        width: CELL_SIZE * 7 + spacing.md * 2,
+        elevation: 8,
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.15,
+        shadowRadius: 12,
+    },
+    header: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        marginBottom: spacing.sm,
+    },
+    monthTitle: {
+        fontSize: fontSize.lg,
+        fontWeight: "600",
+        color: colors.text,
+    },
+    row: {
+        flexDirection: "row",
+    },
+    cell: {
+        width: CELL_SIZE,
+        height: CELL_SIZE,
+        alignItems: "center",
+        justifyContent: "center",
+        borderRadius: CELL_SIZE / 2,
+    },
+    dayLabel: {
+        fontSize: fontSize.xs,
+        fontWeight: "500",
+        color: colors.textTertiary,
+    },
+    dayText: {
+        fontSize: fontSize.sm,
+        color: colors.text,
+    },
+    todayText: {
+        color: colors.primary,
+        fontWeight: "700",
+    },
+    selectedCell: {
+        backgroundColor: colors.primary,
+    },
+    selectedText: {
+        color: "#fff",
+        fontWeight: "700",
+    },
+    todayButton: {
+        alignSelf: "center",
+        marginTop: spacing.sm,
+        paddingVertical: spacing.xs,
+        paddingHorizontal: spacing.md,
+    },
+    todayButtonText: {
+        fontSize: fontSize.sm,
+        color: colors.primary,
+        fontWeight: "600",
+    },
+});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -26,6 +26,7 @@ export function initDB() {
       food_id INTEGER REFERENCES foods(id),
       quantity_grams REAL NOT NULL,
       timestamp INTEGER NOT NULL,
+      date TEXT NOT NULL DEFAULT '',
       meal_type TEXT NOT NULL
     );
 
@@ -45,8 +46,16 @@ export function initDB() {
     "ALTER TABLE foods ADD COLUMN barcode TEXT",
     "ALTER TABLE foods ADD COLUMN openfoodfacts_id TEXT",
     "ALTER TABLE foods ADD COLUMN source TEXT NOT NULL DEFAULT 'manual'",
+    "ALTER TABLE entries ADD COLUMN date TEXT NOT NULL DEFAULT ''",
   ];
   for (const sql of migrations) {
     try { expoDb.execSync(sql); } catch { /* column already exists */ }
   }
+
+  // Backfill date column for existing entries that have no date set
+  expoDb.execSync(`
+    UPDATE entries
+    SET date = strftime('%Y-%m-%d', timestamp / 1000, 'unixepoch', 'localtime')
+    WHERE date = '';
+  `);
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,4 +1,4 @@
-import { eq, and, gte, lt, like } from "drizzle-orm";
+import { eq, like } from "drizzle-orm";
 import { db } from "./index";
 import { foods, entries, goals } from "./schema";
 
@@ -41,17 +41,21 @@ export function addEntry(entry: NewEntry): Entry {
     return db.insert(entries).values(entry).returning().get();
 }
 
+export function formatDateKey(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+}
+
 export function getEntriesByDate(date: Date) {
-    const start = new Date(date);
-    start.setHours(0, 0, 0, 0);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 1);
+    const key = formatDateKey(date);
 
     return db
         .select()
         .from(entries)
         .leftJoin(foods, eq(entries.food_id, foods.id))
-        .where(and(gte(entries.timestamp, start.getTime()), lt(entries.timestamp, end.getTime())))
+        .where(eq(entries.date, key))
         .orderBy(entries.timestamp)
         .all();
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,6 +17,7 @@ export const entries = sqliteTable("entries", {
     food_id: integer("food_id").references(() => foods.id),
     quantity_grams: real("quantity_grams").notNull(),
     timestamp: integer("timestamp").notNull(),
+    date: text("date").notNull(),
     meal_type: text("meal_type").notNull(),
 });
 

--- a/src/features/db/DbTestScreen.tsx
+++ b/src/features/db/DbTestScreen.tsx
@@ -26,6 +26,7 @@ export default function DbTestScreen() {
                 quantity_grams: 50,
                 timestamp: Date.now(),
                 meal_type: "breakfast",
+                date: new Date().toISOString().split("T")[0],
             });
             log(`Added entry id=${entry.id}`);
 

--- a/src/features/log/DateSelectorBar.tsx
+++ b/src/features/log/DateSelectorBar.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { colors, spacing, borderRadius, fontSize } from "@/src/utils/theme";
+import CalendarPicker from "@/src/components/CalendarPicker";
+
+interface DateSelectorBarProps {
+    date: Date;
+    onDateChange: (date: Date) => void;
+}
+
+function isSameDay(a: Date, b: Date) {
+    return (
+        a.getFullYear() === b.getFullYear() &&
+        a.getMonth() === b.getMonth() &&
+        a.getDate() === b.getDate()
+    );
+}
+
+export default function DateSelectorBar({
+    date,
+    onDateChange,
+}: DateSelectorBarProps) {
+    const [calendarVisible, setCalendarVisible] = useState(false);
+
+    function shiftDay(delta: number) {
+        const next = new Date(date);
+        next.setDate(next.getDate() + delta);
+        onDateChange(next);
+    }
+
+    const today = new Date();
+    const isToday = isSameDay(date, today);
+
+    const label = isToday
+        ? "Today"
+        : date.toLocaleDateString("en-US", {
+            weekday: "short",
+            month: "short",
+            day: "numeric",
+        });
+
+    return (
+        <>
+            <View style={styles.container}>
+                <Pressable
+                    onPress={() => shiftDay(-1)}
+                    hitSlop={12}
+                    style={styles.arrow}
+                >
+                    <Ionicons
+                        name="chevron-back"
+                        size={22}
+                        color={colors.text}
+                    />
+                </Pressable>
+
+                <Pressable
+                    onPress={() => setCalendarVisible(true)}
+                    style={styles.dateButton}
+                >
+                    <Text style={styles.dateText}>{label}</Text>
+                    <Ionicons
+                        name="calendar-outline"
+                        size={16}
+                        color={colors.textSecondary}
+                        style={styles.calendarIcon}
+                    />
+                </Pressable>
+
+                <Pressable
+                    onPress={() => shiftDay(1)}
+                    hitSlop={12}
+                    style={styles.arrow}
+                >
+                    <Ionicons
+                        name="chevron-forward"
+                        size={22}
+                        color={colors.text}
+                    />
+                </Pressable>
+            </View>
+
+            <CalendarPicker
+                visible={calendarVisible}
+                selectedDate={date}
+                onSelect={(d) => {
+                    onDateChange(d);
+                    setCalendarVisible(false);
+                }}
+                onClose={() => setCalendarVisible(false)}
+            />
+        </>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        backgroundColor: colors.surface,
+        borderRadius: borderRadius.lg,
+        paddingVertical: spacing.sm,
+        paddingHorizontal: spacing.sm,
+        marginBottom: spacing.md,
+    },
+    arrow: {
+        padding: spacing.xs,
+    },
+    dateButton: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: spacing.xs,
+    },
+    dateText: {
+        fontSize: fontSize.md,
+        fontWeight: "600",
+        color: colors.text,
+    },
+    calendarIcon: {
+        marginLeft: 2,
+    },
+});

--- a/src/features/log/EntryModal.tsx
+++ b/src/features/log/EntryModal.tsx
@@ -11,11 +11,13 @@ import {
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { colors, spacing, borderRadius, fontSize } from "@/src/utils/theme";
-import { addEntry, type Food } from "@/src/db/queries";
+import { addEntry, formatDateKey, type Food } from "@/src/db/queries";
+import { useAppStore } from "@/src/store/useAppStore";
 import { MEAL_TYPES, type MealType } from "@/src/types";
 import logger from "@/src/utils/logger";
 import Button from "@/src/components/Button";
 import Input from "@/src/components/Input";
+import { timestamp } from "drizzle-orm/gel-core";
 
 interface EntryModalProps {
     food: Food | null;
@@ -30,6 +32,7 @@ export default function EntryModal({
     onClose,
     onSaved,
 }: EntryModalProps) {
+    const selectedDate = useAppStore((s) => s.selectedDate);
     const [quantity, setQuantity] = useState("100");
     const [mealType, setMealType] = useState<MealType>(
         defaultMealType ?? "breakfast",
@@ -55,12 +58,14 @@ export default function EntryModal({
             food_id: food.id,
             quantity_grams: qty,
             timestamp: Date.now(),
+            date: formatDateKey(selectedDate),
             meal_type: mealType,
         });
         logger.info("[DB] Added entry", {
             foodId: food.id,
             quantity: qty,
-            mealType,
+            date: formatDateKey(selectedDate),
+            mealType: mealType
         });
         setQuantity("100");
         onSaved();

--- a/src/features/log/LogScreen.tsx
+++ b/src/features/log/LogScreen.tsx
@@ -1,14 +1,23 @@
-import React, { useCallback, useState } from "react";
-import { View, ScrollView, Text, StyleSheet, Pressable } from "react-native";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+    View,
+    ScrollView,
+    StyleSheet,
+    Pressable,
+    Dimensions,
+    type NativeSyntheticEvent,
+    type NativeScrollEvent,
+} from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
-import { colors, spacing, fontSize } from "@/src/utils/theme";
+import { colors, spacing } from "@/src/utils/theme";
 import { getEntriesByDate, deleteEntry, getGoals, type Food, type Entry, type Goals } from "@/src/db/queries";
 import { useAppStore } from "@/src/store/useAppStore";
 import { MEAL_TYPES, type MealType } from "@/src/types";
 import logger from "@/src/utils/logger";
 import MealSection from "./MealSection";
+import DateSelectorBar from "./DateSelectorBar";
 import DailyProgressBar from "./DailyProgressBar";
 
 interface EntryWithFood {
@@ -16,67 +25,32 @@ interface EntryWithFood {
     foods: Food | null;
 }
 
-export default function LogScreen() {
-    const selectedDate = useAppStore((s) => s.selectedDate);
-    const [grouped, setGrouped] = useState<Record<MealType, EntryWithFood[]>>({
+const SCREEN_WIDTH = Dimensions.get("window").width;
+
+function getDateShifted(date: Date, delta: number) {
+    const d = new Date(date);
+    d.setDate(d.getDate() + delta);
+    return d;
+}
+
+function loadGrouped(date: Date) {
+    const rows = getEntriesByDate(date);
+    const map: Record<MealType, EntryWithFood[]> = {
         breakfast: [],
         lunch: [],
         dinner: [],
         snack: [],
-    });
-    const [dailyGoals, setDailyGoals] = useState<Goals>({
-        id: 1,
-        calories: 2000,
-        protein: 150,
-        carbs: 250,
-        fat: 70,
-    });
-
-    const loadEntries = useCallback(() => {
-        const rows = getEntriesByDate(selectedDate);
-        const map: Record<MealType, EntryWithFood[]> = {
-            breakfast: [],
-            lunch: [],
-            dinner: [],
-            snack: [],
-        };
-        for (const row of rows) {
-            const mt = row.entries.meal_type as MealType;
-            if (map[mt]) map[mt].push(row);
-        }
-        setGrouped(map);
-
-        const g = getGoals();
-        if (g) setDailyGoals(g);
-    }, [selectedDate]);
-
-    useFocusEffect(
-        useCallback(() => {
-            loadEntries();
-        }, [loadEntries]),
-    );
-
-    function handleDelete(id: number) {
-        deleteEntry(id);
-        logger.info("[DB] Deleted entry", { id });
-        loadEntries();
+    };
+    for (const row of rows) {
+        const mt = row.entries.meal_type as MealType;
+        if (map[mt]) map[mt].push(row);
     }
+    return map;
+}
 
-    function navigateToAdd(mealType?: MealType) {
-        router.push({
-            pathname: "/log/add",
-            params: mealType ? { mealType } : undefined,
-        });
-    }
-
-    const dateLabel = selectedDate.toLocaleDateString("en-US", {
-        weekday: "long",
-        month: "short",
-        day: "numeric",
-    });
-
-    const allEntries = Object.values(grouped).flat();
-    const dailyTotals = allEntries.reduce(
+function computeTotals(grouped: Record<MealType, EntryWithFood[]>) {
+    const all = Object.values(grouped).flat();
+    return all.reduce(
         (acc, row) => {
             const qty = row.entries.quantity_grams;
             const food = row.foods;
@@ -90,17 +64,27 @@ export default function LogScreen() {
         },
         { calories: 0, protein: 0, carbs: 0, fat: 0 },
     );
+}
 
+function DayPage({
+    grouped,
+    goals,
+    onAdd,
+    onDelete,
+}: {
+    grouped: Record<MealType, EntryWithFood[]>;
+    goals: Goals;
+    onAdd: (mt: MealType) => void;
+    onDelete: (id: number) => void;
+}) {
     return (
-        <View style={styles.screen}>
+        <View style={styles.dayPage}>
             <ScrollView
                 contentContainerStyle={styles.content}
                 showsVerticalScrollIndicator={false}
+                nestedScrollEnabled
             >
-                <Text style={styles.dateLabel}>{dateLabel}</Text>
-
-                <DailyProgressBar totals={dailyTotals} goals={dailyGoals} />
-
+                <DailyProgressBar totals={computeTotals(grouped)} goals={goals} />
                 {MEAL_TYPES.map((meal) => (
                     <MealSection
                         key={meal.key}
@@ -108,10 +92,140 @@ export default function LogScreen() {
                         label={meal.label}
                         icon={meal.icon}
                         items={grouped[meal.key]}
-                        onAdd={() => navigateToAdd(meal.key)}
-                        onDeleteEntry={handleDelete}
+                        onAdd={() => onAdd(meal.key)}
+                        onDeleteEntry={onDelete}
                     />
                 ))}
+            </ScrollView>
+        </View>
+    );
+}
+
+export default function LogScreen() {
+    const selectedDate = useAppStore((s) => s.selectedDate);
+    const setSelectedDate = useAppStore((s) => s.setSelectedDate);
+    const dateRef = useRef(selectedDate);
+    dateRef.current = selectedDate;
+
+    const carouselRef = useRef<ScrollView>(null);
+    const isSettling = useRef(false);
+
+    const [grouped, setGrouped] = useState<Record<MealType, EntryWithFood[]>>({
+        breakfast: [],
+        lunch: [],
+        dinner: [],
+        snack: [],
+    });
+    const [prevGrouped, setPrevGrouped] = useState<Record<MealType, EntryWithFood[]>>({
+        breakfast: [],
+        lunch: [],
+        dinner: [],
+        snack: [],
+    });
+    const [nextGrouped, setNextGrouped] = useState<Record<MealType, EntryWithFood[]>>({
+        breakfast: [],
+        lunch: [],
+        dinner: [],
+        snack: [],
+    });
+    const [dailyGoals, setDailyGoals] = useState<Goals>({
+        id: 1,
+        calories: 2000,
+        protein: 150,
+        carbs: 250,
+        fat: 70,
+    });
+
+    function loadAllDays(center: Date) {
+        setGrouped(loadGrouped(center));
+        setPrevGrouped(loadGrouped(getDateShifted(center, -1)));
+        setNextGrouped(loadGrouped(getDateShifted(center, +1)));
+        const g = getGoals();
+        if (g) setDailyGoals(g);
+    }
+
+    useFocusEffect(
+        useCallback(() => {
+            loadAllDays(selectedDate);
+        }, [selectedDate]),
+    );
+
+    // After date changes (from any source), snap carousel back to center page.
+    // Delay re-enabling swipe detection so any residual scroll events are ignored.
+    useEffect(() => {
+        carouselRef.current?.scrollTo({ x: SCREEN_WIDTH, animated: false });
+        const timer = setTimeout(() => {
+            isSettling.current = false;
+        }, 150);
+        return () => clearTimeout(timer);
+    }, [selectedDate]);
+
+    function handleScrollEnd(e: NativeSyntheticEvent<NativeScrollEvent>) {
+        if (isSettling.current) return;
+        const page = Math.round(e.nativeEvent.contentOffset.x / SCREEN_WIDTH);
+        if (page === 0) {
+            isSettling.current = true;
+            const newDate = getDateShifted(dateRef.current, -1);
+            loadAllDays(newDate);
+            setSelectedDate(newDate);
+        } else if (page === 2) {
+            isSettling.current = true;
+            const newDate = getDateShifted(dateRef.current, 1);
+            loadAllDays(newDate);
+            setSelectedDate(newDate);
+        }
+    }
+
+    function handleDelete(id: number) {
+        deleteEntry(id);
+        logger.info("[DB] Deleted entry", { id });
+        loadAllDays(selectedDate);
+    }
+
+    function navigateToAdd(mealType?: MealType) {
+        router.push({
+            pathname: "/log/add",
+            params: mealType ? { mealType } : undefined,
+        });
+    }
+
+    return (
+        <View style={styles.screen}>
+            <View style={styles.dateSelectorWrapper}>
+                <DateSelectorBar
+                    date={selectedDate}
+                    onDateChange={setSelectedDate}
+                />
+            </View>
+
+            <ScrollView
+                ref={carouselRef}
+                horizontal
+                pagingEnabled
+                showsHorizontalScrollIndicator={false}
+                scrollEventThrottle={16}
+                onMomentumScrollEnd={handleScrollEnd}
+                contentOffset={{ x: SCREEN_WIDTH, y: 0 }}
+                style={styles.carousel}
+            >
+                <DayPage
+                    grouped={prevGrouped}
+                    goals={dailyGoals}
+                    onAdd={navigateToAdd}
+                    onDelete={handleDelete}
+                />
+                <DayPage
+                    grouped={grouped}
+                    goals={dailyGoals}
+                    onAdd={navigateToAdd}
+                    onDelete={handleDelete}
+                />
+                <DayPage
+                    grouped={nextGrouped}
+                    goals={dailyGoals}
+                    onAdd={navigateToAdd}
+                    onDelete={handleDelete}
+                />
             </ScrollView>
 
             {/* Floating add button */}
@@ -130,12 +244,10 @@ export default function LogScreen() {
 
 const styles = StyleSheet.create({
     screen: { flex: 1, backgroundColor: colors.background },
+    dateSelectorWrapper: { paddingHorizontal: spacing.md, paddingTop: spacing.md },
+    carousel: { flex: 1 },
+    dayPage: { width: SCREEN_WIDTH },
     content: { padding: spacing.md, paddingBottom: 100 },
-    dateLabel: {
-        fontSize: fontSize.sm,
-        color: colors.textSecondary,
-        marginBottom: spacing.md,
-    },
     fab: {
         position: "absolute",
         bottom: 24,


### PR DESCRIPTION
Adds `date` column (YYYY-MM-DD) to `entries` and backfills from `timestamp`.

Updates `getEntriesByDate` to filter by `date` and uses app `selectedDate` when creating entries (EntryModal). Keeps `timestamp` for sorting within a day.

Files changed:
- src/db/schema.ts
- src/db/index.ts
- src/db/queries.ts
- src/features/log/EntryModal.tsx

Closes #10 
