### PR TITLE
Issue 17: Add unit support and settings

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -18,13 +18,16 @@ export function initDB() {
       fat_per_100g REAL NOT NULL DEFAULT 0,
       barcode TEXT,
       openfoodfacts_id TEXT,
-      source TEXT NOT NULL DEFAULT 'manual'
+      source TEXT NOT NULL DEFAULT 'manual',
+      default_unit TEXT NOT NULL DEFAULT 'g',
+      serving_size REAL NOT NULL DEFAULT 100
     );
 
     CREATE TABLE IF NOT EXISTS entries (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       food_id INTEGER REFERENCES foods(id),
       quantity_grams REAL NOT NULL,
+      quantity_unit TEXT NOT NULL DEFAULT 'g',
       timestamp INTEGER NOT NULL,
       date TEXT NOT NULL DEFAULT '',
       meal_type TEXT NOT NULL,
@@ -37,7 +40,8 @@ export function initDB() {
       calories REAL NOT NULL DEFAULT 2000,
       protein REAL NOT NULL DEFAULT 150,
       carbs REAL NOT NULL DEFAULT 250,
-      fat REAL NOT NULL DEFAULT 70
+      fat REAL NOT NULL DEFAULT 70,
+      unit_system TEXT NOT NULL DEFAULT 'metric'
     );
 
     CREATE TABLE IF NOT EXISTS recipes (
@@ -49,7 +53,8 @@ export function initDB() {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       recipe_id INTEGER NOT NULL REFERENCES recipes(id),
       food_id INTEGER NOT NULL REFERENCES foods(id),
-      quantity_grams REAL NOT NULL
+      quantity_grams REAL NOT NULL,
+      quantity_unit TEXT NOT NULL DEFAULT 'g'
     );
 
     INSERT OR IGNORE INTO goals (id) VALUES (1);
@@ -63,6 +68,11 @@ export function initDB() {
     "ALTER TABLE entries ADD COLUMN date TEXT NOT NULL DEFAULT ''",
     "ALTER TABLE entries ADD COLUMN recipe_id INTEGER",
     "ALTER TABLE entries ADD COLUMN recipe_log_group TEXT",
+    "ALTER TABLE foods ADD COLUMN default_unit TEXT NOT NULL DEFAULT 'g'",
+    "ALTER TABLE foods ADD COLUMN serving_size REAL NOT NULL DEFAULT 100",
+    "ALTER TABLE entries ADD COLUMN quantity_unit TEXT NOT NULL DEFAULT 'g'",
+    "ALTER TABLE goals ADD COLUMN unit_system TEXT NOT NULL DEFAULT 'metric'",
+    "ALTER TABLE recipe_items ADD COLUMN quantity_unit TEXT NOT NULL DEFAULT 'g'",
   ];
   for (const sql of migrations) {
     try { expoDb.execSync(sql); } catch { /* column already exists */ }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -148,6 +148,7 @@ export function logRecipeToMeal(
             .values({
                 food_id: row.recipe_items.food_id,
                 quantity_grams: row.recipe_items.quantity_grams,
+                quantity_unit: row.recipe_items.quantity_unit ?? "g",
                 timestamp: ts,
                 date,
                 meal_type: mealType,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -10,12 +10,15 @@ export const foods = sqliteTable("foods", {
     barcode: text("barcode"),
     openfoodfacts_id: text("openfoodfacts_id"),
     source: text("source").notNull().default("manual"),
+    default_unit: text("default_unit").notNull().default("g"),
+    serving_size: real("serving_size").notNull().default(100),
 });
 
 export const entries = sqliteTable("entries", {
     id: integer("id").primaryKey({ autoIncrement: true }),
     food_id: integer("food_id").references(() => foods.id),
     quantity_grams: real("quantity_grams").notNull(),
+    quantity_unit: text("quantity_unit").notNull().default("g"),
     timestamp: integer("timestamp").notNull(),
     date: text("date").notNull(),
     meal_type: text("meal_type").notNull(),
@@ -29,6 +32,7 @@ export const goals = sqliteTable("goals", {
     protein: real("protein").notNull().default(150),
     carbs: real("carbs").notNull().default(250),
     fat: real("fat").notNull().default(70),
+    unit_system: text("unit_system").notNull().default("metric"),
 });
 
 export const recipes = sqliteTable("recipes", {
@@ -41,4 +45,5 @@ export const recipeItems = sqliteTable("recipe_items", {
     recipe_id: integer("recipe_id").notNull().references(() => recipes.id),
     food_id: integer("food_id").notNull().references(() => foods.id),
     quantity_grams: real("quantity_grams").notNull(),
+    quantity_unit: text("quantity_unit").notNull().default("g"),
 });

--- a/src/features/log/AddFoodScreen.tsx
+++ b/src/features/log/AddFoodScreen.tsx
@@ -22,6 +22,8 @@ import {
 } from "@/src/db/queries";
 import {
     searchProducts,
+    guessUnit,
+    parseServingSize,
     type OFFProduct,
 } from "@/src/services/openfoodfacts";
 import logger from "@/src/utils/logger";
@@ -125,6 +127,8 @@ export default function AddFoodScreen() {
             fat_per_100g: product.nutriments?.fat_100g ?? 0,
             openfoodfacts_id: product.code,
             source: "openfoodfacts",
+            default_unit: guessUnit(product),
+            serving_size: parseServingSize(product),
         });
         logger.info("[DB] Created food from OFF search", {
             id: food.id,

--- a/src/features/log/EntryModal.tsx
+++ b/src/features/log/EntryModal.tsx
@@ -14,10 +14,10 @@ import { colors, spacing, borderRadius, fontSize } from "@/src/utils/theme";
 import { addEntry, updateEntry, formatDateKey, type Food, type Entry } from "@/src/db/queries";
 import { useAppStore } from "@/src/store/useAppStore";
 import { MEAL_TYPES, type MealType } from "@/src/types";
+import { type FoodUnit, toGrams, fromGrams, unitLabel, unitsForSystem } from "@/src/utils/units";
 import logger from "@/src/utils/logger";
 import Button from "@/src/components/Button";
 import Input from "@/src/components/Input";
-import { timestamp } from "drizzle-orm/gel-core";
 
 interface EntryModalProps {
     food: Food | null;
@@ -35,60 +35,75 @@ export default function EntryModal({
     onSaved,
 }: EntryModalProps) {
     const selectedDate = useAppStore((s) => s.selectedDate);
+    const unitSystem = useAppStore((s) => s.unitSystem);
     const [quantity, setQuantity] = useState("100");
+    const [unit, setUnit] = useState<FoodUnit>("g");
     const [mealType, setMealType] = useState<MealType>(
         defaultMealType ?? "breakfast",
     );
 
-    // initialize when editing an existing entry
+    // initialize when food or entry changes
     React.useEffect(() => {
         if (entry) {
-            setQuantity(String(entry.quantity_grams));
+            const entryUnit = (entry.quantity_unit ?? "g") as FoodUnit;
+            setUnit(entryUnit);
+            setQuantity(String(Math.round(fromGrams(entry.quantity_grams, entryUnit) * 10) / 10));
             setMealType(entry.meal_type as MealType);
+        } else if (food) {
+            const defaultUnit = (food.default_unit ?? "g") as FoodUnit;
+            setUnit(defaultUnit);
+            setQuantity(String(food.serving_size ?? 100));
+            setMealType(defaultMealType ?? "breakfast");
         } else {
             setQuantity("100");
+            setUnit("g");
             setMealType(defaultMealType ?? "breakfast");
         }
-    }, [entry, defaultMealType]);
+    }, [entry, food, defaultMealType]);
 
     const qty = parseFloat(quantity) || 0;
+    const qtyGrams = toGrams(qty, unit);
 
     const calculated = useMemo(() => {
         if (!food) return { calories: 0, protein: 0, carbs: 0, fat: 0 };
-        const factor = qty / 100;
+        const factor = qtyGrams / 100;
         return {
             calories: food.calories_per_100g * factor,
             protein: food.protein_per_100g * factor,
             carbs: food.carbs_per_100g * factor,
             fat: food.fat_per_100g * factor,
         };
-    }, [food, qty]);
+    }, [food, qtyGrams]);
 
     function handleSave() {
         if (!food || qty <= 0) return;
 
         if (entry) {
             updateEntry(entry.id, {
-                quantity_grams: qty,
+                quantity_grams: qtyGrams,
+                quantity_unit: unit,
                 meal_type: mealType,
             });
             logger.info("[DB] Updated entry", {
                 id: entry.id,
                 foodId: food.id,
-                quantity: qty,
+                quantity: qtyGrams,
+                unit,
                 mealType: mealType,
             });
         } else {
             addEntry({
                 food_id: food.id,
-                quantity_grams: qty,
+                quantity_grams: qtyGrams,
+                quantity_unit: unit,
                 timestamp: Date.now(),
                 date: formatDateKey(selectedDate),
                 meal_type: mealType,
             });
             logger.info("[DB] Added entry", {
                 foodId: food.id,
-                quantity: qty,
+                quantity: qtyGrams,
+                unit,
                 date: formatDateKey(selectedDate),
                 mealType: mealType,
             });
@@ -102,6 +117,8 @@ export default function EntryModal({
         setQuantity("100");
         onClose();
     }
+
+    const unitOptions = unitsForSystem(unitSystem);
 
     return (
         <Modal
@@ -143,9 +160,37 @@ export default function EntryModal({
                         value={quantity}
                         onChangeText={setQuantity}
                         keyboardType="decimal-pad"
-                        suffix="g"
+                        suffix={unitLabel(unit)}
                         containerStyle={styles.quantityInput}
                     />
+
+                    {/* Unit picker */}
+                    <Text style={styles.sectionLabel}>Unit</Text>
+                    <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={styles.unitRow}
+                    >
+                        {unitOptions.map((u) => (
+                            <Pressable
+                                key={u}
+                                onPress={() => setUnit(u)}
+                                style={[
+                                    styles.unitChip,
+                                    unit === u && styles.unitChipActive,
+                                ]}
+                            >
+                                <Text
+                                    style={[
+                                        styles.unitChipText,
+                                        unit === u && styles.unitChipTextActive,
+                                    ]}
+                                >
+                                    {unitLabel(u)}
+                                </Text>
+                            </Pressable>
+                        ))}
+                    </ScrollView>
 
                     {/* Live calculation */}
                     <View style={styles.calcCard}>
@@ -258,6 +303,31 @@ const styles = StyleSheet.create({
         marginTop: spacing.xs,
     },
     quantityInput: { marginTop: spacing.lg },
+    unitRow: {
+        flexDirection: "row",
+        gap: spacing.sm,
+        paddingBottom: spacing.sm,
+    },
+    unitChip: {
+        paddingHorizontal: spacing.md,
+        paddingVertical: spacing.sm,
+        borderRadius: borderRadius.sm,
+        backgroundColor: colors.surface,
+        borderWidth: 1,
+        borderColor: colors.border,
+    },
+    unitChipActive: {
+        backgroundColor: colors.primaryLight,
+        borderColor: colors.primary,
+    },
+    unitChipText: {
+        fontSize: fontSize.sm,
+        color: colors.textSecondary,
+    },
+    unitChipTextActive: {
+        color: colors.primary,
+        fontWeight: "600",
+    },
     calcCard: {
         backgroundColor: colors.surface,
         borderRadius: borderRadius.md,

--- a/src/features/log/LogScreen.tsx
+++ b/src/features/log/LogScreen.tsx
@@ -138,6 +138,7 @@ export default function LogScreen() {
         protein: 150,
         carbs: 250,
         fat: 70,
+        unit_system: "metric",
     });
 
     const [editingEntry, setEditingEntry] = useState<EntryWithFood | null>(null);
@@ -147,7 +148,13 @@ export default function LogScreen() {
         setPrevGrouped(loadGrouped(getDateShifted(center, -1)));
         setNextGrouped(loadGrouped(getDateShifted(center, +1)));
         const g = getGoals();
-        if (g) setDailyGoals(g);
+        if (g) {
+            setDailyGoals(g);
+            // Sync unit system from DB into store
+            if (g.unit_system === "metric" || g.unit_system === "imperial") {
+                useAppStore.getState().setUnitSystem(g.unit_system as "metric" | "imperial");
+            }
+        }
     }
 
     useFocusEffect(

--- a/src/features/log/ManualFoodForm.tsx
+++ b/src/features/log/ManualFoodForm.tsx
@@ -12,6 +12,8 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { colors, spacing, borderRadius, fontSize } from "@/src/utils/theme";
 import { addFood, type Food } from "@/src/db/queries";
+import { useAppStore } from "@/src/store/useAppStore";
+import { type FoodUnit, unitLabel, unitsForSystem } from "@/src/utils/units";
 import logger from "@/src/utils/logger";
 import Button from "@/src/components/Button";
 import Input from "@/src/components/Input";
@@ -27,11 +29,13 @@ export default function ManualFoodForm({
     onClose,
     onFoodCreated,
 }: ManualFoodFormProps) {
+    const unitSystem = useAppStore((s) => s.unitSystem);
     const [name, setName] = useState("");
     const [calories, setCalories] = useState("");
     const [protein, setProtein] = useState("");
     const [carbs, setCarbs] = useState("");
     const [fat, setFat] = useState("");
+    const [defaultUnit, setDefaultUnit] = useState<FoodUnit>("g");
 
     function handleSave() {
         const trimmedName = name.trim();
@@ -44,6 +48,7 @@ export default function ManualFoodForm({
             carbs_per_100g: parseFloat(carbs) || 0,
             fat_per_100g: parseFloat(fat) || 0,
             source: "manual",
+            default_unit: defaultUnit,
         });
         logger.info("[DB] Created food manually", { id: food.id, name: food.name });
         resetForm();
@@ -56,6 +61,7 @@ export default function ManualFoodForm({
         setProtein("");
         setCarbs("");
         setFat("");
+        setDefaultUnit("g");
     }
 
     function handleClose() {
@@ -99,12 +105,40 @@ export default function ManualFoodForm({
                     />
 
                     <Text style={styles.sectionLabel}>
+                        Default unit
+                    </Text>
+                    <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={styles.unitRow}
+                    >
+                        {unitsForSystem(unitSystem).map((u) => (
+                            <Pressable
+                                key={u}
+                                onPress={() => setDefaultUnit(u)}
+                                style={[
+                                    styles.unitChip,
+                                    defaultUnit === u && styles.unitChipActive,
+                                ]}
+                            >
+                                <Text
+                                    style={[
+                                        styles.unitChipText,
+                                        defaultUnit === u && styles.unitChipTextActive,
+                                    ]}
+                                >
+                                    {unitLabel(u)}
+                                </Text>
+                            </Pressable>
+                        ))}
+                    </ScrollView>
+
+                    <Text style={styles.sectionLabel}>
                         Nutrition per 100 g
                     </Text>
 
                     <View style={styles.row}>
                         <Input
-                            label="Calories"
                             placeholder="0"
                             suffix="kcal"
                             value={calories}
@@ -184,6 +218,31 @@ const styles = StyleSheet.create({
         color: colors.textSecondary,
         marginBottom: spacing.md,
         marginTop: spacing.sm,
+    },
+    unitRow: {
+        flexDirection: "row",
+        gap: spacing.sm,
+        marginBottom: spacing.md,
+    },
+    unitChip: {
+        paddingHorizontal: spacing.md,
+        paddingVertical: spacing.sm,
+        borderRadius: borderRadius.sm,
+        backgroundColor: colors.surface,
+        borderWidth: 1,
+        borderColor: colors.border,
+    },
+    unitChipActive: {
+        backgroundColor: colors.primaryLight,
+        borderColor: colors.primary,
+    },
+    unitChipText: {
+        fontSize: fontSize.sm,
+        color: colors.textSecondary,
+    },
+    unitChipTextActive: {
+        color: colors.primary,
+        fontWeight: "600",
     },
     row: {
         flexDirection: "row",

--- a/src/features/log/MealSection.tsx
+++ b/src/features/log/MealSection.tsx
@@ -5,6 +5,7 @@ import { colors, spacing, borderRadius, fontSize } from "@/src/utils/theme";
 import type { Food, Entry } from "@/src/db/queries";
 import { getRecipeById } from "@/src/db/queries";
 import type { MealType } from "@/src/types";
+import { type FoodUnit, fromGrams, formatQuantity } from "@/src/utils/units";
 
 interface EntryWithFood {
     entries: Entry;
@@ -139,6 +140,8 @@ function EntryRow({
 }) {
     const food = row.foods;
     const qty = row.entries.quantity_grams;
+    const entryUnit = (row.entries.quantity_unit ?? "g") as FoodUnit;
+    const displayQty = fromGrams(qty, entryUnit);
     const cals = food ? Math.round((food.calories_per_100g * qty) / 100) : 0;
 
     return (
@@ -152,7 +155,7 @@ function EntryRow({
                     {food?.name ?? "Unknown food"}
                 </Text>
                 <Text style={styles.entryDetail}>
-                    {qty}g · {cals} cal
+                    {formatQuantity(Math.round(displayQty * 10) / 10, entryUnit)} · {cals} cal
                 </Text>
             </View>
             <Pressable onPress={() => onDeleteEntry(row.entries.id)} hitSlop={8}>

--- a/src/features/log/RecipeLogModal.tsx
+++ b/src/features/log/RecipeLogModal.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/src/db/queries";
 import { useAppStore } from "@/src/store/useAppStore";
 import { MEAL_TYPES, type MealType } from "@/src/types";
+import { type FoodUnit, fromGrams, formatQuantity } from "@/src/utils/units";
 import logger from "@/src/utils/logger";
 import Button from "@/src/components/Button";
 
@@ -84,13 +85,15 @@ export default function RecipeLogModal({
                 {items.map((row) => {
                     const food = row.foods;
                     const qty = row.recipe_items.quantity_grams;
+                    const itemUnit = (row.recipe_items.quantity_unit ?? "g") as FoodUnit;
+                    const displayQty = fromGrams(qty, itemUnit);
                     const cals = food ? Math.round((food.calories_per_100g * qty) / 100) : 0;
                     return (
                         <View key={row.recipe_items.id} style={styles.itemRow}>
                             <Text style={styles.itemName} numberOfLines={1}>
                                 {food?.name ?? "Unknown"}
                             </Text>
-                            <Text style={styles.itemDetail}>{qty}g · {cals} cal</Text>
+                            <Text style={styles.itemDetail}>{formatQuantity(Math.round(displayQty * 10) / 10, itemUnit)} · {cals} cal</Text>
                         </View>
                     );
                 })}

--- a/src/features/recipes/RecipeEditorScreen.tsx
+++ b/src/features/recipes/RecipeEditorScreen.tsx
@@ -29,11 +29,12 @@ import {
     type Recipe,
     type RecipeItem,
 } from "@/src/db/queries";
-import { searchProducts, type OFFProduct } from "@/src/services/openfoodfacts";
+import { searchProducts, guessUnit, parseServingSize, type OFFProduct } from "@/src/services/openfoodfacts";
 import logger from "@/src/utils/logger";
 import Button from "@/src/components/Button";
 import Input from "@/src/components/Input";
 import BarcodeScannerView from "@/src/features/log/BarcodeScannerView";
+import { type FoodUnit, toGrams, fromGrams, unitLabel } from "@/src/utils/units";
 
 interface ItemWithFood {
     recipeItem: RecipeItem;
@@ -64,11 +65,14 @@ export default function RecipeEditorScreen() {
         if (editingItemId == null) return;
         const q = parseFloat(editingQty) || 0;
         if (q > 0) {
-            updateRecipeItem(editingItemId, { quantity_grams: q });
+            const item = items.find((i) => i.recipeItem.id === editingItemId);
+            const itemUnit = (item?.recipeItem.quantity_unit ?? "g") as FoodUnit;
+            const grams = toGrams(q, itemUnit);
+            updateRecipeItem(editingItemId, { quantity_grams: grams });
             setItems((prev) =>
                 prev.map((i) =>
                     i.recipeItem.id === editingItemId
-                        ? { ...i, recipeItem: { ...i.recipeItem, quantity_grams: q } }
+                        ? { ...i, recipeItem: { ...i.recipeItem, quantity_grams: grams } }
                         : i,
                 ),
             );
@@ -155,6 +159,8 @@ export default function RecipeEditorScreen() {
             fat_per_100g: nu.fat_100g ?? 0,
             openfoodfacts_id: product.code,
             source: "openfoodfacts",
+            default_unit: guessUnit(product),
+            serving_size: parseServingSize(product),
         });
         addItemForFood(food);
     }
@@ -162,35 +168,43 @@ export default function RecipeEditorScreen() {
     function addItemForFood(food: Food) {
         saveCurrentEdit();
         const rid = ensureRecipe();
-        const ri = addRecipeItem({ recipe_id: rid, food_id: food.id, quantity_grams: 100 });
+        const foodUnit = (food.default_unit ?? "g") as FoodUnit;
+        const servingSize = food.serving_size ?? 100;
+        const qtyGrams = toGrams(servingSize, foodUnit);
+        const ri = addRecipeItem({ recipe_id: rid, food_id: food.id, quantity_grams: qtyGrams, quantity_unit: foodUnit });
         setItems((prev) => [...prev, { recipeItem: ri, food }]);
         setFoodQuery("");
         setLocalResults([]);
         setOffResults([]);
         // Auto-open the quantity editor for the new item
         setEditingItemId(ri.id);
-        setEditingQty("100");
+        setEditingQty(String(servingSize));
     }
 
     // ── Item editing ──────────────────────────────────────
     function handleSaveItemQty(itemId: number) {
         const q = parseFloat(editingQty) || 0;
         if (q <= 0) return;
-        updateRecipeItem(itemId, { quantity_grams: q });
+        const item = items.find((i) => i.recipeItem.id === itemId);
+        const itemUnit = (item?.recipeItem.quantity_unit ?? "g") as FoodUnit;
+        const grams = toGrams(q, itemUnit);
+        updateRecipeItem(itemId, { quantity_grams: grams });
         setItems((prev) =>
             prev.map((i) =>
                 i.recipeItem.id === itemId
-                    ? { ...i, recipeItem: { ...i.recipeItem, quantity_grams: q } }
+                    ? { ...i, recipeItem: { ...i.recipeItem, quantity_grams: grams } }
                     : i,
             ),
         );
         setEditingItemId(null);
     }
 
-    function startEditingItem(itemId: number, currentQty: number) {
+    function startEditingItem(itemId: number, currentQtyGrams: number) {
         saveCurrentEdit();
+        const item = items.find((i) => i.recipeItem.id === itemId);
+        const itemUnit = (item?.recipeItem.quantity_unit ?? "g") as FoodUnit;
         setEditingItemId(itemId);
-        setEditingQty(String(currentQty));
+        setEditingQty(String(Math.round(fromGrams(currentQtyGrams, itemUnit) * 10) / 10));
     }
 
     function handleDeleteItem(itemId: number) {
@@ -235,6 +249,8 @@ export default function RecipeEditorScreen() {
                 {/* Items */}
                 {items.map(({ recipeItem, food }) => {
                     const isEditingThis = editingItemId === recipeItem.id;
+                    const itemUnit = (recipeItem.quantity_unit ?? "g") as FoodUnit;
+                    const displayQty = Math.round(fromGrams(recipeItem.quantity_grams, itemUnit) * 10) / 10;
                     const cals = food
                         ? Math.round((food.calories_per_100g * recipeItem.quantity_grams) / 100)
                         : 0;
@@ -259,14 +275,14 @@ export default function RecipeEditorScreen() {
                                             onSubmitEditing={() => handleSaveItemQty(recipeItem.id)}
                                             onBlur={() => handleSaveItemQty(recipeItem.id)}
                                         />
-                                        <Text style={styles.itemDetail}>g</Text>
+                                        <Text style={styles.itemDetail}>{unitLabel(itemUnit)}</Text>
                                         <Pressable onPress={() => handleSaveItemQty(recipeItem.id)} hitSlop={8}>
                                             <Ionicons name="checkmark-circle" size={22} color={colors.success} />
                                         </Pressable>
                                     </View>
                                 ) : (
                                     <Text style={styles.itemDetail}>
-                                        {recipeItem.quantity_grams}g · {cals} cal
+                                        {displayQty} {unitLabel(itemUnit)} · {cals} cal
                                     </Text>
                                 )}
                             </Pressable>

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -1,17 +1,309 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useEffect, useState } from "react";
+import {
+    View,
+    Text,
+    ScrollView,
+    Pressable,
+    StyleSheet,
+    Alert,
+} from "react-native";
+import { colors, spacing, borderRadius, fontSize } from "@/src/utils/theme";
+import { getGoals, setGoals, type Goals } from "@/src/db/queries";
+import { useAppStore } from "@/src/store/useAppStore";
+import type { UnitSystem } from "@/src/types";
+import Input from "@/src/components/Input";
+import Button from "@/src/components/Button";
+
+const UNIT_OPTIONS: { key: UnitSystem; label: string }[] = [
+    { key: "metric", label: "Metric (g, ml)" },
+    { key: "imperial", label: "Imperial (oz, cup)" },
+];
 
 export default function SettingsScreen() {
+    const unitSystem = useAppStore((s) => s.unitSystem);
+    const setUnitSystem = useAppStore((s) => s.setUnitSystem);
+
+    const [calories, setCalories] = useState("2000");
+    const [protein, setProtein] = useState("150");
+    const [carbs, setCarbs] = useState("250");
+    const [fat, setFat] = useState("70");
+
+    useEffect(() => {
+        const g = getGoals();
+        if (g) {
+            setCalories(String(g.calories));
+            setProtein(String(g.protein));
+            setCarbs(String(g.carbs));
+            setFat(String(g.fat));
+            if (g.unit_system === "metric" || g.unit_system === "imperial") {
+                setUnitSystem(g.unit_system as UnitSystem);
+            }
+        }
+    }, []);
+
+    function handleSave() {
+        const cal = parseFloat(calories) || 0;
+        const p = parseFloat(protein) || 0;
+        const c = parseFloat(carbs) || 0;
+        const f = parseFloat(fat) || 0;
+
+        if (cal <= 0) {
+            Alert.alert("Invalid", "Calories must be greater than 0");
+            return;
+        }
+
+        setGoals({
+            calories: cal,
+            protein: p,
+            carbs: c,
+            fat: f,
+            unit_system: unitSystem,
+        });
+        Alert.alert("Saved", "Your goals have been updated.");
+    }
+
+    function handleUnitChange(system: UnitSystem) {
+        setUnitSystem(system);
+        setGoals({ unit_system: system });
+    }
+
+    // Compute macro percentages
+    const pCal = (parseFloat(protein) || 0) * 4;
+    const cCal = (parseFloat(carbs) || 0) * 4;
+    const fCal = (parseFloat(fat) || 0) * 9;
+    const macroTotal = pCal + cCal + fCal;
+
     return (
-        <View style={styles.container}>
-            <Text style={styles.title}>Settings</Text>
-            <Text style={styles.subtitle}>Set goals and preferences.</Text>
+        <ScrollView
+            style={styles.screen}
+            contentContainerStyle={styles.content}
+            keyboardShouldPersistTaps="handled"
+        >
+            <Text style={styles.heading}>Settings</Text>
+
+            {/* ── Unit System ─────────────────────────────── */}
+            <Text style={styles.sectionLabel}>PREFERRED UNITS</Text>
+            <View style={styles.chipRow}>
+                {UNIT_OPTIONS.map((opt) => (
+                    <Pressable
+                        key={opt.key}
+                        style={[
+                            styles.chip,
+                            unitSystem === opt.key && styles.chipActive,
+                        ]}
+                        onPress={() => handleUnitChange(opt.key)}
+                    >
+                        <Text
+                            style={[
+                                styles.chipText,
+                                unitSystem === opt.key && styles.chipTextActive,
+                            ]}
+                        >
+                            {opt.label}
+                        </Text>
+                    </Pressable>
+                ))}
+            </View>
+
+            {/* ── Calorie Goal ────────────────────────────── */}
+            <Text style={styles.sectionLabel}>DAILY GOALS</Text>
+
+            <Input
+                label="Calories"
+                value={calories}
+                onChangeText={setCalories}
+                keyboardType="decimal-pad"
+                suffix="kcal"
+                containerStyle={styles.field}
+            />
+
+            {/* ── Macro Goals ─────────────────────────────── */}
+            <Text style={styles.subLabel}>Macronutrient targets (grams)</Text>
+
+            <View style={styles.row}>
+                <Input
+                    label="Protein"
+                    value={protein}
+                    onChangeText={setProtein}
+                    keyboardType="decimal-pad"
+                    suffix="g"
+                    containerStyle={styles.thirdField}
+                />
+                <Input
+                    label="Carbs"
+                    value={carbs}
+                    onChangeText={setCarbs}
+                    keyboardType="decimal-pad"
+                    suffix="g"
+                    containerStyle={styles.thirdField}
+                />
+                <Input
+                    label="Fat"
+                    value={fat}
+                    onChangeText={setFat}
+                    keyboardType="decimal-pad"
+                    suffix="g"
+                    containerStyle={styles.thirdField}
+                />
+            </View>
+
+            {/* Macro breakdown preview */}
+            {macroTotal > 0 && (
+                <View style={styles.breakdownCard}>
+                    <Text style={styles.breakdownTitle}>Macro Breakdown</Text>
+                    <View style={styles.barContainer}>
+                        <View
+                            style={[
+                                styles.barSegment,
+                                {
+                                    flex: pCal,
+                                    backgroundColor: colors.protein,
+                                    borderTopLeftRadius: 4,
+                                    borderBottomLeftRadius: 4,
+                                },
+                            ]}
+                        />
+                        <View
+                            style={[
+                                styles.barSegment,
+                                { flex: cCal, backgroundColor: colors.carbs },
+                            ]}
+                        />
+                        <View
+                            style={[
+                                styles.barSegment,
+                                {
+                                    flex: fCal,
+                                    backgroundColor: colors.fat,
+                                    borderTopRightRadius: 4,
+                                    borderBottomRightRadius: 4,
+                                },
+                            ]}
+                        />
+                    </View>
+                    <View style={styles.legendRow}>
+                        <LegendDot
+                            color={colors.protein}
+                            label={`Protein ${Math.round((pCal / macroTotal) * 100)}%`}
+                        />
+                        <LegendDot
+                            color={colors.carbs}
+                            label={`Carbs ${Math.round((cCal / macroTotal) * 100)}%`}
+                        />
+                        <LegendDot
+                            color={colors.fat}
+                            label={`Fat ${Math.round((fCal / macroTotal) * 100)}%`}
+                        />
+                    </View>
+                    <Text style={styles.breakdownSub}>
+                        {Math.round(macroTotal)} kcal from macros
+                    </Text>
+                </View>
+            )}
+
+            <Button title="Save Goals" onPress={handleSave} style={styles.saveBtn} />
+        </ScrollView>
+    );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+    return (
+        <View style={styles.legendItem}>
+            <View style={[styles.dot, { backgroundColor: color }]} />
+            <Text style={styles.legendText}>{label}</Text>
         </View>
     );
 }
 
 const styles = StyleSheet.create({
-    container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
-    title: { fontSize: 22, fontWeight: '600', marginBottom: 6 },
-    subtitle: { fontSize: 14, color: '#666' },
+    screen: { flex: 1, backgroundColor: colors.background },
+    content: { padding: spacing.lg, paddingBottom: 100 },
+    heading: {
+        fontSize: fontSize.xl,
+        fontWeight: "700",
+        color: colors.text,
+        marginBottom: spacing.lg,
+    },
+    sectionLabel: {
+        fontSize: fontSize.xs,
+        fontWeight: "600",
+        color: colors.textSecondary,
+        letterSpacing: 0.5,
+        marginBottom: spacing.sm,
+        marginTop: spacing.md,
+    },
+    subLabel: {
+        fontSize: fontSize.sm,
+        color: colors.textSecondary,
+        marginBottom: spacing.md,
+    },
+    chipRow: {
+        flexDirection: "row",
+        gap: spacing.sm,
+        marginBottom: spacing.md,
+    },
+    chip: {
+        flex: 1,
+        paddingVertical: spacing.sm + 2,
+        borderRadius: borderRadius.md,
+        backgroundColor: colors.surface,
+        borderWidth: 1,
+        borderColor: colors.border,
+        alignItems: "center",
+    },
+    chipActive: {
+        backgroundColor: colors.primaryLight,
+        borderColor: colors.primary,
+    },
+    chipText: {
+        fontSize: fontSize.sm,
+        color: colors.textSecondary,
+    },
+    chipTextActive: {
+        color: colors.primary,
+        fontWeight: "600",
+    },
+    field: { marginBottom: spacing.md },
+    row: {
+        flexDirection: "row",
+        gap: spacing.sm,
+        marginBottom: spacing.md,
+    },
+    thirdField: { flex: 1 },
+    breakdownCard: {
+        backgroundColor: colors.surface,
+        borderRadius: borderRadius.lg,
+        padding: spacing.md,
+        marginBottom: spacing.md,
+        borderWidth: 1,
+        borderColor: colors.border,
+    },
+    breakdownTitle: {
+        fontSize: fontSize.sm,
+        fontWeight: "600",
+        color: colors.text,
+        marginBottom: spacing.sm,
+    },
+    barContainer: {
+        flexDirection: "row",
+        height: 10,
+        borderRadius: 4,
+        overflow: "hidden",
+        marginBottom: spacing.sm,
+    },
+    barSegment: { height: 10 },
+    legendRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        marginBottom: spacing.xs,
+    },
+    legendItem: { flexDirection: "row", alignItems: "center", gap: 4 },
+    dot: { width: 8, height: 8, borderRadius: 4 },
+    legendText: { fontSize: fontSize.xs, color: colors.textSecondary },
+    breakdownSub: {
+        fontSize: fontSize.xs,
+        color: colors.textTertiary,
+        textAlign: "center",
+    },
+    saveBtn: { marginTop: spacing.sm },
 });

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -1,4 +1,5 @@
 import logger from "@/src/utils/logger";
+import type { FoodUnit } from "@/src/utils/units";
 
 const BASE_URL = "https://world.openfoodfacts.org";
 const USER_AGENT = "MacroFlow/1.0 (React Native; open-source nutrient tracker)";
@@ -16,6 +17,9 @@ export interface OFFProduct {
         carbohydrates_100g?: number;
         fat_100g?: number;
     };
+    serving_size?: string;
+    serving_quantity?: number;
+    quantity?: string;
 }
 
 interface OFFProductResponse {
@@ -28,13 +32,38 @@ interface OFFSearchResponse {
     products?: OFFProduct[];
 }
 
+const FIELDS =
+    "code,product_name,nutriments,serving_size,serving_quantity,quantity";
+
+/** Guess the default unit from OFF serving_size or quantity string. */
+export function guessUnit(product: OFFProduct): FoodUnit {
+    const text = (product.serving_size ?? product.quantity ?? "").toLowerCase();
+    if (/\bml\b/.test(text) || /\bcl\b/.test(text) || /\bliter|\blitre/.test(text))
+        return "ml";
+    if (/\bfl\s?oz\b/.test(text)) return "fl_oz";
+    if (/\bcup/.test(text)) return "cup";
+    if (/\btbsp\b/.test(text)) return "tbsp";
+    if (/\btsp\b/.test(text)) return "tsp";
+    if (/\boz\b/.test(text)) return "oz";
+    if (/\blb\b/.test(text)) return "lb";
+    return "g";
+}
+
+/** Parse a numeric serving size from OFF, e.g. "250 ml" → 250. */
+export function parseServingSize(product: OFFProduct): number {
+    if (product.serving_quantity && product.serving_quantity > 0)
+        return product.serving_quantity;
+    const m = (product.serving_size ?? "").match(/([\d.]+)/);
+    return m ? parseFloat(m[1]) || 100 : 100;
+}
+
 export async function getProductByBarcode(
     barcode: string,
 ): Promise<OFFProduct | null> {
     logger.info("[API] Fetching product by barcode", { barcode });
 
     const res = await fetch(
-        `${BASE_URL}/api/v2/product/${encodeURIComponent(barcode)}?fields=code,product_name,nutriments`,
+        `${BASE_URL}/api/v2/product/${encodeURIComponent(barcode)}?fields=${FIELDS}`,
         { headers: { "User-Agent": USER_AGENT } },
     );
 
@@ -69,7 +98,7 @@ export async function searchProducts(
         json: "1",
         page: String(page),
         page_size: "20",
-        fields: "code,product_name,nutriments",
+        fields: FIELDS,
     });
 
     const res = await fetch(`${BASE_URL}/cgi/search.pl?${params}`, {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,11 +1,16 @@
 import { create } from "zustand";
+import type { UnitSystem } from "@/src/types";
 
 interface AppState {
     selectedDate: Date;
     setSelectedDate: (date: Date) => void;
+    unitSystem: UnitSystem;
+    setUnitSystem: (system: UnitSystem) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
     selectedDate: new Date(),
     setSelectedDate: (date) => set({ selectedDate: date }),
+    unitSystem: "metric",
+    setUnitSystem: (system) => set({ unitSystem: system }),
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@ export type MealType = "breakfast" | "lunch" | "dinner" | "snack";
 
 export type FoodSource = "manual" | "openfoodfacts";
 
+export type { FoodUnit, UnitSystem } from "@/src/utils/units";
+
 export const MEAL_TYPES: { key: MealType; label: string; icon: string }[] = [
     { key: "breakfast", label: "Breakfast", icon: "sunny-outline" },
     { key: "lunch", label: "Lunch", icon: "partly-sunny-outline" },

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -1,0 +1,66 @@
+export type FoodUnit = "g" | "ml" | "oz" | "fl_oz" | "cup" | "tbsp" | "tsp" | "lb";
+
+export type UnitSystem = "metric" | "imperial";
+
+/** Conversion factor to grams (weight) or ml≈g (volume, assuming density ≈ 1). */
+const TO_GRAMS: Record<FoodUnit, number> = {
+    g: 1,
+    ml: 1,          // 1 ml ≈ 1 g for most food liquids
+    oz: 28.3495,
+    fl_oz: 29.5735,
+    cup: 236.588,
+    tbsp: 14.787,
+    tsp: 4.929,
+    lb: 453.592,
+};
+
+const UNIT_LABELS: Record<FoodUnit, string> = {
+    g: "g",
+    ml: "ml",
+    oz: "oz",
+    fl_oz: "fl oz",
+    cup: "cup",
+    tbsp: "tbsp",
+    tsp: "tsp",
+    lb: "lb",
+};
+
+export const ALL_UNITS: FoodUnit[] = ["g", "ml", "oz", "fl_oz", "cup", "tbsp", "tsp", "lb"];
+
+/** Weight units. */
+export const WEIGHT_UNITS: FoodUnit[] = ["g", "oz", "lb"];
+
+/** Volume units. */
+export const VOLUME_UNITS: FoodUnit[] = ["ml", "fl_oz", "cup", "tbsp", "tsp"];
+
+/** Units shown first depending on system preference. */
+export function unitsForSystem(system: UnitSystem): FoodUnit[] {
+    if (system === "imperial") return ["oz", "lb", "cup", "tbsp", "tsp", "fl_oz", "g", "ml"];
+    return ["g", "ml", "oz", "lb", "cup", "tbsp", "tsp", "fl_oz"];
+}
+
+/** Convert a quantity in the given unit to grams. */
+export function toGrams(quantity: number, unit: FoodUnit): number {
+    return quantity * TO_GRAMS[unit];
+}
+
+/** Convert a gram value to the given unit. */
+export function fromGrams(grams: number, unit: FoodUnit): number {
+    return grams / TO_GRAMS[unit];
+}
+
+/** Human-readable label for a unit. */
+export function unitLabel(unit: FoodUnit): string {
+    return UNIT_LABELS[unit] ?? unit;
+}
+
+/** Format a quantity + unit for display, e.g. "250 ml" or "1.5 cup". */
+export function formatQuantity(quantity: number, unit: FoodUnit): string {
+    const val = Number.isInteger(quantity) ? String(quantity) : quantity.toFixed(1);
+    return `${val} ${unitLabel(unit)}`;
+}
+
+/** Check if a unit is a string we recognise. */
+export function isValidUnit(s: string): s is FoodUnit {
+    return ALL_UNITS.includes(s as FoodUnit);
+}


### PR DESCRIPTION
Adds support for non-gram units (ml, cup, tbsp, tsp, oz, lb) and per-food default units/serving sizes.

Updates OpenFoodFacts parsing to capture serving size and guess a sensible unit. Adds unit-aware entry and recipe handling (stores quantity + unit, converts to grams internally). Adds Settings UI to choose unit system (metric/imperial) and set daily calorie/macro goals.

Files changed include: unit utilities, DB schema + migrations, Entry/ManualFood/Recipe screens, Settings screen, and OFF service.

Closes #17.
