### PR TITLE
refactor(tabs): make Logs center tab (Closes #25)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,31 +2,31 @@ import { useThemeColors } from "@/src/utils/ThemeProvider";
 import { Ionicons } from '@expo/vector-icons';
 import { Tabs } from "expo-router";
 
-const icons = {
-    index: 'home',
-    log: 'create',
+const icons: Record<string, string> = {
+    index: 'create',
     recipes: 'book',
-    history: 'time',
     settings: 'settings'
 };
 
 export default function TabsLayout() {
     const colors = useThemeColors();
+
     return (
         <Tabs
-            screenOptions={({ route }) => ({
-                headerShown: true,
-                headerStyle: { backgroundColor: colors.surface },
-                headerTintColor: colors.text,
+            screenOptions={({ route }: { route: { name: string } }) => ({
+                headerShown: false,
                 tabBarStyle: { backgroundColor: colors.surface, borderTopColor: colors.border },
                 tabBarActiveTintColor: colors.primary,
                 tabBarInactiveTintColor: colors.textSecondary,
-                tabBarIcon: ({ color, size }) => {
-                    const name = icons[route.name as keyof typeof icons];
-
+                tabBarIcon: ({ color, size }: { color: string; size: number }) => {
+                    const name = icons[route.name] ?? 'help';
                     return <Ionicons name={name as any} size={size} color={color} />;
                 },
             })}
-        />
+        >
+            <Tabs.Screen name="recipes" options={{ title: "Recipes", tabBarLabel: "Recipes" }} />
+            <Tabs.Screen name="index" options={{ title: "Logs", tabBarLabel: "Logs" }} />
+            <Tabs.Screen name="settings" options={{ title: "Settings", tabBarLabel: "Settings" }} />
+        </Tabs>
     );
 }

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -1,1 +1,0 @@
-export { default } from "@/src/features/history/HistoryScreen";

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,1 +1,1 @@
-export { default } from "@/src/features/home/HomeScreen";
+export { default } from "@/src/features/log/LogScreen";

--- a/app/(tabs)/log.tsx
+++ b/app/(tabs)/log.tsx
@@ -1,1 +1,0 @@
-export { default } from "@/src/features/log/LogScreen";

--- a/src/features/log/LogScreen.tsx
+++ b/src/features/log/LogScreen.tsx
@@ -17,6 +17,7 @@ import {
     type NativeScrollEvent,
     type NativeSyntheticEvent,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import DailyProgressBar from "./DailyProgressBar";
 import DateSelectorBar from "./DateSelectorBar";
 import EntryModal from "./EntryModal";
@@ -109,6 +110,7 @@ function DayPage({
 export default function LogScreen() {
     const colors = useThemeColors();
     const styles = React.useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
     const selectedDate = useAppStore((s) => s.selectedDate);
     const setSelectedDate = useAppStore((s) => s.setSelectedDate);
     const dateRef = useRef(selectedDate);
@@ -210,7 +212,7 @@ export default function LogScreen() {
     }
 
     return (
-        <View style={styles.screen}>
+        <View style={[styles.screen, { paddingTop: insets.top }]}>
             <View style={styles.dateSelectorWrapper}>
                 <DateSelectorBar
                     date={selectedDate}

--- a/src/features/recipes/RecipesScreen.tsx
+++ b/src/features/recipes/RecipesScreen.tsx
@@ -21,10 +21,12 @@ import {
     TextInput,
     View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function RecipesScreen() {
     const colors = useThemeColors();
     const styles = React.useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
     const [recipes, setRecipes] = useState<Recipe[]>([]);
     const [query, setQuery] = useState("");
 
@@ -64,7 +66,8 @@ export default function RecipesScreen() {
     }
 
     return (
-        <View style={styles.screen}>
+        <View style={[styles.screen, { paddingTop: insets.top }]}>
+            <Text style={styles.heading}>Recipes</Text>
             <View style={styles.searchRow}>
                 <Ionicons name="search" size={18} color={colors.textTertiary} />
                 <TextInput
@@ -119,6 +122,14 @@ export default function RecipesScreen() {
 function createStyles(colors: ThemeColors) {
     return StyleSheet.create({
         screen: { flex: 1, backgroundColor: colors.background },
+        heading: {
+            fontSize: fontSize.xl,
+            fontWeight: "700",
+            color: colors.text,
+            marginBottom: spacing.lg,
+            paddingHorizontal: spacing.lg,
+            paddingTop: spacing.lg,
+        },
         searchRow: {
             flexDirection: "row",
             alignItems: "center",

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -15,6 +15,7 @@ import {
     Text,
     View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const UNIT_OPTIONS: { key: UnitSystem; label: string }[] = [
     { key: "metric", label: "Metric (g, ml)" },
@@ -30,6 +31,7 @@ const APPEARANCE_OPTIONS: { key: AppearanceMode; label: string; icon: string }[]
 export default function SettingsScreen() {
     const colors = useThemeColors();
     const styles = useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
 
     const unitSystem = useAppStore((s) => s.unitSystem);
     const setUnitSystem = useAppStore((s) => s.setUnitSystem);
@@ -140,7 +142,7 @@ export default function SettingsScreen() {
     return (
         <ScrollView
             style={styles.screen}
-            contentContainerStyle={styles.content}
+            contentContainerStyle={[styles.content, { paddingTop: insets.top + spacing.lg }]}
             keyboardShouldPersistTaps="handled"
         >
             <Text style={styles.heading}>Settings</Text>


### PR DESCRIPTION
Closes #25

Summary:
- Remove history and home tabs
- Make Logs the center tab and label it 'Logs'
- Remove headers and add safe-area handling
- Add heading on Recipes screen
