### PR TITLE
feat: minor UI improvements to the logs screen (#29)

### DIFF
--- a/src/features/log/DailyProgressBar.tsx
+++ b/src/features/log/DailyProgressBar.tsx
@@ -118,6 +118,7 @@ export default function DailyProgressBar({
 
     const calRatio =
         goals.calories > 0 ? Math.min(totals.calories / goals.calories, 1) : 0;
+    const isOverCalories = goals.calories > 0 && totals.calories > goals.calories;
 
     function toggle() {
         LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -128,7 +129,7 @@ export default function DailyProgressBar({
         <Pressable style={styles.container} onPress={toggle}>
             {/* Calorie bar – always visible */}
             <View style={styles.headerRow}>
-                <Text style={styles.calorieText}>
+                <Text style={[styles.calorieText, isOverCalories && styles.calorieTextOver]}>
                     {Math.round(totals.calories)}{" "}
                     <Text style={styles.goalText}>
                         / {Math.round(goals.calories)} kcal
@@ -203,6 +204,9 @@ function createStyles(colors: ThemeColors) {
             fontSize: fontSize.md,
             fontWeight: "600",
             color: colors.text,
+        },
+        calorieTextOver: {
+            color: colors.danger,
         },
         goalText: {
             fontWeight: "400",

--- a/src/features/log/DateSelectorBar.tsx
+++ b/src/features/log/DateSelectorBar.tsx
@@ -33,10 +33,21 @@ export default function DateSelectorBar({
     }
 
     const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
     const isToday = isSameDay(date, today);
+    const isYesterday = isSameDay(date, yesterday);
+    const isTomorrow = isSameDay(date, tomorrow);
 
     const label = isToday
         ? "Today"
+        : isYesterday
+        ? "Yesterday"
+        : isTomorrow
+        ? "Tomorrow"
         : date.toLocaleDateString("en-US", {
             weekday: "short",
             month: "short",

--- a/src/features/log/LogScreen.tsx
+++ b/src/features/log/LogScreen.tsx
@@ -211,12 +211,31 @@ export default function LogScreen() {
         });
     }
 
+    function handleDateChange(newDate: Date) {
+        const diff = Math.round(
+            (newDate.getTime() - dateRef.current.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        if (diff === 1 || diff === -1) {
+            isSettling.current = true;
+            carouselRef.current?.scrollTo({
+                x: diff === 1 ? 2 * SCREEN_WIDTH : 0,
+                animated: true,
+            });
+            setTimeout(() => {
+                loadAllDays(newDate);
+                setSelectedDate(newDate);
+            }, 350);
+        } else {
+            setSelectedDate(newDate);
+        }
+    }
+
     return (
         <View style={[styles.screen, { paddingTop: insets.top }]}>
             <View style={styles.dateSelectorWrapper}>
                 <DateSelectorBar
                     date={selectedDate}
-                    onDateChange={setSelectedDate}
+                    onDateChange={handleDateChange}
                 />
             </View>
 


### PR DESCRIPTION
Closes #29

## Changes (3 commits)

1. **Yesterday / Tomorrow labels** – `DateSelectorBar` now shows "Yesterday" and "Tomorrow" in addition to "Today", so the user always knows the relative day at a glance.
2. **Over-target calorie color** – The calorie count in `DailyProgressBar` turns red (`colors.danger`) when the user has exceeded their daily calorie goal.
3. **Arrow navigation animation** – Tapping the chevron arrows now triggers the same sliding carousel animation as swiping. A `handleDateChange` helper in `LogScreen` detects ±1 day shifts, programmatically scrolls the carousel to the adjacent page, then updates the selected date after the animation completes (350 ms), exactly mirroring the existing swipe-to-navigate behaviour.