### PR TITLE
chore: configure EAS Build for Android alpha (#33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ app-example
 # generated native folders
 /ios
 /android
+releases/

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "MacroFlow",
     "slug": "MacroFlow",
-    "version": "1.0.0",
+    "version": "0.0.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "macroflow",
@@ -11,6 +11,7 @@
       "supportsTablet": true
     },
     "android": {
+      "package": "com.herrderkekse.macroflow",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/app.json
+++ b/app.json
@@ -44,6 +44,13 @@
     "experiments": {
       "typedRoutes": true,
       "reactCompiler": true
-    }
+    },
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "3e57a36e-c3d9-4539-b8b0-ccac0b6db534"
+      }
+    },
+    "owner": "herrderkekse"
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,19 @@
+{
+  "cli": {
+    "version": ">= 16.0.0",
+    "appVersionSource": "local"
+  },
+  "build": {
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macroflow",
   "main": "expo-router/entry",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
Closes #33

## Changes
- Set app version to `0.0.1` (from 1.0.0)
- Add `android.package` (`com.herrderkekse.macroflow`) to app.json
- Link EAS project (ID: 3e57a36e-c3d9-4539-b8b0-ccac0b6db534)
- Create `eas.json` with:
  - **preview** profile → APK (for alpha distribution)
  - **production** profile → AAB (for Play Store later)
- Add `releases/` to .gitignore

## APK
The v0.0.1-alpha APK will be attached as a GitHub Release asset after this PR is merged.