### PR TITLE
fix: add unit picker to recipe ingredient editing

### DIFF
--- a/src/features/recipes/RecipeEditorScreen.tsx
+++ b/src/features/recipes/RecipeEditorScreen.tsx
@@ -10,11 +10,11 @@ import {
     getRecipeItems,
     searchFoodsByName,
     updateRecipe,
-    updateRecipeItem,
     type Food,
     type RecipeItem
 } from "@/src/db/queries";
 import BarcodeScannerView from "@/src/features/log/BarcodeScannerView";
+import RecipeItemModal from "@/src/features/recipes/RecipeItemModal";
 import { guessUnit, parseServingSize, searchProducts, type OFFProduct } from "@/src/services/openfoodfacts";
 import logger from "@/src/utils/logger";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
@@ -56,29 +56,8 @@ export default function RecipeEditorScreen() {
     const [hasSearchedOFF, setHasSearchedOFF] = useState(false);
     const [showScanner, setShowScanner] = useState(false);
 
-    // editing item quantity inline
-    const [editingItemId, setEditingItemId] = useState<number | null>(null);
-    const [editingQty, setEditingQty] = useState("");
-
-    // Flush any in-progress quantity edit to DB + state
-    function saveCurrentEdit() {
-        if (editingItemId == null) return;
-        const q = parseFloat(editingQty) || 0;
-        if (q > 0) {
-            const item = items.find((i) => i.recipeItem.id === editingItemId);
-            const itemUnit = (item?.recipeItem.quantity_unit ?? "g") as FoodUnit;
-            const grams = toGrams(q, itemUnit);
-            updateRecipeItem(editingItemId, { quantity_grams: grams });
-            setItems((prev) =>
-                prev.map((i) =>
-                    i.recipeItem.id === editingItemId
-                        ? { ...i, recipeItem: { ...i.recipeItem, quantity_grams: grams } }
-                        : i,
-                ),
-            );
-        }
-        setEditingItemId(null);
-    }
+    // modal for editing an ingredient's quantity + unit
+    const [editingItem, setEditingItem] = useState<ItemWithFood | null>(null);
 
     // ── Load existing recipe ──────────────────────────────
     useEffect(() => {
@@ -166,45 +145,30 @@ export default function RecipeEditorScreen() {
     }
 
     function addItemForFood(food: Food) {
-        saveCurrentEdit();
         const rid = ensureRecipe();
         const foodUnit = (food.default_unit ?? "g") as FoodUnit;
         const servingSize = food.serving_size ?? 100;
         const qtyGrams = toGrams(servingSize, foodUnit);
         const ri = addRecipeItem({ recipe_id: rid, food_id: food.id, quantity_grams: qtyGrams, quantity_unit: foodUnit });
-        setItems((prev) => [...prev, { recipeItem: ri, food }]);
+        const newEntry: ItemWithFood = { recipeItem: ri, food };
+        setItems((prev) => [...prev, newEntry]);
         setFoodQuery("");
         setLocalResults([]);
         setOffResults([]);
-        // Auto-open the quantity editor for the new item
-        setEditingItemId(ri.id);
-        setEditingQty(String(servingSize));
+        // Auto-open the modal editor for the new item
+        setEditingItem(newEntry);
     }
 
     // ── Item editing ──────────────────────────────────────
-    function handleSaveItemQty(itemId: number) {
-        const q = parseFloat(editingQty) || 0;
-        if (q <= 0) return;
-        const item = items.find((i) => i.recipeItem.id === itemId);
-        const itemUnit = (item?.recipeItem.quantity_unit ?? "g") as FoodUnit;
-        const grams = toGrams(q, itemUnit);
-        updateRecipeItem(itemId, { quantity_grams: grams });
+    function handleModalSaved(itemId: number, quantityGrams: number, unit: FoodUnit) {
         setItems((prev) =>
             prev.map((i) =>
                 i.recipeItem.id === itemId
-                    ? { ...i, recipeItem: { ...i.recipeItem, quantity_grams: grams } }
+                    ? { ...i, recipeItem: { ...i.recipeItem, quantity_grams: quantityGrams, quantity_unit: unit } }
                     : i,
             ),
         );
-        setEditingItemId(null);
-    }
-
-    function startEditingItem(itemId: number, currentQtyGrams: number) {
-        saveCurrentEdit();
-        const item = items.find((i) => i.recipeItem.id === itemId);
-        const itemUnit = (item?.recipeItem.quantity_unit ?? "g") as FoodUnit;
-        setEditingItemId(itemId);
-        setEditingQty(String(Math.round(fromGrams(currentQtyGrams, itemUnit) * 10) / 10));
+        setEditingItem(null);
     }
 
     function handleDeleteItem(itemId: number) {
@@ -214,7 +178,6 @@ export default function RecipeEditorScreen() {
 
     // ── Save & back ───────────────────────────────────────
     function handleDone() {
-        saveCurrentEdit();
         if (name.trim()) {
             ensureRecipe();
         }
@@ -247,8 +210,8 @@ export default function RecipeEditorScreen() {
                 </Text>
 
                 {/* Items */}
-                {items.map(({ recipeItem, food }) => {
-                    const isEditingThis = editingItemId === recipeItem.id;
+                {items.map((itemWithFood) => {
+                    const { recipeItem, food } = itemWithFood;
                     const itemUnit = (recipeItem.quantity_unit ?? "g") as FoodUnit;
                     const displayQty = Math.round(fromGrams(recipeItem.quantity_grams, itemUnit) * 10) / 10;
                     const cals = food
@@ -258,33 +221,14 @@ export default function RecipeEditorScreen() {
                         <View key={recipeItem.id} style={styles.itemRow}>
                             <Pressable
                                 style={styles.itemInfo}
-                                onPress={() => startEditingItem(recipeItem.id, recipeItem.quantity_grams)}
+                                onPress={() => setEditingItem(itemWithFood)}
                             >
                                 <Text style={styles.itemName} numberOfLines={1}>
                                     {food?.name ?? "Unknown"}
                                 </Text>
-                                {isEditingThis ? (
-                                    <View style={styles.qtyEditRow}>
-                                        <TextInput
-                                            style={styles.qtyInput}
-                                            value={editingQty}
-                                            onChangeText={setEditingQty}
-                                            keyboardType="decimal-pad"
-                                            autoFocus
-                                            selectTextOnFocus
-                                            onSubmitEditing={() => handleSaveItemQty(recipeItem.id)}
-                                            onBlur={() => handleSaveItemQty(recipeItem.id)}
-                                        />
-                                        <Text style={styles.itemDetail}>{unitLabel(itemUnit)}</Text>
-                                        <Pressable onPress={() => handleSaveItemQty(recipeItem.id)} hitSlop={8}>
-                                            <Ionicons name="checkmark-circle" size={22} color={colors.success} />
-                                        </Pressable>
-                                    </View>
-                                ) : (
-                                    <Text style={styles.itemDetail}>
-                                        {displayQty} {unitLabel(itemUnit)} · {cals} cal
-                                    </Text>
-                                )}
+                                <Text style={styles.itemDetail}>
+                                    {displayQty} {unitLabel(itemUnit)} · {cals} cal
+                                </Text>
                             </Pressable>
                             <Pressable onPress={() => handleDeleteItem(recipeItem.id)} hitSlop={8}>
                                 <Ionicons name="close-circle-outline" size={20} color={colors.textTertiary} />
@@ -363,6 +307,13 @@ export default function RecipeEditorScreen() {
 
                 <Button title="Done" onPress={handleDone} style={styles.doneBtn} />
 
+                <RecipeItemModal
+                    item={editingItem?.recipeItem ?? null}
+                    food={editingItem?.food ?? null}
+                    onClose={() => setEditingItem(null)}
+                    onSaved={handleModalSaved}
+                />
+
                 <BarcodeScannerView
                     visible={showScanner}
                     onClose={() => setShowScanner(false)}
@@ -395,16 +346,7 @@ function createStyles(colors: ThemeColors) {
         itemInfo: { flex: 1, marginRight: spacing.sm },
         itemName: { fontSize: fontSize.sm, fontWeight: "500", color: colors.text },
         itemDetail: { fontSize: fontSize.xs, color: colors.textSecondary, marginTop: 2 },
-        qtyEditRow: { flexDirection: "row", alignItems: "center", gap: spacing.xs, marginTop: 4 },
-        qtyInput: {
-            fontSize: fontSize.sm,
-            color: colors.text,
-            borderBottomWidth: 1,
-            borderBottomColor: colors.primary,
-            minWidth: 50,
-            paddingVertical: 2,
-            paddingHorizontal: 4,
-        },
+
         sectionLabel: {
             fontSize: fontSize.sm,
             fontWeight: "600",

--- a/src/features/recipes/RecipeItemModal.tsx
+++ b/src/features/recipes/RecipeItemModal.tsx
@@ -1,0 +1,287 @@
+import Input from "@/src/components/Input";
+import Button from "@/src/components/Button";
+import { updateRecipeItem, type Food, type RecipeItem } from "@/src/db/queries";
+import { useAppStore } from "@/src/store/useAppStore";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { useThemeColors } from "@/src/utils/ThemeProvider";
+import { fromGrams, toGrams, unitLabel, unitsForSystem, type FoodUnit } from "@/src/utils/units";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo, useState } from "react";
+import {
+    KeyboardAvoidingView,
+    Modal,
+    Platform,
+    Pressable,
+    ScrollView,
+    StyleSheet,
+    Text,
+    View,
+} from "react-native";
+
+interface RecipeItemModalProps {
+    item: RecipeItem | null;
+    food: Food | null;
+    onClose: () => void;
+    onSaved: (itemId: number, quantityGrams: number, unit: FoodUnit) => void;
+}
+
+export default function RecipeItemModal({
+    item,
+    food,
+    onClose,
+    onSaved,
+}: RecipeItemModalProps) {
+    const colors = useThemeColors();
+    const styles = React.useMemo(() => createStyles(colors), [colors]);
+    const unitSystem = useAppStore((s) => s.unitSystem);
+
+    const [quantity, setQuantity] = useState("100");
+    const [unit, setUnit] = useState<FoodUnit>("g");
+
+    React.useEffect(() => {
+        if (item) {
+            const itemUnit = (item.quantity_unit ?? "g") as FoodUnit;
+            setUnit(itemUnit);
+            setQuantity(
+                String(Math.round(fromGrams(item.quantity_grams, itemUnit) * 10) / 10),
+            );
+        }
+    }, [item]);
+
+    const qty = parseFloat(quantity) || 0;
+    const qtyGrams = toGrams(qty, unit);
+
+    const calculated = useMemo(() => {
+        if (!food) return { calories: 0, protein: 0, carbs: 0, fat: 0 };
+        const factor = qtyGrams / 100;
+        return {
+            calories: food.calories_per_100g * factor,
+            protein: food.protein_per_100g * factor,
+            carbs: food.carbs_per_100g * factor,
+            fat: food.fat_per_100g * factor,
+        };
+    }, [food, qtyGrams]);
+
+    function handleSave() {
+        if (!item || qty <= 0) return;
+        updateRecipeItem(item.id, { quantity_grams: qtyGrams, quantity_unit: unit });
+        onSaved(item.id, qtyGrams, unit);
+    }
+
+    const unitOptions = unitsForSystem(unitSystem);
+
+    return (
+        <Modal
+            visible={!!item}
+            animationType="slide"
+            presentationStyle="pageSheet"
+            onRequestClose={onClose}
+        >
+            <KeyboardAvoidingView
+                behavior={Platform.OS === "ios" ? "padding" : undefined}
+                style={styles.flex}
+            >
+                {/* Header */}
+                <View style={styles.header}>
+                    <Text style={styles.headerTitle}>Edit Ingredient</Text>
+                    <Pressable onPress={onClose} hitSlop={8}>
+                        <Ionicons name="close" size={24} color={colors.textSecondary} />
+                    </Pressable>
+                </View>
+
+                <ScrollView
+                    contentContainerStyle={styles.content}
+                    keyboardShouldPersistTaps="handled"
+                >
+                    {/* Food info */}
+                    <Text style={styles.foodName}>{food?.name}</Text>
+                    <Text style={styles.per100}>
+                        per 100 g: {Math.round(food?.calories_per_100g ?? 0)} cal
+                    </Text>
+
+                    {/* Quantity */}
+                    <Input
+                        label="Quantity"
+                        value={quantity}
+                        onChangeText={setQuantity}
+                        keyboardType="decimal-pad"
+                        suffix={unitLabel(unit)}
+                        containerStyle={styles.quantityInput}
+                    />
+
+                    {/* Unit picker */}
+                    <Text style={styles.sectionLabel}>Unit</Text>
+                    <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={styles.unitRow}
+                    >
+                        {unitOptions.map((u) => (
+                            <Pressable
+                                key={u}
+                                onPress={() => setUnit(u)}
+                                style={[
+                                    styles.unitChip,
+                                    unit === u && styles.unitChipActive,
+                                ]}
+                            >
+                                <Text
+                                    style={[
+                                        styles.unitChipText,
+                                        unit === u && styles.unitChipTextActive,
+                                    ]}
+                                >
+                                    {unitLabel(u)}
+                                </Text>
+                            </Pressable>
+                        ))}
+                    </ScrollView>
+
+                    {/* Live macro calculation */}
+                    <View style={styles.calcCard}>
+                        <Text style={styles.calcCalories}>
+                            {Math.round(calculated.calories)} cal
+                        </Text>
+                        <View style={styles.calcMacros}>
+                            <MacroLabel
+                                label="Protein"
+                                value={calculated.protein}
+                                color={colors.protein}
+                                textColor={colors.textSecondary}
+                            />
+                            <MacroLabel
+                                label="Carbs"
+                                value={calculated.carbs}
+                                color={colors.carbs}
+                                textColor={colors.textSecondary}
+                            />
+                            <MacroLabel
+                                label="Fat"
+                                value={calculated.fat}
+                                color={colors.fat}
+                                textColor={colors.textSecondary}
+                            />
+                        </View>
+                    </View>
+
+                    <Button
+                        title="Save"
+                        onPress={handleSave}
+                        disabled={qty <= 0}
+                        style={styles.saveButton}
+                    />
+                </ScrollView>
+            </KeyboardAvoidingView>
+        </Modal>
+    );
+}
+
+function MacroLabel({
+    label,
+    value,
+    color,
+    textColor,
+}: {
+    label: string;
+    value: number;
+    color: string;
+    textColor: string;
+}) {
+    return (
+        <View style={macroStyles.macroItem}>
+            <Text style={[macroStyles.macroValue, { color }]}>{value.toFixed(1)}g</Text>
+            <Text style={[macroStyles.macroLabel, { color: textColor }]}>{label}</Text>
+        </View>
+    );
+}
+
+const macroStyles = StyleSheet.create({
+    macroItem: { alignItems: "center" },
+    macroValue: { fontSize: fontSize.md, fontWeight: "600" },
+    macroLabel: { fontSize: fontSize.xs },
+});
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        flex: { flex: 1, backgroundColor: colors.background },
+        header: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingHorizontal: spacing.lg,
+            paddingTop: spacing.lg,
+            paddingBottom: spacing.md,
+            backgroundColor: colors.surface,
+            borderBottomWidth: StyleSheet.hairlineWidth,
+            borderBottomColor: colors.border,
+        },
+        headerTitle: {
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        content: { padding: spacing.lg },
+        foodName: {
+            fontSize: fontSize.xl,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        per100: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            marginTop: spacing.xs,
+        },
+        quantityInput: { marginTop: spacing.lg },
+        sectionLabel: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.text,
+            marginTop: spacing.lg,
+            marginBottom: spacing.sm,
+        },
+        unitRow: {
+            flexDirection: "row",
+            gap: spacing.sm,
+            paddingBottom: spacing.sm,
+        },
+        unitChip: {
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.surface,
+            borderWidth: 1,
+            borderColor: colors.border,
+        },
+        unitChipActive: {
+            backgroundColor: colors.primaryLight,
+            borderColor: colors.primary,
+        },
+        unitChipText: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+        },
+        unitChipTextActive: {
+            color: colors.primary,
+            fontWeight: "600",
+        },
+        calcCard: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.md,
+            padding: spacing.md,
+            marginTop: spacing.md,
+            alignItems: "center",
+            gap: spacing.sm,
+        },
+        calcCalories: {
+            fontSize: 28,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        calcMacros: {
+            flexDirection: "row",
+            justifyContent: "space-around",
+            width: "100%",
+        },
+        saveButton: { marginTop: spacing.lg },
+    });
+}


### PR DESCRIPTION
## Summary

Resolves #36

## Changes

- Created `src/features/recipes/RecipeItemModal.tsx` — a full-screen modal modelled after `EntryModal` that provides:
  - Quantity input field
  - Horizontal unit chip picker (respects the user's metric/imperial preference)
  - Live macro calculation card (calories, protein, carbs, fat)
  - Save button
- Updated `RecipeEditorScreen.tsx`:
  - Replaced the old inline `TextInput`-only edit row with a tap-to-open `RecipeItemModal`
  - New ingredients automatically open the modal so quantity **and** unit can be set straight away
  - Removed now-unused inline editing state (`editingItemId`, `editingQty`, `saveCurrentEdit`, `handleSaveItemQty`)
  - Removed the unused `updateRecipeItem` import (saving is now handled inside the modal)