### PR TITLE
feat(recipes): recipe_logs table + portion multiplier (#58)

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,5 +1,5 @@
-import { openDatabaseSync } from "expo-sqlite";
 import { drizzle } from "drizzle-orm/expo-sqlite";
+import { openDatabaseSync } from "expo-sqlite";
 import * as schema from "./schema";
 
 const DB_NAME = "macroflow.db";
@@ -23,6 +23,20 @@ export function initDB() {
       serving_size REAL NOT NULL DEFAULT 100
     );
 
+    CREATE TABLE IF NOT EXISTS recipes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS recipe_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      recipe_id INTEGER NOT NULL REFERENCES recipes(id),
+      date TEXT NOT NULL,
+      meal_type TEXT NOT NULL,
+      portion REAL NOT NULL DEFAULT 1,
+      timestamp INTEGER NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS entries (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       food_id INTEGER REFERENCES foods(id),
@@ -31,8 +45,7 @@ export function initDB() {
       timestamp INTEGER NOT NULL,
       date TEXT NOT NULL DEFAULT '',
       meal_type TEXT NOT NULL,
-      recipe_id INTEGER,
-      recipe_log_group TEXT
+      recipe_log_id INTEGER REFERENCES recipe_logs(id)
     );
 
     CREATE TABLE IF NOT EXISTS goals (
@@ -42,11 +55,6 @@ export function initDB() {
       carbs REAL NOT NULL DEFAULT 250,
       fat REAL NOT NULL DEFAULT 70,
       unit_system TEXT NOT NULL DEFAULT 'metric'
-    );
-
-    CREATE TABLE IF NOT EXISTS recipes (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      name TEXT NOT NULL
     );
 
     CREATE TABLE IF NOT EXISTS recipe_items (
@@ -73,6 +81,8 @@ export function initDB() {
     "ALTER TABLE entries ADD COLUMN quantity_unit TEXT NOT NULL DEFAULT 'g'",
     "ALTER TABLE goals ADD COLUMN unit_system TEXT NOT NULL DEFAULT 'metric'",
     "ALTER TABLE recipe_items ADD COLUMN quantity_unit TEXT NOT NULL DEFAULT 'g'",
+    "ALTER TABLE entries ADD COLUMN recipe_portion REAL NOT NULL DEFAULT 1",
+    "ALTER TABLE entries ADD COLUMN recipe_log_id INTEGER REFERENCES recipe_logs(id)",
   ];
   for (const sql of migrations) {
     try { expoDb.execSync(sql); } catch { /* column already exists */ }
@@ -84,4 +94,33 @@ export function initDB() {
     SET date = strftime('%Y-%m-%d', timestamp / 1000, 'unixepoch', 'localtime')
     WHERE date = '';
   `);
+
+  // Migrate legacy recipe_log_group entries to recipe_logs table.
+  // Each distinct (recipe_id, recipe_log_group) becomes a recipe_logs row,
+  // and the entries are linked via recipe_log_id.
+  const legacyGroups = expoDb.getAllSync<{
+    recipe_id: number;
+    recipe_log_group: string;
+    date: string;
+    meal_type: string;
+    recipe_portion: number;
+    timestamp: number;
+  }>(`
+    SELECT DISTINCT recipe_id, recipe_log_group, date, meal_type,
+           recipe_portion, MIN(timestamp) as timestamp
+    FROM entries
+    WHERE recipe_log_group IS NOT NULL AND recipe_log_id IS NULL
+    GROUP BY recipe_log_group
+  `);
+  for (const g of legacyGroups) {
+    const result = expoDb.runSync(
+      `INSERT INTO recipe_logs (recipe_id, date, meal_type, portion, timestamp) VALUES (?, ?, ?, ?, ?)`,
+      [g.recipe_id, g.date, g.meal_type, g.recipe_portion ?? 1, g.timestamp],
+    );
+    const newId = result.lastInsertRowId;
+    expoDb.runSync(
+      `UPDATE entries SET recipe_log_id = ? WHERE recipe_log_group = ?`,
+      [newId, g.recipe_log_group],
+    );
+  }
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -261,26 +261,25 @@ export function updateRecipeLogPortion(
     const recipeLog = getRecipeLogById(recipeLogId);
     if (!recipeLog) return;
 
+    const oldMultiplier = recipeLog.portion;
+    if (oldMultiplier === 0) return;
+    const ratio = newMultiplier / oldMultiplier;
+
     db.update(recipeLogs)
         .set({ portion: newMultiplier })
         .where(eq(recipeLogs.id, recipeLogId))
         .run();
 
-    const templateItems = getRecipeItems(recipeLog.recipe_id);
-    const templateMap = new Map(
-        templateItems.map((t) => [t.recipe_items.food_id, t.recipe_items.quantity_grams]),
-    );
-
+    // Scale ALL entries (native + external) by the ratio so every
+    // ingredient in the group stays proportional.
     const groupEntries = db
         .select()
         .from(entries)
         .where(eq(entries.recipe_log_id, recipeLogId))
         .all();
     for (const entry of groupEntries) {
-        const baseQty = templateMap.get(entry.food_id!);
-        if (baseQty === undefined) continue;
         db.update(entries)
-            .set({ quantity_grams: baseQty * newMultiplier })
+            .set({ quantity_grams: entry.quantity_grams * ratio })
             .where(eq(entries.id, entry.id))
             .run();
     }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,7 +1,7 @@
 import { and, eq, like, sql } from "drizzle-orm";
 import logger from "../utils/logger";
 import { db } from "./index";
-import { entries, foods, goals, recipeItems, recipes } from "./schema";
+import { entries, foods, goals, recipeItems, recipeLogs, recipes } from "./schema";
 
 export type Food = typeof foods.$inferSelect;
 export type NewFood = typeof foods.$inferInsert;
@@ -12,6 +12,8 @@ export type Recipe = typeof recipes.$inferSelect;
 export type NewRecipe = typeof recipes.$inferInsert;
 export type RecipeItem = typeof recipeItems.$inferSelect;
 export type NewRecipeItem = typeof recipeItems.$inferInsert;
+export type RecipeLog = typeof recipeLogs.$inferSelect;
+export type NewRecipeLog = typeof recipeLogs.$inferInsert;
 
 // ── Food CRUD ──────────────────────────────────────────────
 
@@ -179,60 +181,112 @@ export function getStreak(): number {
 }
 
 export interface LoggedRecipeGroup {
+    recipeLogId: number;
     recipeId: number;
     recipeName: string;
-    recipeLogGroup: string;
+    portion: number;
 }
 
 export function getLoggedRecipeGroups(date: string, mealType: string): LoggedRecipeGroup[] {
     const rows = db
-        .selectDistinct({
-            recipeId: entries.recipe_id,
-            recipeLogGroup: entries.recipe_log_group,
+        .select({
+            recipeLogId: recipeLogs.id,
+            recipeId: recipeLogs.recipe_id,
+            portion: recipeLogs.portion,
         })
-        .from(entries)
+        .from(recipeLogs)
         .where(
             and(
-                eq(entries.date, date),
-                eq(entries.meal_type, mealType),
-                sql`${entries.recipe_log_group} IS NOT NULL`,
+                eq(recipeLogs.date, date),
+                eq(recipeLogs.meal_type, mealType),
             ),
         )
         .all();
 
-    const result: LoggedRecipeGroup[] = [];
-    for (const row of rows) {
-        if (!row.recipeId || !row.recipeLogGroup) continue;
+    return rows.map((row) => {
         const recipe = getRecipeById(row.recipeId);
-        result.push({
+        return {
+            recipeLogId: row.recipeLogId,
             recipeId: row.recipeId,
             recipeName: recipe?.name ?? "Recipe",
-            recipeLogGroup: row.recipeLogGroup,
-        });
-    }
-    return result;
+            portion: row.portion,
+        };
+    });
+}
+
+export function getRecipeLogById(id: number): RecipeLog | undefined {
+    return db.select().from(recipeLogs).where(eq(recipeLogs.id, id)).get();
 }
 
 export function logRecipeToMeal(
     recipeId: number,
     mealType: string,
     date: string,
-    group: string,
-) {
+    portionMultiplier = 1,
+): number {
+    const recipeLog = db
+        .insert(recipeLogs)
+        .values({
+            recipe_id: recipeId,
+            date,
+            meal_type: mealType,
+            portion: portionMultiplier,
+            timestamp: Date.now(),
+        })
+        .returning()
+        .get();
+
     const items = getRecipeItems(recipeId);
     const ts = Date.now();
     for (const row of items) {
         db.insert(entries)
             .values({
                 food_id: row.recipe_items.food_id,
-                quantity_grams: row.recipe_items.quantity_grams,
+                quantity_grams: row.recipe_items.quantity_grams * portionMultiplier,
                 quantity_unit: row.recipe_items.quantity_unit ?? "g",
                 timestamp: ts,
                 date,
                 meal_type: mealType,
-                recipe_id: recipeId,
-                recipe_log_group: group,
+                recipe_log_id: recipeLog.id,
             })
             .run();
     }
+    return recipeLog.id;
+}
+
+export function updateRecipeLogPortion(
+    recipeLogId: number,
+    newMultiplier: number,
+) {
+    const recipeLog = getRecipeLogById(recipeLogId);
+    if (!recipeLog) return;
+
+    db.update(recipeLogs)
+        .set({ portion: newMultiplier })
+        .where(eq(recipeLogs.id, recipeLogId))
+        .run();
+
+    const templateItems = getRecipeItems(recipeLog.recipe_id);
+    const templateMap = new Map(
+        templateItems.map((t) => [t.recipe_items.food_id, t.recipe_items.quantity_grams]),
+    );
+
+    const groupEntries = db
+        .select()
+        .from(entries)
+        .where(eq(entries.recipe_log_id, recipeLogId))
+        .all();
+    for (const entry of groupEntries) {
+        const baseQty = templateMap.get(entry.food_id!);
+        if (baseQty === undefined) continue;
+        db.update(entries)
+            .set({ quantity_grams: baseQty * newMultiplier })
+            .where(eq(entries.id, entry.id))
+            .run();
+    }
+}
+
+export function deleteRecipeLog(recipeLogId: number) {
+    db.delete(entries).where(eq(entries.recipe_log_id, recipeLogId)).run();
+    db.delete(recipeLogs).where(eq(recipeLogs.id, recipeLogId)).run();
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, real } from "drizzle-orm/sqlite-core";
+import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 export const foods = sqliteTable("foods", {
     id: integer("id").primaryKey({ autoIncrement: true }),
@@ -14,6 +14,15 @@ export const foods = sqliteTable("foods", {
     serving_size: real("serving_size").notNull().default(100),
 });
 
+export const recipeLogs = sqliteTable("recipe_logs", {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    recipe_id: integer("recipe_id").notNull().references(() => recipes.id),
+    date: text("date").notNull(),
+    meal_type: text("meal_type").notNull(),
+    portion: real("portion").notNull().default(1),
+    timestamp: integer("timestamp").notNull(),
+});
+
 export const entries = sqliteTable("entries", {
     id: integer("id").primaryKey({ autoIncrement: true }),
     food_id: integer("food_id").references(() => foods.id),
@@ -22,8 +31,7 @@ export const entries = sqliteTable("entries", {
     timestamp: integer("timestamp").notNull(),
     date: text("date").notNull(),
     meal_type: text("meal_type").notNull(),
-    recipe_id: integer("recipe_id"),
-    recipe_log_group: text("recipe_log_group"),
+    recipe_log_id: integer("recipe_log_id").references(() => recipeLogs.id),
 });
 
 export const goals = sqliteTable("goals", {

--- a/src/features/log/EntryModal.tsx
+++ b/src/features/log/EntryModal.tsx
@@ -69,8 +69,8 @@ export default function EntryModal({
             // association is always preserved when opening Edit Entry.
             const groups = getLoggedRecipeGroups(entry.date, entry.meal_type);
             setRecipeGroups(groups);
-            if (entry.recipe_id && entry.recipe_log_group) {
-                const match = groups.find((g) => g.recipeLogGroup === entry.recipe_log_group);
+            if (entry.recipe_log_id) {
+                const match = groups.find((g) => g.recipeLogId === entry.recipe_log_id);
                 setSelectedGroup(match ?? null);
             } else {
                 setSelectedGroup(null);
@@ -99,7 +99,7 @@ export default function EntryModal({
         const groups = getLoggedRecipeGroups(dateKey, mealType);
         setRecipeGroups(groups);
         setSelectedGroup((prev) =>
-            prev && groups.some((g) => g.recipeLogGroup === prev.recipeLogGroup) ? prev : null,
+            prev && groups.some((g) => g.recipeLogId === prev.recipeLogId) ? prev : null,
         );
     }, [mealType]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -125,8 +125,7 @@ export default function EntryModal({
                 quantity_grams: qtyGrams,
                 quantity_unit: unit,
                 meal_type: mealType,
-                recipe_id: selectedGroup?.recipeId ?? null,
-                recipe_log_group: selectedGroup?.recipeLogGroup ?? null,
+                recipe_log_id: selectedGroup?.recipeLogId ?? null,
             });
             logger.info("[DB] Updated entry", {
                 id: entry.id,
@@ -134,7 +133,7 @@ export default function EntryModal({
                 quantity: qtyGrams,
                 unit,
                 mealType: mealType,
-                recipeGroup: selectedGroup?.recipeLogGroup,
+                recipeLogId: selectedGroup?.recipeLogId,
             });
         } else {
             addEntry({
@@ -144,8 +143,7 @@ export default function EntryModal({
                 timestamp: Date.now(),
                 date: formatDateKey(selectedDate),
                 meal_type: mealType,
-                recipe_id: selectedGroup?.recipeId,
-                recipe_log_group: selectedGroup?.recipeLogGroup,
+                recipe_log_id: selectedGroup?.recipeLogId,
             });
             logger.info("[DB] Added entry", {
                 foodId: food.id,
@@ -153,7 +151,7 @@ export default function EntryModal({
                 unit,
                 date: formatDateKey(selectedDate),
                 mealType: mealType,
-                recipeGroup: selectedGroup?.recipeLogGroup,
+                recipeLogId: selectedGroup?.recipeLogId,
             });
         }
 
@@ -298,10 +296,10 @@ export default function EntryModal({
                         <>
                             <Text style={styles.sectionLabel}>Add to Recipe</Text>
                             {recipeGroups.map((g) => {
-                                const isSelected = selectedGroup?.recipeLogGroup === g.recipeLogGroup;
+                                const isSelected = selectedGroup?.recipeLogId === g.recipeLogId;
                                 return (
                                     <Pressable
-                                        key={g.recipeLogGroup}
+                                        key={g.recipeLogId}
                                         onPress={() => setSelectedGroup(isSelected ? null : g)}
                                         style={[styles.recipeGroupRow, isSelected && styles.recipeGroupRowActive]}
                                     >

--- a/src/features/log/EntryModal.tsx
+++ b/src/features/log/EntryModal.tsx
@@ -48,6 +48,7 @@ export default function EntryModal({
     );
     const [recipeGroups, setRecipeGroups] = useState<LoggedRecipeGroup[]>([]);
     const [selectedGroup, setSelectedGroup] = useState<LoggedRecipeGroup | null>(null);
+    const [portionMode, setPortionMode] = useState<"per-portion" | "total">("per-portion");
 
     // Initialize form fields and fetch recipe groups whenever the entry/food/meal/date changes.
     // Keeping this in a single effect avoids a race where a second effect would overwrite
@@ -117,6 +118,12 @@ export default function EntryModal({
         };
     }, [food, qtyGrams]);
 
+    // When adding to a recipe group with a non-1 multiplier and
+    // "per-portion" mode, scale the quantity by the group portion.
+    const shouldApplyPortion =
+        !entry && selectedGroup && selectedGroup.portion !== 1 && portionMode === "per-portion";
+    const finalQtyGrams = shouldApplyPortion ? qtyGrams * selectedGroup.portion : qtyGrams;
+
     function handleSave() {
         if (!food || qty <= 0) return;
 
@@ -138,7 +145,7 @@ export default function EntryModal({
         } else {
             addEntry({
                 food_id: food.id,
-                quantity_grams: qtyGrams,
+                quantity_grams: finalQtyGrams,
                 quantity_unit: unit,
                 timestamp: Date.now(),
                 date: formatDateKey(selectedDate),
@@ -147,7 +154,7 @@ export default function EntryModal({
             });
             logger.info("[DB] Added entry", {
                 foodId: food.id,
-                quantity: qtyGrams,
+                quantity: finalQtyGrams,
                 unit,
                 date: formatDateKey(selectedDate),
                 mealType: mealType,
@@ -300,7 +307,10 @@ export default function EntryModal({
                                 return (
                                     <Pressable
                                         key={g.recipeLogId}
-                                        onPress={() => setSelectedGroup(isSelected ? null : g)}
+                                        onPress={() => {
+                                            setSelectedGroup(isSelected ? null : g);
+                                            setPortionMode("per-portion");
+                                        }}
                                         style={[styles.recipeGroupRow, isSelected && styles.recipeGroupRowActive]}
                                     >
                                         <Ionicons
@@ -312,11 +322,41 @@ export default function EntryModal({
                                             style={[styles.recipeGroupName, isSelected && styles.recipeGroupNameActive]}
                                             numberOfLines={1}
                                         >
-                                            {g.recipeName}
+                                            {g.recipeName}{g.portion !== 1 ? ` (${g.portion}x)` : ""}
                                         </Text>
                                     </Pressable>
                                 );
                             })}
+                        </>
+                    )}
+
+                    {/* Portion mode toggle — shown when adding to a recipe group with multiplier ≠ 1 */}
+                    {!entry && selectedGroup && selectedGroup.portion !== 1 && (
+                        <>
+                            <Text style={styles.sectionLabel}>Amount is</Text>
+                            <View style={styles.mealRow}>
+                                <Pressable
+                                    onPress={() => setPortionMode("per-portion")}
+                                    style={[styles.mealChip, portionMode === "per-portion" && styles.mealChipActive]}
+                                >
+                                    <Text style={[styles.mealChipText, portionMode === "per-portion" && styles.mealChipTextActive]}>
+                                        Per Portion
+                                    </Text>
+                                </Pressable>
+                                <Pressable
+                                    onPress={() => setPortionMode("total")}
+                                    style={[styles.mealChip, portionMode === "total" && styles.mealChipActive]}
+                                >
+                                    <Text style={[styles.mealChipText, portionMode === "total" && styles.mealChipTextActive]}>
+                                        Total
+                                    </Text>
+                                </Pressable>
+                            </View>
+                            <Text style={styles.portionHint}>
+                                {portionMode === "per-portion"
+                                    ? `Saved as ${Math.round(finalQtyGrams)}g (${qty} × ${selectedGroup.portion})`
+                                    : `Saved as ${Math.round(qtyGrams)}g (no multiplier applied)`}
+                            </Text>
                         </>
                     )}
 
@@ -486,6 +526,11 @@ function createStyles(colors: ThemeColors, insetsTop = 0) {
         recipeGroupNameActive: {
             fontWeight: "600",
             color: colors.primary,
+        },
+        portionHint: {
+            fontSize: fontSize.xs,
+            color: colors.textSecondary,
+            marginTop: spacing.xs,
         },
         saveButton: { marginTop: spacing.lg },
     });

--- a/src/features/log/LogScreen.tsx
+++ b/src/features/log/LogScreen.tsx
@@ -1,8 +1,10 @@
-import { deleteEntry, getEntriesByDate, getGoals, type Entry, type Food, type Goals } from "@/src/db/queries";
+import Button from "@/src/components/Button";
+import Input from "@/src/components/Input";
+import { deleteEntry, deleteRecipeLog, getEntriesByDate, getGoals, updateRecipeLogPortion, type Entry, type Food, type Goals } from "@/src/db/queries";
 import { useAppStore } from "@/src/store/useAppStore";
 import { MEAL_TYPES, type MealType } from "@/src/types";
 import logger from "@/src/utils/logger";
-import { spacing, type ThemeColors } from "@/src/utils/theme";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { useThemeColors } from "@/src/utils/ThemeProvider";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
@@ -10,9 +12,11 @@ import { router } from "expo-router";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
     Dimensions,
+    Modal,
     Pressable,
     ScrollView,
     StyleSheet,
+    Text,
     View,
     type NativeScrollEvent,
     type NativeSyntheticEvent,
@@ -21,7 +25,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import DailyProgressBar from "./DailyProgressBar";
 import DateSelectorBar from "./DateSelectorBar";
 import EntryModal from "./EntryModal";
-import MealSection from "./MealSection";
+import MealSection, { type RecipeGroup } from "./MealSection";
 
 interface EntryWithFood {
     entries: Entry;
@@ -75,12 +79,16 @@ function DayPage({
     onAdd,
     onDelete,
     onEdit,
+    onEditRecipeGroup,
+    onDeleteRecipeLog,
 }: {
     grouped: Record<MealType, EntryWithFood[]>;
     goals: Goals;
     onAdd: (mt: MealType) => void;
     onDelete: (id: number) => void;
     onEdit: (row: EntryWithFood) => void;
+    onEditRecipeGroup: (group: RecipeGroup, multiplier: number) => void;
+    onDeleteRecipeLog: (recipeLogId: number) => void;
 }) {
     return (
         <View style={styles.dayPage}>
@@ -100,6 +108,8 @@ function DayPage({
                         onAdd={() => onAdd(meal.key)}
                         onDeleteEntry={onDelete}
                         onEdit={onEdit}
+                        onEditRecipeGroup={onEditRecipeGroup}
+                        onDeleteRecipeLog={onDeleteRecipeLog}
                     />
                 ))}
             </ScrollView>
@@ -147,6 +157,11 @@ export default function LogScreen() {
     });
 
     const [editingEntry, setEditingEntry] = useState<EntryWithFood | null>(null);
+    const [editingRecipeGroup, setEditingRecipeGroup] = useState<{
+        group: RecipeGroup;
+        multiplier: number;
+    } | null>(null);
+    const [portionInput, setPortionInput] = useState("1");
 
     function loadAllDays(center: Date) {
         setGrouped(loadGrouped(center));
@@ -200,8 +215,35 @@ export default function LogScreen() {
         loadAllDays(selectedDate);
     }
 
+    function handleDeleteRecipeLog(recipeLogId: number) {
+        deleteRecipeLog(recipeLogId);
+        logger.info("[DB] Deleted recipe log", { recipeLogId });
+        loadAllDays(selectedDate);
+    }
+
     function handleEdit(row: EntryWithFood) {
         setEditingEntry(row);
+    }
+
+    function handleEditRecipeGroup(group: RecipeGroup, multiplier: number) {
+        setEditingRecipeGroup({ group, multiplier });
+        setPortionInput(String(multiplier));
+    }
+
+    function handleSavePortionMultiplier() {
+        if (!editingRecipeGroup) return;
+        const newMultiplier = Math.max(0, parseFloat(portionInput) || 0);
+        if (newMultiplier <= 0) return;
+        updateRecipeLogPortion(
+            editingRecipeGroup.group.recipeLogId,
+            newMultiplier,
+        );
+        logger.info("[DB] Updated recipe log portion", {
+            recipeLogId: editingRecipeGroup.group.recipeLogId,
+            newMultiplier,
+        });
+        setEditingRecipeGroup(null);
+        loadAllDays(selectedDate);
     }
 
     function navigateToAdd(mealType?: MealType) {
@@ -255,6 +297,8 @@ export default function LogScreen() {
                     onAdd={navigateToAdd}
                     onDelete={handleDelete}
                     onEdit={handleEdit}
+                    onEditRecipeGroup={handleEditRecipeGroup}
+                    onDeleteRecipeLog={handleDeleteRecipeLog}
                 />
                 <DayPage
                     grouped={grouped}
@@ -262,6 +306,8 @@ export default function LogScreen() {
                     onAdd={navigateToAdd}
                     onDelete={handleDelete}
                     onEdit={handleEdit}
+                    onEditRecipeGroup={handleEditRecipeGroup}
+                    onDeleteRecipeLog={handleDeleteRecipeLog}
                 />
                 <DayPage
                     grouped={nextGrouped}
@@ -269,6 +315,8 @@ export default function LogScreen() {
                     onAdd={navigateToAdd}
                     onDelete={handleDelete}
                     onEdit={handleEdit}
+                    onEditRecipeGroup={handleEditRecipeGroup}
+                    onDeleteRecipeLog={handleDeleteRecipeLog}
                 />
             </ScrollView>
 
@@ -292,6 +340,53 @@ export default function LogScreen() {
             >
                 <Ionicons name="add" size={28} color="#fff" />
             </Pressable>
+
+            {/* Recipe portion edit modal */}
+            <Modal
+                visible={!!editingRecipeGroup}
+                transparent
+                animationType="fade"
+                onRequestClose={() => setEditingRecipeGroup(null)}
+            >
+                <Pressable style={styles.overlay} onPress={() => setEditingRecipeGroup(null)}>
+                    <Pressable style={styles.portionModal} onPress={() => { }}>
+                        <Text style={styles.portionModalTitle}>
+                            Adjust Portions
+                        </Text>
+                        <Text style={styles.portionModalSubtitle}>
+                            {editingRecipeGroup?.group.recipeName}
+                        </Text>
+                        <View style={styles.portionRow}>
+                            <Pressable
+                                onPress={() => {
+                                    const v = Math.max(0.25, (parseFloat(portionInput) || 1) - 0.25);
+                                    setPortionInput(String(Math.round(v * 100) / 100));
+                                }}
+                                style={styles.portionBtn}
+                            >
+                                <Ionicons name="remove" size={20} color={colors.primary} />
+                            </Pressable>
+                            <Input
+                                value={portionInput}
+                                onChangeText={setPortionInput}
+                                keyboardType="decimal-pad"
+                                containerStyle={styles.portionInputContainer}
+                                style={styles.portionInputText}
+                            />
+                            <Pressable
+                                onPress={() => {
+                                    const v = (parseFloat(portionInput) || 1) + 0.25;
+                                    setPortionInput(String(Math.round(v * 100) / 100));
+                                }}
+                                style={styles.portionBtn}
+                            >
+                                <Ionicons name="add" size={20} color={colors.primary} />
+                            </Pressable>
+                        </View>
+                        <Button title="Save" onPress={handleSavePortionMultiplier} />
+                    </Pressable>
+                </Pressable>
+            </Modal>
         </View>
     );
 }
@@ -323,5 +418,55 @@ function createStyles(colors: ThemeColors) {
             shadowRadius: 4,
         },
         fabPressed: { opacity: 0.8, transform: [{ scale: 0.95 }] },
+        overlay: {
+            flex: 1,
+            backgroundColor: "rgba(0,0,0,0.5)",
+            justifyContent: "center",
+            alignItems: "center",
+            padding: spacing.lg,
+        },
+        portionModal: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.lg,
+            width: "100%",
+            maxWidth: 340,
+        },
+        portionModalTitle: {
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+            color: colors.text,
+            marginBottom: spacing.xs,
+        },
+        portionModalSubtitle: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            marginBottom: spacing.md,
+        },
+        portionRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            marginBottom: spacing.md,
+        },
+        portionBtn: {
+            width: 40,
+            height: 40,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.background,
+            borderWidth: 1,
+            borderColor: colors.border,
+            alignItems: "center",
+            justifyContent: "center",
+        },
+        portionInputContainer: {
+            flex: 1,
+            marginBottom: 0,
+        },
+        portionInputText: {
+            textAlign: "center",
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+        },
     });
 }

--- a/src/features/log/MealSection.tsx
+++ b/src/features/log/MealSection.tsx
@@ -1,5 +1,5 @@
 import type { Entry, Food } from "@/src/db/queries";
-import { getRecipeById, getRecipeItems } from "@/src/db/queries";
+import { getRecipeById, getRecipeItems, getRecipeLogById } from "@/src/db/queries";
 import type { MealType } from "@/src/types";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { useThemeColors } from "@/src/utils/ThemeProvider";
@@ -21,38 +21,46 @@ interface MealSectionProps {
     onAdd: () => void;
     onDeleteEntry: (id: number) => void;
     onEdit?: (row: EntryWithFood) => void;
+    onEditRecipeGroup?: (group: RecipeGroup, currentMultiplier: number) => void;
+    onDeleteRecipeLog?: (recipeLogId: number) => void;
 }
 
-interface RecipeGroup {
-    group: string;
+export interface RecipeGroup {
+    recipeLogId: number;
     recipeId: number;
     recipeName: string;
+    portion: number;
     rows: EntryWithFood[];
 }
 
 function groupEntries(items: EntryWithFood[]) {
     const standalone: EntryWithFood[] = [];
-    const recipeMap = new Map<string, EntryWithFood[]>();
+    const recipeMap = new Map<number, EntryWithFood[]>();
 
     for (const item of items) {
-        const g = item.entries.recipe_log_group;
-        if (g) {
-            const list = recipeMap.get(g) ?? [];
+        const rlId = item.entries.recipe_log_id;
+        if (rlId) {
+            const list = recipeMap.get(rlId) ?? [];
             list.push(item);
-            recipeMap.set(g, list);
+            recipeMap.set(rlId, list);
         } else {
             standalone.push(item);
         }
     }
 
     const recipeGroups: RecipeGroup[] = [];
-    for (const [group, rows] of recipeMap) {
-        const recipeId = rows[0].entries.recipe_id!;
-        const recipe = getRecipeById(recipeId);
+    for (const [recipeLogId, rows] of recipeMap) {
+        const recipeLog = getRecipeLogById(recipeLogId);
+        if (!recipeLog) {
+            standalone.push(...rows);
+            continue;
+        }
+        const recipe = getRecipeById(recipeLog.recipe_id);
         recipeGroups.push({
-            group,
-            recipeId,
+            recipeLogId,
+            recipeId: recipeLog.recipe_id,
             recipeName: recipe?.name ?? "Recipe",
+            portion: recipeLog.portion,
             rows,
         });
     }
@@ -67,6 +75,8 @@ export default function MealSection({
     onAdd,
     onDeleteEntry,
     onEdit,
+    onEditRecipeGroup,
+    onDeleteRecipeLog,
 }: MealSectionProps) {
     const colors = useThemeColors();
     const styles = useMemo(() => createStyles(colors), [colors]);
@@ -110,10 +120,12 @@ export default function MealSection({
                     {/* Recipe groups */}
                     {recipeGroups.map((rg) => (
                         <RecipeGroupRow
-                            key={rg.group}
+                            key={rg.recipeLogId}
                             group={rg}
                             onEdit={onEdit}
                             onDeleteEntry={onDeleteEntry}
+                            onEditRecipeGroup={onEditRecipeGroup}
+                            onDeleteRecipeLog={onDeleteRecipeLog}
                         />
                     ))}
 
@@ -181,10 +193,14 @@ function RecipeGroupRow({
     group,
     onEdit,
     onDeleteEntry,
+    onEditRecipeGroup,
+    onDeleteRecipeLog,
 }: {
     group: RecipeGroup;
     onEdit?: (row: EntryWithFood) => void;
     onDeleteEntry: (id: number) => void;
+    onEditRecipeGroup?: (group: RecipeGroup, currentMultiplier: number) => void;
+    onDeleteRecipeLog?: (recipeLogId: number) => void;
 }) {
     const colors = useThemeColors();
     const styles = useMemo(() => createStyles(colors), [colors]);
@@ -196,6 +212,8 @@ function RecipeGroupRow({
         return sum + (food.calories_per_100g * row.entries.quantity_grams) / 100;
     }, 0);
 
+    const multiplier = group.portion;
+
     const isModified = useMemo(() => {
         const templateItems = getRecipeItems(group.recipeId);
         if (templateItems.length !== group.rows.length) return true;
@@ -204,10 +222,16 @@ function RecipeGroupRow({
         );
         for (const row of group.rows) {
             const templateQty = templateMap.get(row.entries.food_id!);
-            if (templateQty === undefined || templateQty !== row.entries.quantity_grams) return true;
+            if (templateQty === undefined) return true;
+            const expected = templateQty * multiplier;
+            if (Math.abs(row.entries.quantity_grams - expected) > 0.01) return true;
         }
         return false;
-    }, [group.recipeId, group.rows]);
+    }, [group.recipeId, group.rows, multiplier]);
+
+    const displayName = multiplier !== 1
+        ? `${multiplier}x ${group.recipeName}`
+        : group.recipeName;
 
     return (
         <View style={styles.recipeGroup}>
@@ -227,15 +251,22 @@ function RecipeGroupRow({
                     style={{ marginLeft: 4 }}
                 />
                 <Text style={styles.recipeName} numberOfLines={1}>
-                    {group.recipeName}
+                    {displayName}
                 </Text>
                 <Text style={styles.recipeDetail}>
                     {group.rows.length} items · {Math.round(totalCals)} cal
                 </Text>
+                {onEditRecipeGroup && (
+                    <Pressable
+                        onPress={() => onEditRecipeGroup(group, multiplier)}
+                        hitSlop={8}
+                        style={{ marginRight: spacing.xs }}
+                    >
+                        <Ionicons name="resize-outline" size={18} color={colors.primary} />
+                    </Pressable>
+                )}
                 <Pressable
-                    onPress={() => {
-                        for (const row of group.rows) onDeleteEntry(row.entries.id);
-                    }}
+                    onPress={() => onDeleteRecipeLog?.(group.recipeLogId)}
                     hitSlop={8}
                 >
                     <Ionicons name="close-circle-outline" size={20} color={colors.textTertiary} />

--- a/src/features/log/RecipeLogModal.tsx
+++ b/src/features/log/RecipeLogModal.tsx
@@ -1,4 +1,5 @@
 import Button from "@/src/components/Button";
+import Input from "@/src/components/Input";
 import {
     formatDateKey,
     getRecipeItems,
@@ -39,28 +40,35 @@ export default function RecipeLogModal({
     const styles = React.useMemo(() => createStyles(colors), [colors]);
     const selectedDate = useAppStore((s) => s.selectedDate);
     const [mealType, setMealType] = useState<MealType>(defaultMealType ?? "breakfast");
+    const [portionInput, setPortionInput] = useState("1");
 
     React.useEffect(() => {
         if (defaultMealType) setMealType(defaultMealType);
     }, [defaultMealType]);
 
+    React.useEffect(() => {
+        if (recipe) setPortionInput("1");
+    }, [recipe]);
+
     if (!recipe) return null;
+
+    const portion = Math.max(0, parseFloat(portionInput) || 0);
 
     const items = getRecipeItems(recipe.id);
     const totalCals = items.reduce((sum, row) => {
         const food = row.foods;
         if (!food) return sum;
         return sum + (food.calories_per_100g * row.recipe_items.quantity_grams) / 100;
-    }, 0);
+    }, 0) * portion;
 
     function handleSave() {
-        if (!recipe) return;
-        const group = `${recipe.id}-${Date.now()}`;
-        logRecipeToMeal(recipe.id, mealType, formatDateKey(selectedDate), group);
+        if (!recipe || portion <= 0) return;
+        logRecipeToMeal(recipe.id, mealType, formatDateKey(selectedDate), portion);
         logger.info("[DB] Logged recipe to meal", {
             recipeId: recipe.id,
             mealType,
             date: formatDateKey(selectedDate),
+            portionMultiplier: portion,
         });
         onSaved();
     }
@@ -73,54 +81,84 @@ export default function RecipeLogModal({
             onRequestClose={onClose}
         >
             <View style={styles.container}>
-            <View style={styles.header}>
-                <Text style={styles.headerTitle}>Add Recipe</Text>
-                <Pressable onPress={onClose} hitSlop={8}>
-                    <Ionicons name="close" size={24} color={colors.textSecondary} />
-                </Pressable>
-            </View>
-
-            <ScrollView contentContainerStyle={styles.content}>
-                <Text style={styles.recipeName}>{recipe.name}</Text>
-                <Text style={styles.summary}>
-                    {items.length} item{items.length !== 1 ? "s" : ""} · {Math.round(totalCals)} cal
-                </Text>
-
-                {items.map((row) => {
-                    const food = row.foods;
-                    const qty = row.recipe_items.quantity_grams;
-                    const itemUnit = (row.recipe_items.quantity_unit ?? "g") as FoodUnit;
-                    const displayQty = fromGrams(qty, itemUnit);
-                    const cals = food ? Math.round((food.calories_per_100g * qty) / 100) : 0;
-                    return (
-                        <View key={row.recipe_items.id} style={styles.itemRow}>
-                            <Text style={styles.itemName} numberOfLines={1}>
-                                {food?.name ?? "Unknown"}
-                            </Text>
-                            <Text style={styles.itemDetail}>{formatQuantity(Math.round(displayQty * 10) / 10, itemUnit)} · {cals} cal</Text>
-                        </View>
-                    );
-                })}
-
-                <Text style={styles.sectionLabel}>Meal</Text>
-                <View style={styles.mealRow}>
-                    {MEAL_TYPES.map((m) => (
-                        <Pressable
-                            key={m.key}
-                            onPress={() => setMealType(m.key)}
-                            style={[styles.mealChip, mealType === m.key && styles.mealChipActive]}
-                        >
-                            <Text
-                                style={[styles.mealChipText, mealType === m.key && styles.mealChipTextActive]}
-                            >
-                                {m.label}
-                            </Text>
-                        </Pressable>
-                    ))}
+                <View style={styles.header}>
+                    <Text style={styles.headerTitle}>Add Recipe</Text>
+                    <Pressable onPress={onClose} hitSlop={8}>
+                        <Ionicons name="close" size={24} color={colors.textSecondary} />
+                    </Pressable>
                 </View>
 
-                <Button title="Add to Log" onPress={handleSave} style={styles.saveBtn} />
-            </ScrollView>
+                <ScrollView contentContainerStyle={styles.content}>
+                    <Text style={styles.recipeName}>{recipe.name}</Text>
+                    <Text style={styles.summary}>
+                        {items.length} item{items.length !== 1 ? "s" : ""} · {Math.round(totalCals)} cal
+                    </Text>
+
+                    {/* Portion multiplier */}
+                    <Text style={styles.sectionLabel}>Portions</Text>
+                    <View style={styles.portionRow}>
+                        <Pressable
+                            onPress={() => {
+                                const v = Math.max(0.25, (parseFloat(portionInput) || 1) - 0.25);
+                                setPortionInput(String(Math.round(v * 100) / 100));
+                            }}
+                            style={styles.portionBtn}
+                        >
+                            <Ionicons name="remove" size={20} color={colors.primary} />
+                        </Pressable>
+                        <Input
+                            value={portionInput}
+                            onChangeText={setPortionInput}
+                            keyboardType="decimal-pad"
+                            containerStyle={styles.portionInput}
+                            style={styles.portionInputText}
+                        />
+                        <Pressable
+                            onPress={() => {
+                                const v = (parseFloat(portionInput) || 1) + 0.25;
+                                setPortionInput(String(Math.round(v * 100) / 100));
+                            }}
+                            style={styles.portionBtn}
+                        >
+                            <Ionicons name="add" size={20} color={colors.primary} />
+                        </Pressable>
+                    </View>
+
+                    {items.map((row) => {
+                        const food = row.foods;
+                        const qty = row.recipe_items.quantity_grams * portion;
+                        const itemUnit = (row.recipe_items.quantity_unit ?? "g") as FoodUnit;
+                        const displayQty = fromGrams(qty, itemUnit);
+                        const cals = food ? Math.round((food.calories_per_100g * qty) / 100) : 0;
+                        return (
+                            <View key={row.recipe_items.id} style={styles.itemRow}>
+                                <Text style={styles.itemName} numberOfLines={1}>
+                                    {food?.name ?? "Unknown"}
+                                </Text>
+                                <Text style={styles.itemDetail}>{formatQuantity(Math.round(displayQty * 10) / 10, itemUnit)} · {cals} cal</Text>
+                            </View>
+                        );
+                    })}
+
+                    <Text style={styles.sectionLabel}>Meal</Text>
+                    <View style={styles.mealRow}>
+                        {MEAL_TYPES.map((m) => (
+                            <Pressable
+                                key={m.key}
+                                onPress={() => setMealType(m.key)}
+                                style={[styles.mealChip, mealType === m.key && styles.mealChipActive]}
+                            >
+                                <Text
+                                    style={[styles.mealChipText, mealType === m.key && styles.mealChipTextActive]}
+                                >
+                                    {m.label}
+                                </Text>
+                            </Pressable>
+                        ))}
+                    </View>
+
+                    <Button title="Add to Log" onPress={handleSave} style={styles.saveBtn} />
+                </ScrollView>
             </View>
         </Modal>
     );
@@ -201,5 +239,30 @@ function createStyles(colors: ThemeColors) {
             fontWeight: "600",
         },
         saveBtn: { marginTop: spacing.md },
+        portionRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            marginBottom: spacing.md,
+        },
+        portionBtn: {
+            width: 40,
+            height: 40,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.surface,
+            borderWidth: 1,
+            borderColor: colors.border,
+            alignItems: "center",
+            justifyContent: "center",
+        },
+        portionInput: {
+            flex: 1,
+            marginBottom: 0,
+        },
+        portionInputText: {
+            textAlign: "center",
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+        },
     });
 }

--- a/src/services/importExport.ts
+++ b/src/services/importExport.ts
@@ -2,7 +2,7 @@ import { File, Paths } from "expo-file-system";
 import * as Sharing from "expo-sharing";
 import * as DocumentPicker from "expo-document-picker";
 import { db } from "@/src/db";
-import { foods, entries, goals, recipes, recipeItems } from "@/src/db/schema";
+import { foods, entries, goals, recipes, recipeItems, recipeLogs } from "@/src/db/schema";
 
 // ── Types ──────────────────────────────────────────────────
 
@@ -14,6 +14,7 @@ interface ExportPayload {
     goals: (typeof goals.$inferSelect)[];
     recipes: (typeof recipes.$inferSelect)[];
     recipeItems: (typeof recipeItems.$inferSelect)[];
+    recipeLogs?: (typeof recipeLogs.$inferSelect)[];
 }
 
 // ── Export ──────────────────────────────────────────────────
@@ -27,6 +28,7 @@ export async function exportData(): Promise<void> {
         goals: db.select().from(goals).all(),
         recipes: db.select().from(recipes).all(),
         recipeItems: db.select().from(recipeItems).all(),
+        recipeLogs: db.select().from(recipeLogs).all(),
     };
 
     const json = JSON.stringify(payload, null, 2);
@@ -63,8 +65,9 @@ export async function importData(): Promise<{ inserted: number }> {
     // Wrap everything in a transaction so partial imports don't corrupt the DB
     db.transaction((tx) => {
         // Clear existing data (order matters for FK constraints)
-        tx.delete(recipeItems).run();
         tx.delete(entries).run();
+        tx.delete(recipeLogs).run();
+        tx.delete(recipeItems).run();
         tx.delete(recipes).run();
         tx.delete(foods).run();
 
@@ -79,6 +82,12 @@ export async function importData(): Promise<{ inserted: number }> {
         for (const row of data.recipeItems) {
             tx.insert(recipeItems).values(row).run();
             inserted++;
+        }
+        if (data.recipeLogs) {
+            for (const row of data.recipeLogs) {
+                tx.insert(recipeLogs).values(row).run();
+                inserted++;
+            }
         }
         for (const row of data.entries) {
             tx.insert(entries).values(row).run();
@@ -110,5 +119,9 @@ function validate(data: unknown): asserts data is ExportPayload {
         if (!Array.isArray(d[key])) {
             throw new Error(`Invalid backup file: missing "${key}" array.`);
         }
+    }
+    // recipeLogs is optional for backwards compat with older exports
+    if (d.recipeLogs !== undefined && !Array.isArray(d.recipeLogs)) {
+        throw new Error(`Invalid backup file: "recipeLogs" must be an array.`);
     }
 }


### PR DESCRIPTION
Implements recipe-scoped portion multipliers via a new `recipe_logs` table.

- Adds  with  stored per logged recipe
- Entries reference ; legacy  migrated
- , , , , and import/export updated
-  now scales all group entries (including external additions)

Closes #58.