### PR TITLE
fix(search): actionable error feedback for OpenFoodFacts search (#39)

### DIFF
--- a/src/features/recipes/RecipeEditorScreen.tsx
+++ b/src/features/recipes/RecipeEditorScreen.tsx
@@ -62,6 +62,7 @@ export default function RecipeEditorScreen() {
     const [offResults, setOffResults] = useState<OFFProduct[]>([]);
     const [isSearchingOFF, setIsSearchingOFF] = useState(false);
     const [hasSearchedOFF, setHasSearchedOFF] = useState(false);
+    const [offError, setOffError] = useState<string | null>(null);
     const [showScanner, setShowScanner] = useState(false);
     const [showManualForm, setShowManualForm] = useState(false);
 
@@ -112,17 +113,22 @@ export default function RecipeEditorScreen() {
 
     useEffect(() => {
         setOffResults([]);
+        setOffError(null);
         setHasSearchedOFF(false);
     }, [foodQuery]);
 
     const handleSearchOFF = useCallback(async () => {
         if (foodQuery.trim().length < 2) return;
         setIsSearchingOFF(true);
+        setOffError(null);
         try {
             const results = await searchProducts(foodQuery.trim());
             setOffResults(results);
             setHasSearchedOFF(true);
-        } catch { /* ignore */ } finally {
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "Search failed";
+            setOffError(msg);
+        } finally {
             setIsSearchingOFF(false);
         }
     }, [foodQuery]);
@@ -312,7 +318,7 @@ export default function RecipeEditorScreen() {
                     keyboardShouldPersistTaps="handled"
                     nestedScrollEnabled
                 >
-                    {foodQuery.trim().length >= 2 && !hasSearchedOFF && (
+                    {foodQuery.trim().length >= 2 && !hasSearchedOFF && !offError && (
                         <Button
                             title={isSearchingOFF ? "Searching…" : "Search OpenFoodFacts"}
                             onPress={handleSearchOFF}
@@ -320,6 +326,18 @@ export default function RecipeEditorScreen() {
                             loading={isSearchingOFF}
                             style={styles.offBtn}
                         />
+                    )}
+
+                    {offError && (
+                        <View style={styles.errorBox}>
+                            <Text style={styles.errorText}>{offError}</Text>
+                            <Button
+                                title="Retry"
+                                variant="ghost"
+                                onPress={handleSearchOFF}
+                                textStyle={{ fontSize: fontSize.sm }}
+                            />
+                        </View>
                     )}
 
                     {localResults.map((food) => (
@@ -449,6 +467,23 @@ function createStyles(colors: ThemeColors) {
         },
         actionBtn: { flex: 1 },
         offBtn: { marginTop: spacing.sm, marginHorizontal: spacing.lg },
+        errorBox: {
+            flexDirection: "row" as const,
+            alignItems: "center" as const,
+            justifyContent: "space-between" as const,
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.sm,
+            padding: spacing.sm,
+            marginTop: spacing.sm,
+            marginHorizontal: spacing.lg,
+            borderWidth: 1,
+            borderColor: colors.danger,
+        },
+        errorText: {
+            flex: 1,
+            fontSize: fontSize.sm,
+            color: colors.danger,
+        },
         doneBtn: { marginTop: spacing.lg },
     });
 }

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -107,7 +107,11 @@ export async function searchProducts(
 
     if (!res.ok) {
         logger.error("[API] Search failed", { status: res.status });
-        throw new Error("Search request failed");
+        throw new Error(
+            res.status === 503
+                ? "OpenFoodFacts is temporarily unavailable — try again later"
+                : `Search failed (HTTP ${res.status})`,
+        );
     }
 
     const data: OFFSearchResponse = await res.json();


### PR DESCRIPTION
Fixes broken/silent OpenFoodFacts search error handling across recipe and log flows.

## Changes

**`src/services/openfoodfacts.ts`**
- 503 responses now throw a clear "OpenFoodFacts is temporarily unavailable" message
- Other HTTP errors include the status code in the message

**`src/features/recipes/RecipeEditorScreen.tsx`**
- Added `offError` state (was previously an empty `catch` block that silently swallowed errors)
- Error box with red border + Retry button now shown on failure — matches `AddFoodScreen` pattern
- Error resets when the search query changes

## Before / After

| Screen | Before | After |
|--------|--------|-------|
| Edit Recipe (503) | Nothing happened | "OpenFoodFacts is temporarily unavailable — try again later" + Retry |
| Edit Recipe (rate limit) | Nothing happened | "Rate limited — please wait Xs" + Retry |
| Add to Log (503) | "Search request failed" | "OpenFoodFacts is temporarily unavailable — try again later" + Retry |
| Add to Log (rate limit) | "Rate limited — please wait s" | Same (seconds already shown correctly) |

Resolves #39.