### PR TITLE
feat(recipes): reverse food order in Edit Recipe (#38)

### DIFF
--- a/src/features/recipes/RecipeEditorScreen.tsx
+++ b/src/features/recipes/RecipeEditorScreen.tsx
@@ -240,7 +240,7 @@ export default function RecipeEditorScreen() {
                 </Text>
 
                 {/* Items */}
-                {items.map((itemWithFood) => {
+                {items.slice().reverse().map((itemWithFood) => {
                     const { recipeItem, food } = itemWithFood;
                     const itemUnit = (recipeItem.quantity_unit ?? "g") as FoodUnit;
                     const displayQty = Math.round(fromGrams(recipeItem.quantity_grams, itemUnit) * 10) / 10;


### PR DESCRIPTION
Reverse the displayed order of ingredients in the Edit Recipe screen so newest items show first.

Closes #38.