### PR TITLE
feat(templates): edit and remove foods (#63)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -7,7 +7,7 @@ import { StyleSheet, Text, View } from "react-native";
 
 const icons: Record<string, string> = {
     index: 'create',
-    recipes: 'book',
+    recipes: 'library',
     settings: 'settings'
 };
 
@@ -62,7 +62,7 @@ export default function TabsLayout() {
                 },
             })}
         >
-            <Tabs.Screen name="recipes" options={{ title: "Recipes", tabBarLabel: "Recipes" }} />
+            <Tabs.Screen name="recipes" options={{ title: "Templates", tabBarLabel: "Templates" }} />
             <Tabs.Screen name="index" options={{ title: "Logs", tabBarLabel: "Logs" }} />
             <Tabs.Screen name="settings" options={{ title: "Settings", tabBarLabel: "Settings" }} />
         </Tabs>

--- a/app/recipes/_layout.tsx
+++ b/app/recipes/_layout.tsx
@@ -12,6 +12,7 @@ export default function RecipesLayout() {
             }}
         >
             <Stack.Screen name="edit" options={{ title: "Edit Recipe" }} />
+            <Stack.Screen name="food-edit" options={{ title: "Edit Food" }} />
         </Stack>
     );
 }

--- a/app/recipes/food-edit.tsx
+++ b/app/recipes/food-edit.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/src/features/recipes/FoodEditorScreen";

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -42,6 +42,24 @@ export function getFoodByOpenfoodfactsId(offId: string): Food | undefined {
         .get();
 }
 
+export function getAllFoods(): Food[] {
+    return db.select().from(foods).all();
+}
+
+export function getFoodById(id: number): Food | undefined {
+    return db.select().from(foods).where(eq(foods.id, id)).get();
+}
+
+export function updateFood(id: number, values: Partial<NewFood>) {
+    db.update(foods).set(values).where(eq(foods.id, id)).run();
+}
+
+export function deleteFood(id: number) {
+    db.delete(recipeItems).where(eq(recipeItems.food_id, id)).run();
+    db.delete(entries).where(eq(entries.food_id, id)).run();
+    db.delete(foods).where(eq(foods.id, id)).run();
+}
+
 // ── Entry CRUD ─────────────────────────────────────────────
 
 export function addEntry(entry: NewEntry): Entry {

--- a/src/features/recipes/FoodEditorScreen.tsx
+++ b/src/features/recipes/FoodEditorScreen.tsx
@@ -1,0 +1,206 @@
+import Button from "@/src/components/Button";
+import Input from "@/src/components/Input";
+import { getFoodById, updateFood } from "@/src/db/queries";
+import { useAppStore } from "@/src/store/useAppStore";
+import logger from "@/src/utils/logger";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { useThemeColors } from "@/src/utils/ThemeProvider";
+import { type FoodUnit, unitLabel, unitsForSystem } from "@/src/utils/units";
+import { router, useLocalSearchParams } from "expo-router";
+import React, { useEffect, useState } from "react";
+import {
+    KeyboardAvoidingView,
+    Platform,
+    Pressable,
+    ScrollView,
+    StyleSheet,
+    Text,
+    View
+} from "react-native";
+
+export default function FoodEditorScreen() {
+    const { foodId } = useLocalSearchParams<{ foodId: string }>();
+    const colors = useThemeColors();
+    const styles = React.useMemo(() => createStyles(colors), [colors]);
+    const unitSystem = useAppStore((s) => s.unitSystem);
+
+    const [name, setName] = useState("");
+    const [calories, setCalories] = useState("");
+    const [protein, setProtein] = useState("");
+    const [carbs, setCarbs] = useState("");
+    const [fat, setFat] = useState("");
+    const [defaultUnit, setDefaultUnit] = useState<FoodUnit>("g");
+
+    useEffect(() => {
+        if (!foodId) return;
+        const food = getFoodById(Number(foodId));
+        if (food) {
+            setName(food.name);
+            setCalories(String(food.calories_per_100g));
+            setProtein(String(food.protein_per_100g));
+            setCarbs(String(food.carbs_per_100g));
+            setFat(String(food.fat_per_100g));
+            setDefaultUnit(food.default_unit as FoodUnit);
+        }
+    }, [foodId]);
+
+    function handleSave() {
+        if (!foodId || !name.trim()) return;
+        updateFood(Number(foodId), {
+            name: name.trim(),
+            calories_per_100g: parseFloat(calories) || 0,
+            protein_per_100g: parseFloat(protein) || 0,
+            carbs_per_100g: parseFloat(carbs) || 0,
+            fat_per_100g: parseFloat(fat) || 0,
+            default_unit: defaultUnit,
+        });
+        logger.info("[DB] Updated food", { id: foodId, name: name.trim() });
+        router.back();
+    }
+
+
+    return (
+        <KeyboardAvoidingView
+            behavior={Platform.OS === "ios" ? "padding" : undefined}
+            style={styles.flex}
+        >
+            <ScrollView
+                contentContainerStyle={styles.content}
+                keyboardShouldPersistTaps="handled"
+            >
+                <Input
+                    label="Food Name"
+                    placeholder="e.g., Chicken Breast"
+                    value={name}
+                    onChangeText={setName}
+                    containerStyle={styles.field}
+                />
+
+                <Text style={styles.sectionLabel}>Default unit</Text>
+                <ScrollView
+                    horizontal
+                    showsHorizontalScrollIndicator={false}
+                    contentContainerStyle={styles.unitRow}
+                >
+                    {unitsForSystem(unitSystem).map((u) => (
+                        <Pressable
+                            key={u}
+                            onPress={() => setDefaultUnit(u)}
+                            style={[
+                                styles.unitChip,
+                                defaultUnit === u && styles.unitChipActive,
+                            ]}
+                        >
+                            <Text
+                                style={[
+                                    styles.unitChipText,
+                                    defaultUnit === u && styles.unitChipTextActive,
+                                ]}
+                            >
+                                {unitLabel(u)}
+                            </Text>
+                        </Pressable>
+                    ))}
+                </ScrollView>
+
+                <Text style={styles.sectionLabel}>Nutrition per 100 g</Text>
+
+                <View style={styles.row}>
+                    <Input
+                        label="Calories"
+                        placeholder="0"
+                        suffix="kcal"
+                        value={calories}
+                        onChangeText={setCalories}
+                        keyboardType="decimal-pad"
+                        containerStyle={styles.halfField}
+                    />
+                    <Input
+                        label="Protein"
+                        placeholder="0"
+                        suffix="g"
+                        value={protein}
+                        onChangeText={setProtein}
+                        keyboardType="decimal-pad"
+                        containerStyle={styles.halfField}
+                    />
+                </View>
+
+                <View style={styles.row}>
+                    <Input
+                        label="Carbs"
+                        placeholder="0"
+                        suffix="g"
+                        value={carbs}
+                        onChangeText={setCarbs}
+                        keyboardType="decimal-pad"
+                        containerStyle={styles.halfField}
+                    />
+                    <Input
+                        label="Fat"
+                        placeholder="0"
+                        suffix="g"
+                        value={fat}
+                        onChangeText={setFat}
+                        keyboardType="decimal-pad"
+                        containerStyle={styles.halfField}
+                    />
+                </View>
+
+                <Button
+                    title="Save"
+                    onPress={handleSave}
+                    disabled={!name.trim()}
+                    style={styles.saveButton}
+                />
+            </ScrollView>
+        </KeyboardAvoidingView>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        flex: { flex: 1, backgroundColor: colors.background },
+        content: { padding: spacing.lg },
+        field: { marginBottom: spacing.md },
+        sectionLabel: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            marginBottom: spacing.md,
+            marginTop: spacing.sm,
+        },
+        unitRow: {
+            flexDirection: "row",
+            gap: spacing.sm,
+            marginBottom: spacing.md,
+        },
+        unitChip: {
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.surface,
+            borderWidth: 1,
+            borderColor: colors.border,
+        },
+        unitChipActive: {
+            backgroundColor: colors.primaryLight,
+            borderColor: colors.primary,
+        },
+        unitChipText: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+        },
+        unitChipTextActive: {
+            color: colors.primary,
+            fontWeight: "600",
+        },
+        row: {
+            flexDirection: "row",
+            gap: spacing.md,
+            marginBottom: spacing.md,
+        },
+        halfField: { flex: 1 },
+        saveButton: { marginTop: spacing.md },
+    });
+}

--- a/src/features/recipes/RecipesScreen.tsx
+++ b/src/features/recipes/RecipesScreen.tsx
@@ -1,8 +1,12 @@
 import {
+    deleteFood,
     deleteRecipe,
+    getAllFoods,
     getAllRecipes,
     getRecipeItems,
+    searchFoodsByName,
     searchRecipesByName,
+    type Food,
     type Recipe,
 } from "@/src/db/queries";
 import logger from "@/src/utils/logger";
@@ -23,23 +27,42 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+type FilterType = "all" | "recipes" | "foods";
+
+type TemplateItem =
+    | { kind: "food"; data: Food }
+    | { kind: "recipe"; data: Recipe };
+
 export default function RecipesScreen() {
     const colors = useThemeColors();
     const styles = React.useMemo(() => createStyles(colors), [colors]);
     const insets = useSafeAreaInsets();
-    const [recipes, setRecipes] = useState<Recipe[]>([]);
+    const [items, setItems] = useState<TemplateItem[]>([]);
     const [query, setQuery] = useState("");
+    const [filter, setFilter] = useState<FilterType>("all");
+    const [filterExpanded, setFilterExpanded] = useState(false);
 
     function load() {
-        const list = query.trim().length >= 2
-            ? searchRecipesByName(query.trim())
-            : getAllRecipes();
-        setRecipes(list);
+        const q = query.trim();
+        const hasQuery = q.length >= 2;
+        const result: TemplateItem[] = [];
+
+        if (filter !== "foods") {
+            const recipeList = hasQuery ? searchRecipesByName(q) : getAllRecipes();
+            for (const r of recipeList) result.push({ kind: "recipe", data: r });
+        }
+        if (filter !== "recipes") {
+            const foodList = hasQuery ? searchFoodsByName(q) : getAllFoods();
+            for (const f of foodList) result.push({ kind: "food", data: f });
+        }
+
+        result.sort((a, b) => a.data.name.localeCompare(b.data.name));
+        setItems(result);
     }
 
-    useFocusEffect(useCallback(() => { load(); }, [query]));
+    useFocusEffect(useCallback(() => { load(); }, [query, filter]));
 
-    function handleDelete(recipe: Recipe) {
+    function handleDeleteRecipe(recipe: Recipe) {
         Alert.alert("Delete recipe", `Remove "${recipe.name}"?`, [
             { text: "Cancel", style: "cancel" },
             {
@@ -54,25 +77,89 @@ export default function RecipesScreen() {
         ]);
     }
 
-    function summaryText(recipeId: number) {
-        const items = getRecipeItems(recipeId);
-        if (items.length === 0) return "No items";
-        const totalCals = items.reduce((sum, row) => {
+    function handleDeleteFood(food: Food) {
+        Alert.alert(
+            "Delete food",
+            `Remove "${food.name}"? This will also remove it from recipes and log entries.`,
+            [
+                { text: "Cancel", style: "cancel" },
+                {
+                    text: "Delete",
+                    style: "destructive",
+                    onPress: () => {
+                        deleteFood(food.id);
+                        logger.info("[DB] Deleted food", { id: food.id });
+                        load();
+                    },
+                },
+            ],
+        );
+    }
+
+    function recipeSummary(recipeId: number) {
+        const recipeItemsList = getRecipeItems(recipeId);
+        if (recipeItemsList.length === 0) return "No items";
+        const totalCals = recipeItemsList.reduce((sum, row) => {
             const food = row.foods;
             if (!food) return sum;
             return sum + (food.calories_per_100g * row.recipe_items.quantity_grams) / 100;
         }, 0);
-        return `${items.length} item${items.length > 1 ? "s" : ""} · ${Math.round(totalCals)} cal`;
+        return `${recipeItemsList.length} item${recipeItemsList.length > 1 ? "s" : ""} · ${Math.round(totalCals)} cal`;
+    }
+
+    function foodSummary(food: Food) {
+        return `${Math.round(food.calories_per_100g)} cal/100g`;
+    }
+
+    function toggleFilter(type: "recipes" | "foods") {
+        setFilter((prev) => (prev === type ? "all" : type));
+    }
+
+    function renderItem({ item }: { item: TemplateItem }) {
+        if (item.kind === "recipe") {
+            const recipe = item.data as Recipe;
+            return (
+                <Pressable
+                    style={styles.card}
+                    onPress={() => router.push({ pathname: "/recipes/edit", params: { recipeId: String(recipe.id) } } as unknown as Href)}
+                >
+                    <Ionicons name="book-outline" size={22} color={colors.primary} style={styles.cardIcon} />
+                    <View style={styles.cardInfo}>
+                        <Text style={styles.cardName} numberOfLines={1}>{recipe.name}</Text>
+                        <Text style={styles.cardSub}>{recipeSummary(recipe.id)}</Text>
+                    </View>
+                    <Pressable onPress={() => handleDeleteRecipe(recipe)} hitSlop={8}>
+                        <Ionicons name="trash-outline" size={20} color={colors.danger} />
+                    </Pressable>
+                </Pressable>
+            );
+        }
+        const food = item.data as Food;
+        return (
+            <Pressable
+                style={styles.card}
+                onPress={() => router.push({ pathname: "/recipes/food-edit", params: { foodId: String(food.id) } } as unknown as Href)}
+            >
+                <Ionicons name="nutrition-outline" size={22} color={colors.success} style={styles.cardIcon} />
+                <View style={styles.cardInfo}>
+                    <Text style={styles.cardName} numberOfLines={1}>{food.name}</Text>
+                    <Text style={styles.cardSub}>{foodSummary(food)}</Text>
+                </View>
+                <Pressable onPress={() => handleDeleteFood(food)} hitSlop={8}>
+                    <Ionicons name="trash-outline" size={20} color={colors.danger} />
+                </Pressable>
+            </Pressable>
+        );
     }
 
     return (
         <View style={[styles.screen, { paddingTop: insets.top }]}>
-            <Text style={styles.heading}>Recipes</Text>
+            <Text style={styles.heading}>Templates</Text>
             <View style={styles.searchRow}>
                 <Ionicons name="search" size={18} color={colors.textTertiary} />
                 <TextInput
                     style={styles.searchInput}
-                    placeholder="Search recipes…"
+                    placeholder="Search templates…"
                     placeholderTextColor={colors.textTertiary}
                     value={query}
                     onChangeText={setQuery}
@@ -84,29 +171,62 @@ export default function RecipesScreen() {
                 )}
             </View>
 
+            <Pressable
+                onPress={() => setFilterExpanded((prev) => !prev)}
+                style={styles.filterHeader}
+            >
+                <Text style={styles.filterLabel}>Filter</Text>
+                <Ionicons
+                    name={filterExpanded ? "chevron-up" : "chevron-down"}
+                    size={18}
+                    color={colors.textSecondary}
+                />
+            </Pressable>
+            {filterExpanded && (
+                <View style={styles.filterRow}>
+                    <Pressable
+                        style={[styles.filterButton, filter === "recipes" && styles.filterButtonActive]}
+                        onPress={() => toggleFilter("recipes")}
+                    >
+                        <Ionicons
+                            name="book-outline"
+                            size={16}
+                            color={filter === "recipes" ? colors.primary : colors.textSecondary}
+                            style={{ marginRight: spacing.xs }}
+                        />
+                        <Text style={[styles.filterButtonText, filter === "recipes" && styles.filterButtonTextActive]}>
+                            Recipes
+                        </Text>
+                    </Pressable>
+                    <Pressable
+                        style={[styles.filterButton, filter === "foods" && styles.filterButtonActive]}
+                        onPress={() => toggleFilter("foods")}
+                    >
+                        <Ionicons
+                            name="nutrition-outline"
+                            size={16}
+                            color={filter === "foods" ? colors.primary : colors.textSecondary}
+                            style={{ marginRight: spacing.xs }}
+                        />
+                        <Text style={[styles.filterButtonText, filter === "foods" && styles.filterButtonTextActive]}>
+                            Foods
+                        </Text>
+                    </Pressable>
+                </View>
+            )}
+
             <FlatList
-                data={recipes}
-                keyExtractor={(r) => String(r.id)}
+                data={items}
+                keyExtractor={(item) =>
+                    item.kind === "recipe" ? `recipe-${item.data.id}` : `food-${item.data.id}`
+                }
                 contentContainerStyle={styles.list}
                 ListEmptyComponent={
                     <Text style={styles.empty}>
-                        {query ? "No matching recipes" : "No recipes yet — tap + to create one"}
+                        {query ? "No matching templates" : "No templates yet — tap + to create a recipe"}
                     </Text>
                 }
-                renderItem={({ item }) => (
-                    <Pressable
-                        style={styles.card}
-                        onPress={() => router.push({ pathname: "/recipes/edit", params: { recipeId: String(item.id) } } as unknown as Href)}
-                    >
-                        <View style={styles.cardInfo}>
-                            <Text style={styles.cardName} numberOfLines={1}>{item.name}</Text>
-                            <Text style={styles.cardSub}>{summaryText(item.id)}</Text>
-                        </View>
-                        <Pressable onPress={() => handleDelete(item)} hitSlop={8}>
-                            <Ionicons name="trash-outline" size={20} color={colors.danger} />
-                        </Pressable>
-                    </Pressable>
-                )}
+                renderItem={renderItem}
             />
 
             <Pressable
@@ -133,7 +253,8 @@ function createStyles(colors: ThemeColors) {
         searchRow: {
             flexDirection: "row",
             alignItems: "center",
-            margin: spacing.md,
+            marginHorizontal: spacing.md,
+            marginBottom: spacing.xs,
             backgroundColor: colors.surface,
             borderRadius: borderRadius.md,
             paddingHorizontal: spacing.md,
@@ -147,6 +268,49 @@ function createStyles(colors: ThemeColors) {
             fontSize: fontSize.md,
             color: colors.text,
             padding: 0,
+        },
+        filterHeader: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginHorizontal: spacing.md,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+        },
+        filterLabel: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.textSecondary,
+        },
+        filterRow: {
+            flexDirection: "row",
+            gap: spacing.sm,
+            marginHorizontal: spacing.md,
+            paddingHorizontal: spacing.md,
+            marginBottom: spacing.sm,
+        },
+        filterButton: {
+            flex: 1,
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "center",
+            paddingVertical: spacing.sm,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.surface,
+            borderWidth: 1,
+            borderColor: colors.border,
+        },
+        filterButtonActive: {
+            backgroundColor: colors.primaryLight,
+            borderColor: colors.primary,
+        },
+        filterButtonText: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+        },
+        filterButtonTextActive: {
+            color: colors.primary,
+            fontWeight: "600",
         },
         list: { paddingHorizontal: spacing.md, paddingBottom: 100 },
         empty: {
@@ -163,6 +327,7 @@ function createStyles(colors: ThemeColors) {
             flexDirection: "row",
             alignItems: "center",
         },
+        cardIcon: { marginRight: spacing.sm },
         cardInfo: { flex: 1, marginRight: spacing.sm },
         cardName: { fontSize: fontSize.md, fontWeight: "600", color: colors.text },
         cardSub: { fontSize: fontSize.xs, color: colors.textSecondary, marginTop: 2 },


### PR DESCRIPTION
Implements the Templates screen with food editing and removal support.

- Renames the **Recipes** tab to **Templates** with a library icon
- Lists all **foods and recipes** in a unified, alphabetically sorted list
- Adds distinguishing icons: `nutrition-outline` for foods, `book-outline` for recipes
- Adds a **collapsible Filter section** (collapsed by default) with Recipes / Foods toggle buttons
- Tapping a food navigates to a new **FoodEditorScreen** (reuses the ManualFoodForm field layout)
- Tapping a recipe navigates to the existing RecipeEditorScreen
- Adds `getAllFoods`, `getFoodById`, `updateFood`, `deleteFood` query helpers

Closes #63.