### PR TITLE
fix: prefill carbs and fat values on Edit Food screen

### DIFF
--- a/src/features/recipes/FoodEditorScreen.tsx
+++ b/src/features/recipes/FoodEditorScreen.tsx
@@ -133,6 +133,7 @@ export default function FoodEditorScreen() {
                         label={t("settings.carbs")}
                         placeholder="0"
                         suffix={t("common.g")}
+                        value={carbs}
                         onChangeText={setCarbs}
                         keyboardType="decimal-pad"
                         containerStyle={styles.halfField}
@@ -141,6 +142,7 @@ export default function FoodEditorScreen() {
                         label={t("settings.fat")}
                         placeholder="0"
                         suffix={t("common.g")}
+                        value={fat}
                         onChangeText={setFat}
                         keyboardType="decimal-pad"
                         containerStyle={styles.halfField}


### PR DESCRIPTION
## Summary

Fat and Carbs were not being prefilled on the Edit Food screen because the `value` prop was missing from the `carbs` and `fat` `Input` components in `FoodEditorScreen.tsx`. Calories and Protein worked correctly because they had the `value` prop set.

## Fix

Added `value={carbs}` and `value={fat}` to the respective `Input` components.

Resolves #84