### PR TITLE
fix: scale streak badge for long streaks (up to 4 digits)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,8 +3,8 @@ import { useThemeColors } from "@/src/utils/ThemeProvider";
 import { Ionicons } from '@expo/vector-icons';
 import { Tabs, useFocusEffect } from "expo-router";
 import { useCallback, useState } from "react";
-import { StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
+import { StyleSheet, Text, View } from "react-native";
 
 const icons: Record<string, string> = {
     index: 'create',
@@ -24,12 +24,12 @@ export default function TabsLayout() {
         streakBadge: {
             position: 'absolute',
             top: -4,
-            right: -14,
+            right: -18,
             flexDirection: 'row',
             alignItems: 'center',
         },
         streakText: {
-            fontSize: 14,
+            fontSize: streak >= 1000 ? 9 : streak >= 100 ? 11 : 13,
             fontWeight: '700',
             color: colors.textSecondary,
         },
@@ -55,7 +55,7 @@ export default function TabsLayout() {
                             <View style={styles.iconContainer}>
                                 <Ionicons name={name as any} size={size} color={color} />
                                 <View style={styles.streakBadge}>
-                                    <Text style={styles.streakText}>🔥{streak}</Text>
+                                    <Text style={styles.streakText} numberOfLines={1}>{`🔥${streak}`}</Text>
                                 </View>
                             </View>
                         );


### PR DESCRIPTION
## Summary

Resolves #86

## Changes

- Scale streak badge font size based on digit count: 13px (1–2 digits) → 11px (3 digits) → 9px (4 digits) to keep the number fitting next to the flame
- Add `numberOfLines={1}` to the streak `Text` to prevent the emoji and number from splitting onto separate lines (known Android behaviour)
- Slightly widen the right offset from `-14` to `-18` to give the larger text a bit more breathing room