### PR TITLE
fix: resolve Android ScreenStackFragment crash in recipe editors

### DIFF
--- a/app/recipes/_layout.tsx
+++ b/app/recipes/_layout.tsx
@@ -1,37 +1,5 @@
-import { useThemeColors } from "@/src/utils/ThemeProvider";
-import { Stack } from "expo-router";
-import { useTranslation } from "react-i18next";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Slot } from "expo-router";
 
 export default function RecipesLayout() {
-    const { t } = useTranslation();
-    const colors = useThemeColors();
-    const insets = useSafeAreaInsets();
-    return (
-        <Stack
-            screenOptions={{
-                headerStyle: { backgroundColor: colors.surface },
-                headerTintColor: colors.text,
-                headerShadowVisible: false,
-                headerStatusBarHeight: insets.top,
-            }}
-        >
-            <Stack.Screen
-                name="edit"
-                options={({ route }) => ({
-                    title: (route.params as { recipeId?: string })?.recipeId
-                        ? t("recipes.recipeEditorTitle")
-                        : t("recipes.newRecipeTitle"),
-                })}
-            />
-            <Stack.Screen
-                name="food-edit"
-                options={({ route }) => ({
-                    title: (route.params as { foodId?: string })?.foodId
-                        ? t("recipes.foodEditorTitle")
-                        : t("recipes.newFoodTitle"),
-                })}
-            />
-        </Stack>
-    );
+    return <Slot />;
 }

--- a/src/features/recipes/FoodEditorScreen.tsx
+++ b/src/features/recipes/FoodEditorScreen.tsx
@@ -7,16 +7,18 @@ import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/t
 import { useThemeColors } from "@/src/utils/ThemeProvider";
 import { unitLabel, unitsForSystem, type FoodUnit } from "@/src/utils/units";
 import { Ionicons } from "@expo/vector-icons";
-import { router, useLocalSearchParams } from "expo-router";
+import { router, Stack, useLocalSearchParams } from "expo-router";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function FoodEditorScreen() {
     const { foodId } = useLocalSearchParams<{ foodId?: string }>();
     const { t } = useTranslation();
     const colors = useThemeColors();
     const styles = React.useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
     const unitSystem = useAppStore((s) => s.unitSystem);
 
     const [name, setName] = useState("");
@@ -99,6 +101,19 @@ export default function FoodEditorScreen() {
 
 
     return (
+        <>
+        <Stack.Screen
+            options={{
+                headerShown: true,
+                headerStyle: { backgroundColor: colors.surface },
+                headerTintColor: colors.text,
+                headerShadowVisible: false,
+                headerStatusBarHeight: insets.top,
+                title: foodId
+                    ? t("recipes.foodEditorTitle")
+                    : t("recipes.newFoodTitle"),
+            }}
+        />
         <ScrollView
             style={styles.flex}
             contentContainerStyle={styles.content}
@@ -236,6 +251,7 @@ export default function FoodEditorScreen() {
                 style={styles.saveButton}
             />
         </ScrollView>
+        </>
     );
 }
 

--- a/src/features/recipes/RecipeEditorScreen.tsx
+++ b/src/features/recipes/RecipeEditorScreen.tsx
@@ -23,7 +23,7 @@ import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/t
 import { useThemeColors } from "@/src/utils/ThemeProvider";
 import { fromGrams, toGrams, unitLabel, type FoodUnit } from "@/src/utils/units";
 import { Ionicons } from "@expo/vector-icons";
-import { router, useLocalSearchParams } from "expo-router";
+import { router, Stack, useLocalSearchParams } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     Alert,
@@ -36,6 +36,7 @@ import {
     useWindowDimensions,
     View
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 
 interface ItemWithFood {
@@ -51,6 +52,7 @@ export default function RecipeEditorScreen() {
     const styles = React.useMemo(() => createStyles(colors), [colors]);
     const { recipeId } = useLocalSearchParams<{ recipeId?: string }>();
     const { height: screenHeight } = useWindowDimensions();
+    const insets = useSafeAreaInsets();
     const sheetRef = useRef<BottomSheetRef>(null);
     const snapPoints = useMemo(() => [SHEET_COLLAPSED, Math.round(screenHeight * 0.8)], [screenHeight]);
     const isEditing = !!recipeId;
@@ -223,6 +225,18 @@ export default function RecipeEditorScreen() {
 
     return (
         <View style={styles.screen}>
+            <Stack.Screen
+                options={{
+                    headerShown: true,
+                    headerStyle: { backgroundColor: colors.surface },
+                    headerTintColor: colors.text,
+                    headerShadowVisible: false,
+                    headerStatusBarHeight: insets.top,
+                    title: isEditing
+                        ? t("recipes.recipeEditorTitle")
+                        : t("recipes.newRecipeTitle"),
+                }}
+            />
             <ScrollView
                 contentContainerStyle={styles.content}
                 keyboardShouldPersistTaps="handled"


### PR DESCRIPTION
## Summary

Fixes the "ScreenStackFragment added into a non-stack container" crash on Android when navigating to the recipe or food editor screens.

## Root Cause

The `app/recipes/_layout.tsx` rendered a `<Stack>` navigator inside the root `<Stack>` (from `app/_layout.tsx`). On Android, this nesting creates conflicting native `ScreenStack` / `ScreenStackFragment` hierarchies in `react-native-screens`, causing the crash.

## Changes

- **`app/recipes/_layout.tsx`** — replaced `<Stack>` with `<Slot>` (passthrough layout, no nested navigator)
- **`RecipeEditorScreen.tsx`** — moved header configuration into the screen via `<Stack.Screen options={...} />`
- **`FoodEditorScreen.tsx`** — same treatment, each screen now owns its header config

Resolves #94