### PR TITLE
fix: persist appearance setting across restarts

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -100,6 +100,7 @@ export function initDB() {
     "ALTER TABLE goals ADD COLUMN language TEXT NOT NULL DEFAULT 'en'",
     "ALTER TABLE foods ADD COLUMN last_logged_amount REAL",
     "ALTER TABLE foods ADD COLUMN last_logged_unit TEXT",
+    "ALTER TABLE goals ADD COLUMN appearance_mode TEXT NOT NULL DEFAULT 'system'",
   ];
   for (const sql of migrations) {
     try { expoDb.execSync(sql); } catch { /* column already exists */ }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -44,6 +44,7 @@ export const goals = sqliteTable("goals", {
     fat: real("fat").notNull().default(70),
     unit_system: text("unit_system").notNull().default("metric"),
     language: text("language").notNull().default("en"),
+    appearance_mode: text("appearance_mode").notNull().default("system"),
 });
 
 export const recipes = sqliteTable("recipes", {

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -63,6 +63,9 @@ export default function SettingsScreen() {
             if (g.unit_system === "metric" || g.unit_system === "imperial") {
                 setUnitSystem(g.unit_system as UnitSystem);
             }
+            if (g.appearance_mode === "light" || g.appearance_mode === "dark" || g.appearance_mode === "system") {
+                setAppearanceMode(g.appearance_mode as AppearanceMode);
+            }
         }
     }, []);
 
@@ -137,6 +140,9 @@ export default function SettingsScreen() {
                 if (g.unit_system === "metric" || g.unit_system === "imperial") {
                     setUnitSystem(g.unit_system as UnitSystem);
                 }
+                if (g.appearance_mode === "light" || g.appearance_mode === "dark" || g.appearance_mode === "system") {
+                    setAppearanceMode(g.appearance_mode as AppearanceMode);
+                }
             }
             Alert.alert(
                 t("settings.importComplete"),
@@ -191,7 +197,7 @@ export default function SettingsScreen() {
                             styles.chip,
                             appearanceMode === opt.key && styles.chipActive,
                         ]}
-                        onPress={() => setAppearanceMode(opt.key)}
+                        onPress={() => { setAppearanceMode(opt.key); setGoals({ appearance_mode: opt.key }); }}
                     >
                         <Text
                             style={[


### PR DESCRIPTION
## Summary

Resolves #103

The appearance setting was only stored in Zustand (in-memory) and never written to the database, causing it to reset to `system` on every app restart.

## Changes

- **`src/db/schema.ts`**: Added `appearance_mode` column to the `goals` table (default: `'system'`)
- **`src/db/index.ts`**: Added `ALTER TABLE` migration so existing databases gain the new column
- **`src/features/settings/SettingsScreen.tsx`**:
  - Load `appearance_mode` from the database on mount
  - Persist to the database whenever the user changes the appearance option
  - Also restore `appearance_mode` when settings are restored via data import