### PR TITLE
feat: tap empty meal section to open add food screen

### DIFF
--- a/src/features/log/MealSection.tsx
+++ b/src/features/log/MealSection.tsx
@@ -164,7 +164,9 @@ export default function MealSection({
 
 
             {items.length === 0 ? (
-                <Text style={styles.empty}>{t("log.noFoodsLogged")}</Text>
+                <Pressable onPress={() => !selectionMode && onAdd()} style={styles.emptyPressable}>
+                    <Text style={styles.empty}>{t("log.noFoodsLogged")}</Text>
+                </Pressable>
             ) : (
                 <>
                     {/* Recipe groups */}
@@ -470,6 +472,11 @@ function createStyles(colors: ThemeColors) {
             color: colors.textTertiary,
             fontStyle: "italic",
             paddingVertical: spacing.xs,
+        },
+        emptyPressable: {
+            alignSelf: "stretch",
+            marginTop: -spacing.sm,
+            paddingTop: spacing.sm,
         },
         entryRow: {
             flexDirection: "row",


### PR DESCRIPTION
closes #77

When a meal section has no entries, tapping anywhere in the card body (including the gap below the header) now opens the add food screen. The empty-state text is wrapped in a `Pressable` with a negative top margin matching the header's bottom margin, ensuring the full area is tappable.