### PR TITLE
fix: load appearanceMode and unitSystem from DB on startup

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,7 +5,7 @@ import { getGoals } from "../src/db/queries";
 import "../src/i18n";
 import i18n from "../src/i18n";
 import { useAppStore } from "../src/store/useAppStore";
-import type { Language } from "../src/types";
+import type { AppearanceMode, Language, UnitSystem } from "../src/types";
 import { ThemeProvider, useThemeColors } from "../src/utils/ThemeProvider";
 import { useEffect } from "react";
 
@@ -14,6 +14,8 @@ initDB();
 function InnerLayout() {
   const colors = useThemeColors();
   const setLanguage = useAppStore((s) => s.setLanguage);
+  const setAppearanceMode = useAppStore((s) => s.setAppearanceMode);
+  const setUnitSystem = useAppStore((s) => s.setUnitSystem);
 
   useEffect(() => {
     const goals = getGoals();
@@ -21,6 +23,12 @@ function InnerLayout() {
       const lang = goals.language as Language;
       setLanguage(lang);
       i18n.changeLanguage(lang);
+    }
+    if (goals?.appearance_mode === "light" || goals?.appearance_mode === "dark" || goals?.appearance_mode === "system") {
+      setAppearanceMode(goals.appearance_mode as AppearanceMode);
+    }
+    if (goals?.unit_system === "metric" || goals?.unit_system === "imperial") {
+      setUnitSystem(goals.unit_system as UnitSystem);
     }
   }, []);
 


### PR DESCRIPTION
## Summary

Resolves #106

### Root cause
On app launch, `_layout.tsx` only hydrated `language` from the goals database into the store. `appearanceMode` and `unitSystem` were left at their store defaults (`"system"` and `"metric"`). The `ThemeProvider` therefore always started with the `"system"` appearance. Only when `SettingsScreen` mounted and ran its own `useEffect` were the persisted values loaded, causing the theme to flip at that point.

### Fix
In `InnerLayout`'s startup `useEffect` inside `app/_layout.tsx`, also read `appearance_mode` and `unit_system` from the goals DB and push them into the store — the same pattern already used for `language`.