### PR TITLE
feat: add [+] button to create custom serving unit in Add to Log / Edit Entry

### DIFF
--- a/src/features/log/EntryModal.tsx
+++ b/src/features/log/EntryModal.tsx
@@ -1,6 +1,6 @@
 import Button from "@/src/components/Button";
 import Input from "@/src/components/Input";
-import { addEntry, formatDateKey, getLoggedRecipeGroups, getServingUnits, updateEntry, updateFood, type Entry, type Food, type LoggedRecipeGroup, type ServingUnit } from "@/src/db/queries";
+import { addEntry, addServingUnit, formatDateKey, getLoggedRecipeGroups, getServingUnits, updateEntry, updateFood, type Entry, type Food, type LoggedRecipeGroup, type ServingUnit } from "@/src/db/queries";
 import { useAppStore } from "@/src/store/useAppStore";
 import { MEAL_TYPES, type MealType } from "@/src/types";
 import logger from "@/src/utils/logger";
@@ -17,6 +17,7 @@ import {
     ScrollView,
     StyleSheet,
     Text,
+    TextInput,
     View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -53,6 +54,9 @@ export default function EntryModal({
     const [recipeGroups, setRecipeGroups] = useState<LoggedRecipeGroup[]>([]);
     const [selectedGroup, setSelectedGroup] = useState<LoggedRecipeGroup | null>(null);
     const [portionMode, setPortionMode] = useState<"per-portion" | "total">("per-portion");
+    const [showAddUnit, setShowAddUnit] = useState(false);
+    const [newUnitName, setNewUnitName] = useState("");
+    const [newUnitGrams, setNewUnitGrams] = useState("");
     const amountTouched = useRef(false);
 
     // Initialize form fields and fetch recipe groups whenever the entry/food/meal/date changes.
@@ -212,6 +216,21 @@ export default function EntryModal({
         onSaved();
     }
 
+    function handleAddUnit() {
+        if (!food?.id) return;
+        const name = newUnitName.trim();
+        const grams = parseFloat(newUnitGrams);
+        if (!name || !grams || grams <= 0) return;
+        const saved = addServingUnit({ food_id: food.id, name, grams });
+        const updated = getServingUnits(food.id);
+        setFoodServingUnits(updated);
+        setCustomServingUnit(saved);
+        if (!amountTouched.current) setQuantity("1");
+        setNewUnitName("");
+        setNewUnitGrams("");
+        setShowAddUnit(false);
+    }
+
     function handleClose() {
         setQuantity("100");
         onClose();
@@ -314,7 +333,54 @@ export default function EntryModal({
                                 </Text>
                             </Pressable>
                         ))}
+                        {food?.id ? (
+                            <Pressable
+                                onPress={() => setShowAddUnit((v) => !v)}
+                                style={[styles.unitChip, styles.unitChipAdd]}
+                            >
+                                <Ionicons name="add" size={16} color={colors.primary} />
+                            </Pressable>
+                        ) : null}
                     </ScrollView>
+
+                    {/* Inline add-custom-unit form */}
+                    {showAddUnit && (
+                        <View style={styles.addUnitForm}>
+                            <Text style={styles.addUnitTitle}>{t("recipes.addServingUnit")}</Text>
+                            <View style={styles.addUnitRow}>
+                                <TextInput
+                                    style={[styles.addUnitInput, { flex: 2 }]}
+                                    placeholder={t("recipes.servingUnitNamePlaceholder")}
+                                    placeholderTextColor={colors.textSecondary}
+                                    value={newUnitName}
+                                    onChangeText={setNewUnitName}
+                                />
+                                <TextInput
+                                    style={[styles.addUnitInput, { flex: 1 }]}
+                                    placeholder={t("recipes.servingUnitGrams")}
+                                    placeholderTextColor={colors.textSecondary}
+                                    value={newUnitGrams}
+                                    onChangeText={setNewUnitGrams}
+                                    keyboardType="decimal-pad"
+                                />
+                            </View>
+                            <View style={styles.addUnitActions}>
+                                <Pressable
+                                    onPress={() => { setShowAddUnit(false); setNewUnitName(""); setNewUnitGrams(""); }}
+                                    style={styles.addUnitCancelBtn}
+                                >
+                                    <Text style={styles.addUnitCancelText}>{t("common.cancel")}</Text>
+                                </Pressable>
+                                <Pressable
+                                    onPress={handleAddUnit}
+                                    style={[styles.addUnitSaveBtn, (!newUnitName.trim() || !parseFloat(newUnitGrams)) && styles.addUnitSaveBtnDisabled]}
+                                    disabled={!newUnitName.trim() || !parseFloat(newUnitGrams)}
+                                >
+                                    <Text style={styles.addUnitSaveText}>{t("common.save")}</Text>
+                                </Pressable>
+                            </View>
+                        </View>
+                    )}
 
                     {/* Live calculation */}
                     <View style={styles.calcCard}>
@@ -525,6 +591,70 @@ function createStyles(colors: ThemeColors, insetsTop = 0) {
         unitChipTextActive: {
             color: colors.primary,
             fontWeight: "600",
+        },
+        unitChipAdd: {
+            borderColor: colors.primary,
+            borderStyle: "dashed",
+            justifyContent: "center",
+            alignItems: "center",
+            paddingHorizontal: spacing.sm,
+        },
+        addUnitForm: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+            padding: spacing.md,
+            marginTop: spacing.sm,
+        },
+        addUnitTitle: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.text,
+            marginBottom: spacing.sm,
+        },
+        addUnitRow: {
+            flexDirection: "row",
+            gap: spacing.sm,
+        },
+        addUnitInput: {
+            borderWidth: 1,
+            borderColor: colors.border,
+            borderRadius: borderRadius.sm,
+            paddingHorizontal: spacing.sm,
+            paddingVertical: spacing.xs,
+            fontSize: fontSize.sm,
+            color: colors.text,
+            backgroundColor: colors.background,
+        },
+        addUnitActions: {
+            flexDirection: "row",
+            justifyContent: "flex-end",
+            gap: spacing.sm,
+            marginTop: spacing.sm,
+        },
+        addUnitCancelBtn: {
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.xs,
+            borderRadius: borderRadius.sm,
+        },
+        addUnitCancelText: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+        },
+        addUnitSaveBtn: {
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.xs,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.primary,
+        },
+        addUnitSaveBtnDisabled: {
+            backgroundColor: colors.border,
+        },
+        addUnitSaveText: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.background,
         },
         calcCard: {
             backgroundColor: colors.surface,


### PR DESCRIPTION
## Summary

Closes #108

Users can now create a custom serving unit directly from the **Add to Log** and **Edit Entry** screens, without having to navigate to the food template first.

## Changes

- Added a dashed `[+]` chip button at the end of the unit picker row in `EntryModal`
- Tapping it reveals an inline form with **unit name** and **grams** inputs
- On save, the new serving unit is persisted to the food template via `addServingUnit` and automatically selected
- Cancelling dismisses the form without saving
- Works on both iOS and Android (no platform-specific `Alert.prompt` dependency)