### PR TITLE
fix: UI not updating when moving entry to another meal on the same day

### DIFF
--- a/src/features/log/LogScreen.tsx
+++ b/src/features/log/LogScreen.tsx
@@ -432,6 +432,7 @@ export default function LogScreen() {
         }
         exitSelectionMode();
         setMoveModalVisible(false);
+        loadAllDays(targetDate);
         setSelectedDate(targetDate);
     }
 


### PR DESCRIPTION
## Summary

Resolves #110

## Root cause

When moving an entry to another meal on the **same day**, `handleMoveCopy` called `setSelectedDate(targetDate)` where `targetDate` was the same `Date` reference as the store's current `selectedDate` (the modal initialises its internal state from `initialDate={selectedDate}`). Zustand's shallow `Object.is` equality check saw no change, so no re-render was triggered and `useFocusEffect` never fired `loadAllDays` — leaving the UI stale.

Different-day moves worked because the new date reference caused a genuine store update, which re-ran `useFocusEffect`.

## Fix

Added a direct call to `loadAllDays(targetDate)` in `handleMoveCopy` right after the database operation. This ensures the grouped-entry state is always refreshed immediately, regardless of whether the target date is the same or different.