### PR TITLE
Refactor Settings: Replace tab with 'More' (closes #113)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -9,7 +9,7 @@ import { StyleSheet, Text, View } from "react-native";
 const icons: Record<string, string> = {
     index: 'create',
     recipes: 'library',
-    settings: 'settings'
+    more: 'ellipsis-horizontal'
 };
 
 export default function TabsLayout() {
@@ -66,7 +66,12 @@ export default function TabsLayout() {
         >
             <Tabs.Screen name="recipes" options={{ title: t("nav.templates"), tabBarLabel: t("nav.templates") }} />
             <Tabs.Screen name="index" options={{ title: t("nav.logs"), tabBarLabel: t("nav.logs") }} />
-            <Tabs.Screen name="settings" options={{ title: t("nav.settings"), tabBarLabel: t("nav.settings") }} />
+            <Tabs.Screen name="more" options={{ title: t("nav.more"), tabBarLabel: t("nav.more") }} />
+            {/* Hidden screens — part of tabs so the tab bar stays visible */}
+            <Tabs.Screen name="analytics" options={{ href: null }} />
+            <Tabs.Screen name="goals" options={{ href: null }} />
+            <Tabs.Screen name="backup" options={{ href: null }} />
+            <Tabs.Screen name="settings" options={{ href: null }} />
         </Tabs>
     );
 }

--- a/app/(tabs)/analytics.tsx
+++ b/app/(tabs)/analytics.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../src/features/analytics/AnalyticsScreen";

--- a/app/(tabs)/backup.tsx
+++ b/app/(tabs)/backup.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/src/features/settings/BackupScreen";

--- a/app/(tabs)/goals.tsx
+++ b/app/(tabs)/goals.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/src/features/settings/GoalsScreen";

--- a/app/(tabs)/more.tsx
+++ b/app/(tabs)/more.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/src/features/more/MoreScreen";

--- a/app/analytics.tsx
+++ b/app/analytics.tsx
@@ -1,1 +1,0 @@
-export { default } from "../src/features/analytics/AnalyticsScreen";

--- a/src/features/analytics/AnalyticsScreen.tsx
+++ b/src/features/analytics/AnalyticsScreen.tsx
@@ -4,6 +4,7 @@ import logger from "@/src/utils/logger";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { useThemeColors } from "@/src/utils/ThemeProvider";
 import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ActivityIndicator, Dimensions, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
@@ -336,9 +337,16 @@ export default function AnalyticsScreen() {
 
 
 
+    const router = useRouter();
+
     return (
         <View style={[styles.container, { paddingTop: insets.top }]}>
-            <Text style={styles.title}>{t("analytics.title")}</Text>
+            <View style={styles.titleRow}>
+                <Pressable onPress={() => router.navigate("/(tabs)/more" as any)} style={styles.backBtn} hitSlop={8}>
+                    <Ionicons name="chevron-back" size={24} color={colors.primary} />
+                </Pressable>
+                <Text style={styles.title}>{t("analytics.title")}</Text>
+            </View>
 
             <ScrollView
                 style={styles.scroll}
@@ -708,13 +716,18 @@ function createStyles(colors: ThemeColors) {
             flex: 1,
             backgroundColor: colors.background,
         },
+        titleRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            paddingHorizontal: spacing.md,
+            paddingTop: spacing.md,
+            paddingBottom: spacing.sm,
+        },
+        backBtn: { padding: 4, marginRight: spacing.sm },
         title: {
             fontSize: fontSize.xl,
             fontWeight: "700",
             color: colors.text,
-            paddingHorizontal: spacing.md,
-            paddingTop: spacing.md,
-            paddingBottom: spacing.sm,
         },
         scroll: {
             flex: 1,

--- a/src/features/more/MoreScreen.tsx
+++ b/src/features/more/MoreScreen.tsx
@@ -1,0 +1,127 @@
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { useThemeColors } from "@/src/utils/ThemeProvider";
+import { Ionicons } from "@expo/vector-icons";
+import type { Href } from "expo-router";
+import { useRouter } from "expo-router";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+type MenuItem = {
+    icon: React.ComponentProps<typeof Ionicons>["name"];
+    labelKey: string;
+    route: string;
+    color: string;
+};
+
+export default function MoreScreen() {
+    const { t } = useTranslation();
+    const colors = useThemeColors();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
+    const router = useRouter();
+
+    const menuItems: MenuItem[] = [
+        { icon: "bar-chart", labelKey: "more.analytics", route: "/(tabs)/analytics", color: "#6C63FF" },
+        { icon: "flag", labelKey: "more.goals", route: "/(tabs)/goals", color: "#FF6B6B" },
+        { icon: "archive", labelKey: "more.backup", route: "/(tabs)/backup", color: "#4ECDC4" },
+    ];
+
+    return (
+        <View style={[styles.screen, { paddingTop: insets.top }]}>
+            <ScrollView contentContainerStyle={styles.content}>
+                <Text style={styles.heading}>{t("nav.more")}</Text>
+
+                <View style={styles.menuCard}>
+                    {menuItems.map((item, index) => (
+                        <React.Fragment key={item.route}>
+                            <Pressable
+                                style={({ pressed }) => [styles.menuRow, pressed && styles.menuRowPressed]}
+                                onPress={() => router.push(item.route as unknown as Href)}
+                            >
+                                <View style={[styles.iconWrapper, { backgroundColor: item.color + "20" }]}>
+                                    <Ionicons name={item.icon} size={22} color={item.color} />
+                                </View>
+                                <Text style={styles.menuLabel}>{t(item.labelKey)}</Text>
+                                <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
+                            </Pressable>
+                            {index < menuItems.length - 1 && <View style={styles.divider} />}
+                        </React.Fragment>
+                    ))}
+                </View>
+            </ScrollView>
+
+            {/* Settings gear FAB */}
+            <Pressable
+                style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
+                onPress={() => router.push("/(tabs)/settings" as unknown as Href)}
+            >
+                <Ionicons name="settings-sharp" size={26} color="#fff" />
+            </Pressable>
+        </View>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        screen: { flex: 1, backgroundColor: colors.background },
+        content: { padding: spacing.lg, paddingBottom: 100 },
+        heading: {
+            fontSize: fontSize.xl,
+            fontWeight: "700",
+            color: colors.text,
+            marginBottom: spacing.lg,
+        },
+        menuCard: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            borderWidth: 1,
+            borderColor: colors.border,
+            overflow: "hidden",
+        },
+        menuRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.md + 2,
+            gap: spacing.md,
+        },
+        menuRowPressed: { opacity: 0.6 },
+        iconWrapper: {
+            width: 40,
+            height: 40,
+            borderRadius: borderRadius.md,
+            alignItems: "center",
+            justifyContent: "center",
+        },
+        menuLabel: {
+            flex: 1,
+            fontSize: fontSize.md,
+            fontWeight: "500",
+            color: colors.text,
+        },
+        divider: {
+            height: StyleSheet.hairlineWidth,
+            backgroundColor: colors.border,
+            marginLeft: spacing.md + 40 + spacing.md,
+        },
+        fab: {
+            position: "absolute",
+            bottom: 24,
+            right: 24,
+            width: 56,
+            height: 56,
+            borderRadius: 28,
+            backgroundColor: colors.primary,
+            alignItems: "center",
+            justifyContent: "center",
+            elevation: 4,
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: 2 },
+            shadowOpacity: 0.25,
+            shadowRadius: 4,
+        },
+        fabPressed: { opacity: 0.8, transform: [{ scale: 0.95 }] },
+    });
+}

--- a/src/features/settings/BackupScreen.tsx
+++ b/src/features/settings/BackupScreen.tsx
@@ -1,0 +1,145 @@
+import Button from "@/src/components/Button";
+import { getGoals } from "@/src/db/queries";
+import { exportData, importData } from "@/src/services/importExport";
+import { useAppStore } from "@/src/store/useAppStore";
+import type { AppearanceMode, UnitSystem } from "@/src/types";
+import { fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { useThemeColors } from "@/src/utils/ThemeProvider";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import React, { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+export default function BackupScreen() {
+    const { t } = useTranslation();
+    const colors = useThemeColors();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
+    const router = useRouter();
+
+    const setUnitSystem = useAppStore((s) => s.setUnitSystem);
+    const setAppearanceMode = useAppStore((s) => s.setAppearanceMode);
+
+    const [exporting, setExporting] = useState(false);
+    const [importing, setImporting] = useState(false);
+
+    async function handleExport() {
+        try {
+            setExporting(true);
+            await exportData();
+        } catch (e: any) {
+            Alert.alert(t("settings.exportFailed"), e.message ?? "Unknown error");
+        } finally {
+            setExporting(false);
+        }
+    }
+
+    function handleImportConfirm() {
+        Alert.alert(
+            t("settings.importTitle"),
+            t("settings.importWarning"),
+            [
+                { text: t("common.cancel"), style: "cancel" },
+                { text: t("settings.importData"), style: "destructive", onPress: handleImport },
+            ],
+        );
+    }
+
+    async function handleImport() {
+        try {
+            setImporting(true);
+            const { inserted } = await importData();
+            const g = getGoals();
+            if (g) {
+                if (g.unit_system === "metric" || g.unit_system === "imperial") {
+                    setUnitSystem(g.unit_system as UnitSystem);
+                }
+                if (g.appearance_mode === "light" || g.appearance_mode === "dark" || g.appearance_mode === "system") {
+                    setAppearanceMode(g.appearance_mode as AppearanceMode);
+                }
+            }
+            Alert.alert(
+                t("settings.importComplete"),
+                t("settings.recordsRestored_other", { count: inserted }),
+            );
+        } catch (e: any) {
+            if (e.message !== "cancelled") {
+                Alert.alert(t("settings.importFailed"), e.message ?? "Unknown error");
+            }
+        } finally {
+            setImporting(false);
+        }
+    }
+
+    return (
+        <ScrollView
+            style={styles.screen}
+            contentContainerStyle={[styles.content, { paddingTop: insets.top + spacing.lg }]}
+        >
+            <View style={styles.headerRow}>
+                <Pressable onPress={() => router.navigate("/(tabs)/more" as any)} style={styles.backBtn} hitSlop={8}>
+                    <Ionicons name="chevron-back" size={24} color={colors.primary} />
+                </Pressable>
+                <Text style={styles.heading}>{t("more.backup")}</Text>
+            </View>
+
+            <Text style={styles.sectionLabel}>{t("settings.data")}</Text>
+            <Text style={styles.subLabel}>{t("settings.dataDescription")}</Text>
+
+            <View style={styles.row}>
+                <Button
+                    title={t("settings.exportData")}
+                    variant="outline"
+                    onPress={handleExport}
+                    loading={exporting}
+                    style={{ flex: 1 }}
+                />
+                <Button
+                    title={t("settings.importData")}
+                    variant="outline"
+                    onPress={handleImportConfirm}
+                    loading={importing}
+                    style={{ flex: 1 }}
+                />
+            </View>
+        </ScrollView>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        screen: { flex: 1, backgroundColor: colors.background },
+        content: { padding: spacing.lg, paddingBottom: 40 },
+        headerRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            marginBottom: spacing.lg,
+        },
+        backBtn: { padding: 4 },
+        heading: {
+            fontSize: fontSize.xl,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        sectionLabel: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            letterSpacing: 0.5,
+            marginBottom: spacing.sm,
+            marginTop: spacing.md,
+        },
+        subLabel: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            marginBottom: spacing.md,
+        },
+        row: {
+            flexDirection: "row",
+            gap: spacing.sm,
+        },
+    });
+}

--- a/src/features/settings/GoalsScreen.tsx
+++ b/src/features/settings/GoalsScreen.tsx
@@ -1,0 +1,244 @@
+import Button from "@/src/components/Button";
+import Input from "@/src/components/Input";
+import { getGoals, setGoals } from "@/src/db/queries";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { useThemeColors } from "@/src/utils/ThemeProvider";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+export default function GoalsScreen() {
+    const { t } = useTranslation();
+    const colors = useThemeColors();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
+    const router = useRouter();
+
+    const [calories, setCalories] = useState("2000");
+    const [protein, setProtein] = useState("150");
+    const [carbs, setCarbs] = useState("250");
+    const [fat, setFat] = useState("70");
+
+    useEffect(() => {
+        const g = getGoals();
+        if (g) {
+            setCalories(String(g.calories));
+            setProtein(String(g.protein));
+            setCarbs(String(g.carbs));
+            setFat(String(g.fat));
+        }
+    }, []);
+
+    function handleSave() {
+        const cal = parseFloat(calories) || 0;
+        const p = parseFloat(protein) || 0;
+        const c = parseFloat(carbs) || 0;
+        const f = parseFloat(fat) || 0;
+
+        if (cal <= 0) {
+            Alert.alert(t("settings.invalid"), t("settings.caloriesMustBeGreater"));
+            return;
+        }
+
+        setGoals({ calories: cal, protein: p, carbs: c, fat: f });
+        Alert.alert(t("settings.saved"), t("settings.goalsUpdated"));
+    }
+
+    const pCal = (parseFloat(protein) || 0) * 4;
+    const cCal = (parseFloat(carbs) || 0) * 4;
+    const fCal = (parseFloat(fat) || 0) * 9;
+    const macroTotal = pCal + cCal + fCal;
+
+    return (
+        <ScrollView
+            style={styles.screen}
+            contentContainerStyle={[styles.content, { paddingTop: insets.top + spacing.lg }]}
+            keyboardShouldPersistTaps="handled"
+        >
+            <View style={styles.headerRow}>
+                <Pressable onPress={() => router.navigate("/(tabs)/more" as any)} style={styles.backBtn} hitSlop={8}>
+                    <Ionicons name="chevron-back" size={24} color={colors.primary} />
+                </Pressable>
+                <Text style={styles.heading}>{t("more.goals")}</Text>
+            </View>
+
+            <Text style={styles.sectionLabel}>{t("settings.dailyGoals")}</Text>
+
+            <Input
+                label={t("settings.calories")}
+                value={calories}
+                onChangeText={setCalories}
+                keyboardType="decimal-pad"
+                suffix={t("common.kcal")}
+                containerStyle={styles.field}
+            />
+
+            <View style={styles.row}>
+                <Input
+                    label={t("settings.protein")}
+                    value={protein}
+                    onChangeText={setProtein}
+                    keyboardType="decimal-pad"
+                    suffix={t("common.g")}
+                    containerStyle={styles.thirdField}
+                />
+                <Input
+                    label={t("settings.carbs")}
+                    value={carbs}
+                    onChangeText={setCarbs}
+                    keyboardType="decimal-pad"
+                    suffix={t("common.g")}
+                    containerStyle={styles.thirdField}
+                />
+                <Input
+                    label={t("settings.fat")}
+                    value={fat}
+                    onChangeText={setFat}
+                    keyboardType="decimal-pad"
+                    suffix={t("common.g")}
+                    containerStyle={styles.thirdField}
+                />
+            </View>
+
+            {macroTotal > 0 && (
+                <View style={styles.breakdownCard}>
+                    <Text style={styles.breakdownTitle}>{t("settings.macroBreakdown")}</Text>
+                    <View style={styles.barContainer}>
+                        <View
+                            style={[
+                                styles.barSegment,
+                                {
+                                    flex: pCal,
+                                    backgroundColor: colors.protein,
+                                    borderTopLeftRadius: 4,
+                                    borderBottomLeftRadius: 4,
+                                },
+                            ]}
+                        />
+                        <View
+                            style={[styles.barSegment, { flex: cCal, backgroundColor: colors.carbs }]}
+                        />
+                        <View
+                            style={[
+                                styles.barSegment,
+                                {
+                                    flex: fCal,
+                                    backgroundColor: colors.fat,
+                                    borderTopRightRadius: 4,
+                                    borderBottomRightRadius: 4,
+                                },
+                            ]}
+                        />
+                    </View>
+                    <View style={styles.legendRow}>
+                        <LegendDot
+                            color={colors.protein}
+                            label={`${t("settings.protein")} ${Math.round((pCal / macroTotal) * 100)}%`}
+                            textColor={colors.textSecondary}
+                        />
+                        <LegendDot
+                            color={colors.carbs}
+                            label={`${t("settings.carbs")} ${Math.round((cCal / macroTotal) * 100)}%`}
+                            textColor={colors.textSecondary}
+                        />
+                        <LegendDot
+                            color={colors.fat}
+                            label={`${t("settings.fat")} ${Math.round((fCal / macroTotal) * 100)}%`}
+                            textColor={colors.textSecondary}
+                        />
+                    </View>
+                    <Text style={styles.breakdownSub}>
+                        {t("settings.macroKcal", { kcal: Math.round(macroTotal) })}
+                    </Text>
+                </View>
+            )}
+
+            <Button title={t("settings.saveGoals")} onPress={handleSave} style={styles.saveBtn} />
+        </ScrollView>
+    );
+}
+
+function LegendDot({ color, label, textColor }: { color: string; label: string; textColor: string }) {
+    return (
+        <View style={legendStyles.legendItem}>
+            <View style={[legendStyles.dot, { backgroundColor: color }]} />
+            <Text style={[legendStyles.legendText, { color: textColor }]}>{label}</Text>
+        </View>
+    );
+}
+
+const legendStyles = StyleSheet.create({
+    legendItem: { flexDirection: "row", alignItems: "center", gap: 4 },
+    dot: { width: 8, height: 8, borderRadius: 4 },
+    legendText: { fontSize: fontSize.xs },
+});
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        screen: { flex: 1, backgroundColor: colors.background },
+        content: { padding: spacing.lg, paddingBottom: 100 },
+        headerRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            marginBottom: spacing.lg,
+        },
+        backBtn: { padding: 4 },
+        heading: {
+            fontSize: fontSize.xl,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        sectionLabel: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            letterSpacing: 0.5,
+            marginBottom: spacing.sm,
+            marginTop: spacing.md,
+        },
+        field: { marginBottom: spacing.md },
+        row: {
+            flexDirection: "row",
+            gap: spacing.sm,
+            marginBottom: spacing.md,
+        },
+        thirdField: { flex: 1 },
+        breakdownCard: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.md,
+            marginBottom: spacing.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+        },
+        breakdownTitle: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.text,
+            marginBottom: spacing.sm,
+        },
+        barContainer: {
+            flexDirection: "row",
+            height: 10,
+            borderRadius: 4,
+            overflow: "hidden",
+            marginBottom: spacing.sm,
+        },
+        barSegment: { height: 10 },
+        legendRow: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            marginBottom: spacing.xs,
+        },
+        breakdownSub: {
+            fontSize: fontSize.xs,
+            color: colors.textTertiary,
+            textAlign: "center",
+        },
+        saveBtn: { marginTop: spacing.sm },
+    });
+}

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -1,16 +1,14 @@
-import Button from "@/src/components/Button";
-import Input from "@/src/components/Input";
-import { getGoals, setGoals } from "@/src/db/queries";
+import { setGoals } from "@/src/db/queries";
 import { SUPPORTED_LANGUAGES } from "@/src/i18n";
-import { exportData, importData } from "@/src/services/importExport";
 import { useAppStore } from "@/src/store/useAppStore";
 import type { AppearanceMode, Language, UnitSystem } from "@/src/types";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { useThemeColors } from "@/src/utils/ThemeProvider";
-import React, { useEffect, useMemo, useState } from "react";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
-    Alert,
     Pressable,
     ScrollView,
     StyleSheet,
@@ -29,6 +27,7 @@ export default function SettingsScreen() {
     const colors = useThemeColors();
     const styles = useMemo(() => createStyles(colors), [colors]);
     const insets = useSafeAreaInsets();
+    const router = useRouter();
 
     const unitSystem = useAppStore((s) => s.unitSystem);
     const setUnitSystem = useAppStore((s) => s.setUnitSystem);
@@ -48,48 +47,6 @@ export default function SettingsScreen() {
         { key: "dark", label: t("settings.appearanceDark") },
     ];
 
-    const [calories, setCalories] = useState("2000");
-    const [protein, setProtein] = useState("150");
-    const [carbs, setCarbs] = useState("250");
-    const [fat, setFat] = useState("70");
-
-    useEffect(() => {
-        const g = getGoals();
-        if (g) {
-            setCalories(String(g.calories));
-            setProtein(String(g.protein));
-            setCarbs(String(g.carbs));
-            setFat(String(g.fat));
-            if (g.unit_system === "metric" || g.unit_system === "imperial") {
-                setUnitSystem(g.unit_system as UnitSystem);
-            }
-            if (g.appearance_mode === "light" || g.appearance_mode === "dark" || g.appearance_mode === "system") {
-                setAppearanceMode(g.appearance_mode as AppearanceMode);
-            }
-        }
-    }, []);
-
-    function handleSave() {
-        const cal = parseFloat(calories) || 0;
-        const p = parseFloat(protein) || 0;
-        const c = parseFloat(carbs) || 0;
-        const f = parseFloat(fat) || 0;
-
-        if (cal <= 0) {
-            Alert.alert(t("settings.invalid"), t("settings.caloriesMustBeGreater"));
-            return;
-        }
-
-        setGoals({
-            calories: cal,
-            protein: p,
-            carbs: c,
-            fat: f,
-            unit_system: unitSystem,
-        });
-        Alert.alert(t("settings.saved"), t("settings.goalsUpdated"));
-    }
-
     function handleUnitChange(system: UnitSystem) {
         setUnitSystem(system);
         setGoals({ unit_system: system });
@@ -100,76 +57,18 @@ export default function SettingsScreen() {
         setGoals({ language: lang });
     }
 
-    // ── Import / Export ─────────────────────────────────
-    const [exporting, setExporting] = useState(false);
-    const [importing, setImporting] = useState(false);
-
-    async function handleExport() {
-        try {
-            setExporting(true);
-            await exportData();
-        } catch (e: any) {
-            Alert.alert(t("settings.exportFailed"), e.message ?? "Unknown error");
-        } finally {
-            setExporting(false);
-        }
-    }
-
-    function handleImportConfirm() {
-        Alert.alert(
-            t("settings.importTitle"),
-            t("settings.importWarning"),
-            [
-                { text: t("common.cancel"), style: "cancel" },
-                { text: t("settings.importData"), style: "destructive", onPress: handleImport },
-            ],
-        );
-    }
-
-    async function handleImport() {
-        try {
-            setImporting(true);
-            const { inserted } = await importData();
-            // Reload goals into local state after import
-            const g = getGoals();
-            if (g) {
-                setCalories(String(g.calories));
-                setProtein(String(g.protein));
-                setCarbs(String(g.carbs));
-                setFat(String(g.fat));
-                if (g.unit_system === "metric" || g.unit_system === "imperial") {
-                    setUnitSystem(g.unit_system as UnitSystem);
-                }
-                if (g.appearance_mode === "light" || g.appearance_mode === "dark" || g.appearance_mode === "system") {
-                    setAppearanceMode(g.appearance_mode as AppearanceMode);
-                }
-            }
-            Alert.alert(
-                t("settings.importComplete"),
-                t("settings.recordsRestored_other", { count: inserted }),
-            );
-        } catch (e: any) {
-            if (e.message !== "cancelled") {
-                Alert.alert(t("settings.importFailed"), e.message ?? "Unknown error");
-            }
-        } finally {
-            setImporting(false);
-        }
-    }
-
-    // Compute macro percentages
-    const pCal = (parseFloat(protein) || 0) * 4;
-    const cCal = (parseFloat(carbs) || 0) * 4;
-    const fCal = (parseFloat(fat) || 0) * 9;
-    const macroTotal = pCal + cCal + fCal;
-
     return (
         <ScrollView
             style={styles.screen}
             contentContainerStyle={[styles.content, { paddingTop: insets.top + spacing.lg }]}
             keyboardShouldPersistTaps="handled"
         >
-            <Text style={styles.heading}>{t("settings.title")}</Text>
+            <View style={styles.headerRow}>
+                <Pressable onPress={() => router.navigate("/(tabs)/more" as any)} style={styles.backBtn} hitSlop={8}>
+                    <Ionicons name="chevron-back" size={24} color={colors.primary} />
+                </Pressable>
+                <Text style={styles.heading}>{t("settings.title")}</Text>
+            </View>
 
             {/* ── Language ────────────────────────────────── */}
             <Text style={styles.sectionLabel}>{t("settings.language")}</Text>
@@ -193,20 +92,12 @@ export default function SettingsScreen() {
                 {APPEARANCE_OPTIONS.map((opt) => (
                     <Pressable
                         key={opt.key}
-                        style={[
-                            styles.chip,
-                            appearanceMode === opt.key && styles.chipActive,
-                        ]}
+                        style={[styles.chip, appearanceMode === opt.key && styles.chipActive]}
                         onPress={() => { setAppearanceMode(opt.key); setGoals({ appearance_mode: opt.key }); }}
                     >
-                        <Text
-                            style={[
-                                styles.chipText,
-                                appearanceMode === opt.key && styles.chipTextActive,
-                            ]}
-                        >
-                        {opt.label}
-                    </Text>
+                        <Text style={[styles.chipText, appearanceMode === opt.key && styles.chipTextActive]}>
+                            {opt.label}
+                        </Text>
                     </Pressable>
                 ))}
             </View>
@@ -217,170 +108,34 @@ export default function SettingsScreen() {
                 {UNIT_OPTIONS.map((opt) => (
                     <Pressable
                         key={opt.key}
-                        style={[
-                            styles.chip,
-                            unitSystem === opt.key && styles.chipActive,
-                        ]}
+                        style={[styles.chip, unitSystem === opt.key && styles.chipActive]}
                         onPress={() => handleUnitChange(opt.key)}
                     >
-                        <Text
-                            style={[
-                                styles.chipText,
-                                unitSystem === opt.key && styles.chipTextActive,
-                            ]}
-                        >
+                        <Text style={[styles.chipText, unitSystem === opt.key && styles.chipTextActive]}>
                             {opt.label}
                         </Text>
                     </Pressable>
                 ))}
             </View>
-
-            {/* ── Calorie Goal ────────────────────────────── */}
-            <Text style={styles.sectionLabel}>{t("settings.dailyGoals")}</Text>
-
-            <Input
-                label={t("settings.calories")}
-                value={calories}
-                onChangeText={setCalories}
-                keyboardType="decimal-pad"
-                suffix={t("common.kcal")}
-                containerStyle={styles.field}
-            />
-
-            {/* ── Macro Goals ─────────────────────────────── */}
-            <View style={styles.row}>
-                <Input
-                    label={t("settings.protein")}
-                    value={protein}
-                    onChangeText={setProtein}
-                    keyboardType="decimal-pad"
-                    suffix={t("common.g")}
-                    containerStyle={styles.thirdField}
-                />
-                <Input
-                    label={t("settings.carbs")}
-                    value={carbs}
-                    onChangeText={setCarbs}
-                    keyboardType="decimal-pad"
-                    suffix={t("common.g")}
-                    containerStyle={styles.thirdField}
-                />
-                <Input
-                    label={t("settings.fat")}
-                    value={fat}
-                    onChangeText={setFat}
-                    keyboardType="decimal-pad"
-                    suffix={t("common.g")}
-                    containerStyle={styles.thirdField}
-                />
-            </View>
-
-            {/* Macro breakdown preview */}
-            {macroTotal > 0 && (
-                <View style={styles.breakdownCard}>
-                    <Text style={styles.breakdownTitle}>{t("settings.macroBreakdown")}</Text>
-                    <View style={styles.barContainer}>
-                        <View
-                            style={[
-                                styles.barSegment,
-                                {
-                                    flex: pCal,
-                                    backgroundColor: colors.protein,
-                                    borderTopLeftRadius: 4,
-                                    borderBottomLeftRadius: 4,
-                                },
-                            ]}
-                        />
-                        <View
-                            style={[
-                                styles.barSegment,
-                                { flex: cCal, backgroundColor: colors.carbs },
-                            ]}
-                        />
-                        <View
-                            style={[
-                                styles.barSegment,
-                                {
-                                    flex: fCal,
-                                    backgroundColor: colors.fat,
-                                    borderTopRightRadius: 4,
-                                    borderBottomRightRadius: 4,
-                                },
-                            ]}
-                        />
-                    </View>
-                    <View style={styles.legendRow}>
-                        <LegendDot
-                            color={colors.protein}
-                            label={`${t("settings.protein")} ${Math.round((pCal / macroTotal) * 100)}%`}
-                            textColor={colors.textSecondary}
-                        />
-                        <LegendDot
-                            color={colors.carbs}
-                            label={`${t("settings.carbs")} ${Math.round((cCal / macroTotal) * 100)}%`}
-                            textColor={colors.textSecondary}
-                        />
-                        <LegendDot
-                            color={colors.fat}
-                            label={`${t("settings.fat")} ${Math.round((fCal / macroTotal) * 100)}%`}
-                            textColor={colors.textSecondary}
-                        />
-                    </View>
-                    <Text style={styles.breakdownSub}>
-                        {t("settings.macroKcal", { kcal: Math.round(macroTotal) })}
-                    </Text>
-                </View>
-            )}
-
-            <Button title={t("settings.saveGoals")} onPress={handleSave} style={styles.saveBtn} />
-
-            {/* ── Import / Export ──────────────────────────── */}
-            <Text style={styles.sectionLabel}>{t("settings.data")}</Text>
-            <Text style={styles.subLabel}>{t("settings.dataDescription")}</Text>
-            <View style={styles.row}>
-                <Button
-                    title={t("settings.exportData")}
-                    variant="outline"
-                    onPress={handleExport}
-                    loading={exporting}
-                    style={{ flex: 1 }}
-                />
-                <Button
-                    title={t("settings.importData")}
-                    variant="outline"
-                    onPress={handleImportConfirm}
-                    loading={importing}
-                    style={{ flex: 1 }}
-                />
-            </View>
         </ScrollView>
     );
 }
 
-function LegendDot({ color, label, textColor }: { color: string; label: string; textColor: string }) {
-    return (
-        <View style={legendStyles.legendItem}>
-            <View style={[legendStyles.dot, { backgroundColor: color }]} />
-            <Text style={[legendStyles.legendText, { color: textColor }]}>{label}</Text>
-        </View>
-    );
-}
-
-const legendStyles = StyleSheet.create({
-    legendItem: { flexDirection: "row", alignItems: "center", gap: 4 },
-    dot: { width: 8, height: 8, borderRadius: 4 },
-    legendText: { fontSize: fontSize.xs },
-});
-
 function createStyles(colors: ThemeColors) {
     return StyleSheet.create({
         screen: { flex: 1, backgroundColor: colors.background },
-        content: { padding: spacing.lg, paddingBottom: 100 },
+        content: { padding: spacing.lg, paddingBottom: 40 },
+        headerRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            marginBottom: spacing.lg,
+        },
+        backBtn: { padding: 4 },
         heading: {
             fontSize: fontSize.xl,
             fontWeight: "700",
             color: colors.text,
-            marginBottom: spacing.lg,
         },
         sectionLabel: {
             fontSize: fontSize.xs,
@@ -389,11 +144,6 @@ function createStyles(colors: ThemeColors) {
             letterSpacing: 0.5,
             marginBottom: spacing.sm,
             marginTop: spacing.md,
-        },
-        subLabel: {
-            fontSize: fontSize.sm,
-            color: colors.textSecondary,
-            marginBottom: spacing.md,
         },
         chipRow: {
             flexDirection: "row",
@@ -421,45 +171,5 @@ function createStyles(colors: ThemeColors) {
             color: colors.primary,
             fontWeight: "600",
         },
-        field: { marginBottom: spacing.md },
-        row: {
-            flexDirection: "row",
-            gap: spacing.sm,
-            marginBottom: spacing.md,
-        },
-        thirdField: { flex: 1 },
-        breakdownCard: {
-            backgroundColor: colors.surface,
-            borderRadius: borderRadius.lg,
-            padding: spacing.md,
-            marginBottom: spacing.md,
-            borderWidth: 1,
-            borderColor: colors.border,
-        },
-        breakdownTitle: {
-            fontSize: fontSize.sm,
-            fontWeight: "600",
-            color: colors.text,
-            marginBottom: spacing.sm,
-        },
-        barContainer: {
-            flexDirection: "row",
-            height: 10,
-            borderRadius: 4,
-            overflow: "hidden",
-            marginBottom: spacing.sm,
-        },
-        barSegment: { height: 10 },
-        legendRow: {
-            flexDirection: "row",
-            justifyContent: "space-between",
-            marginBottom: spacing.xs,
-        },
-        breakdownSub: {
-            fontSize: fontSize.xs,
-            color: colors.textTertiary,
-            textAlign: "center",
-        },
-        saveBtn: { marginTop: spacing.sm },
     });
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -3,6 +3,7 @@ const de = {
         logs: "Protokoll",
         templates: "Vorlagen",
         settings: "Einstellungen",
+        more: "Mehr",
     },
     meal: {
         breakfast: "Frühstück",
@@ -181,6 +182,11 @@ const de = {
         noData: "Keine Daten für den gewählten Zeitraum",
         calorieDisclaimer:
             "Die Kalorienangaben können aufgrund von Alkohol, Ballaststoffen oder Dateninkonsistenzen von der Summe der Makros abweichen. Die Makros werden normalisiert, um den Kalorien zu entsprechen.",
+    },
+    more: {
+        analytics: "Analyse",
+        goals: "Ziele",
+        backup: "Datensicherung",
     },
 } as const;
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -4,6 +4,7 @@ const en = {
         logs: "Logs",
         templates: "Templates",
         settings: "Settings",
+        more: "More",
     },
     meal: {
         breakfast: "Breakfast",
@@ -180,6 +181,11 @@ const en = {
         trendFlat: "→ Stable",
         noData: "No data for the selected period",
         calorieDisclaimer: "Calorie values may not perfectly match the macro breakdown due to alcohol, fiber, or data inconsistencies. Macros are normalized to match calories.",
+    },
+    more: {
+        analytics: "Analytics",
+        goals: "Goals",
+        backup: "Backup Data",
     },
 } as const;
 


### PR DESCRIPTION
Refactor settings into a 'More' screen with links to Analytics, Goals, and Backup Data.

This PR:
- Adds MoreScreen with links and a gear FAB
- Extracts GoalsScreen and BackupScreen from SettingsScreen
- Keeps bottom tab bar visible when navigating to these screens by placing them under app/(tabs) and marking them hidden via href: null

Closes #113