### PR TITLE
feat: Create custom unit from all food screens

### DIFF
--- a/src/components/UnitPicker.tsx
+++ b/src/components/UnitPicker.tsx
@@ -1,0 +1,260 @@
+import { addServingUnit, getServingUnits, type ServingUnit } from "@/src/db/queries";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { useThemeColors } from "@/src/utils/ThemeProvider";
+import { unitLabel, type FoodUnit } from "@/src/utils/units";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useState } from "react";
+import {
+    Pressable,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TextInput,
+    View,
+} from "react-native";
+import { useTranslation } from "react-i18next";
+
+interface UnitPickerProps {
+    /** Standard unit options to display (e.g. from unitsForSystem) */
+    unitOptions: FoodUnit[];
+    /** Currently selected standard unit */
+    selectedUnit: FoodUnit;
+    /** Called when a standard unit chip is pressed */
+    onSelectUnit: (unit: FoodUnit) => void;
+    /** Custom serving units for the food */
+    servingUnits: ServingUnit[];
+    /** Currently selected custom serving unit (null if standard unit is active) */
+    selectedServingUnit: ServingUnit | null;
+    /** Called when a custom serving unit chip is pressed */
+    onSelectServingUnit: (su: ServingUnit) => void;
+    /** Food ID; required for creating new serving units. If null, add button is hidden. */
+    foodId: number | null;
+    /** Called after a new serving unit is created and saved to DB */
+    onServingUnitCreated?: (saved: ServingUnit, allUnits: ServingUnit[]) => void;
+    /** When true, hides the "+" add-unit button entirely */
+    hideAddButton?: boolean;
+}
+
+export default function UnitPicker({
+    unitOptions,
+    selectedUnit,
+    onSelectUnit,
+    servingUnits,
+    selectedServingUnit,
+    onSelectServingUnit,
+    foodId,
+    onServingUnitCreated,
+    hideAddButton,
+}: UnitPickerProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = React.useMemo(() => createStyles(colors), [colors]);
+
+    const [showAddUnit, setShowAddUnit] = useState(false);
+    const [newUnitName, setNewUnitName] = useState("");
+    const [newUnitGrams, setNewUnitGrams] = useState("");
+
+    function handleAddUnit() {
+        if (!foodId) return;
+        const name = newUnitName.trim();
+        const grams = parseFloat(newUnitGrams);
+        if (!name || !grams || grams <= 0) return;
+        const saved = addServingUnit({ food_id: foodId, name, grams });
+        const updated = getServingUnits(foodId);
+        setNewUnitName("");
+        setNewUnitGrams("");
+        setShowAddUnit(false);
+        onServingUnitCreated?.(saved, updated);
+    }
+
+    const canAdd = foodId != null && !hideAddButton;
+
+    return (
+        <View>
+            <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.unitRow}
+            >
+                {unitOptions.map((u) => (
+                    <Pressable
+                        key={u}
+                        onPress={() => onSelectUnit(u)}
+                        style={[
+                            styles.unitChip,
+                            selectedUnit === u && !selectedServingUnit && styles.unitChipActive,
+                        ]}
+                    >
+                        <Text
+                            style={[
+                                styles.unitChipText,
+                                selectedUnit === u && !selectedServingUnit && styles.unitChipTextActive,
+                            ]}
+                        >
+                            {unitLabel(u)}
+                        </Text>
+                    </Pressable>
+                ))}
+                {servingUnits.map((su) => (
+                    <Pressable
+                        key={`su-${su.id}`}
+                        onPress={() => onSelectServingUnit(su)}
+                        style={[
+                            styles.unitChip,
+                            selectedServingUnit?.id === su.id && styles.unitChipActive,
+                        ]}
+                    >
+                        <Text
+                            style={[
+                                styles.unitChipText,
+                                selectedServingUnit?.id === su.id && styles.unitChipTextActive,
+                            ]}
+                        >
+                            {su.name} ({su.grams}g)
+                        </Text>
+                    </Pressable>
+                ))}
+                {canAdd && (
+                    <Pressable
+                        onPress={() => setShowAddUnit((v) => !v)}
+                        style={[styles.unitChip, styles.unitChipAdd]}
+                    >
+                        <Ionicons name="add" size={16} color={colors.primary} />
+                    </Pressable>
+                )}
+            </ScrollView>
+
+            {showAddUnit && (
+                <View style={styles.addUnitForm}>
+                    <Text style={styles.addUnitTitle}>{t("recipes.addServingUnit")}</Text>
+                    <View style={styles.addUnitRow}>
+                        <TextInput
+                            style={[styles.addUnitInput, { flex: 2 }]}
+                            placeholder={t("recipes.servingUnitNamePlaceholder")}
+                            placeholderTextColor={colors.textSecondary}
+                            value={newUnitName}
+                            onChangeText={setNewUnitName}
+                        />
+                        <TextInput
+                            style={[styles.addUnitInput, { flex: 1 }]}
+                            placeholder={t("recipes.servingUnitGrams")}
+                            placeholderTextColor={colors.textSecondary}
+                            value={newUnitGrams}
+                            onChangeText={setNewUnitGrams}
+                            keyboardType="decimal-pad"
+                        />
+                    </View>
+                    <View style={styles.addUnitActions}>
+                        <Pressable
+                            onPress={() => { setShowAddUnit(false); setNewUnitName(""); setNewUnitGrams(""); }}
+                            style={styles.addUnitCancelBtn}
+                        >
+                            <Text style={styles.addUnitCancelText}>{t("common.cancel")}</Text>
+                        </Pressable>
+                        <Pressable
+                            onPress={handleAddUnit}
+                            style={[styles.addUnitSaveBtn, (!newUnitName.trim() || !parseFloat(newUnitGrams)) && styles.addUnitSaveBtnDisabled]}
+                            disabled={!newUnitName.trim() || !parseFloat(newUnitGrams)}
+                        >
+                            <Text style={styles.addUnitSaveText}>{t("common.save")}</Text>
+                        </Pressable>
+                    </View>
+                </View>
+            )}
+        </View>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        unitRow: {
+            flexDirection: "row",
+            gap: spacing.sm,
+            paddingBottom: spacing.sm,
+        },
+        unitChip: {
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.surface,
+            borderWidth: 1,
+            borderColor: colors.border,
+        },
+        unitChipActive: {
+            backgroundColor: colors.primaryLight,
+            borderColor: colors.primary,
+        },
+        unitChipText: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+        },
+        unitChipTextActive: {
+            color: colors.primary,
+            fontWeight: "600",
+        },
+        unitChipAdd: {
+            borderColor: colors.primary,
+            borderStyle: "dashed",
+            justifyContent: "center",
+            alignItems: "center",
+            paddingHorizontal: spacing.sm,
+        },
+        addUnitForm: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+            padding: spacing.md,
+            marginTop: spacing.sm,
+        },
+        addUnitTitle: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.text,
+            marginBottom: spacing.sm,
+        },
+        addUnitRow: {
+            flexDirection: "row",
+            gap: spacing.sm,
+        },
+        addUnitInput: {
+            borderWidth: 1,
+            borderColor: colors.border,
+            borderRadius: borderRadius.sm,
+            paddingHorizontal: spacing.sm,
+            paddingVertical: spacing.xs,
+            fontSize: fontSize.sm,
+            color: colors.text,
+            backgroundColor: colors.background,
+        },
+        addUnitActions: {
+            flexDirection: "row",
+            justifyContent: "flex-end",
+            gap: spacing.sm,
+            marginTop: spacing.sm,
+        },
+        addUnitCancelBtn: {
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.xs,
+            borderRadius: borderRadius.sm,
+        },
+        addUnitCancelText: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+        },
+        addUnitSaveBtn: {
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.xs,
+            borderRadius: borderRadius.sm,
+            backgroundColor: colors.primary,
+        },
+        addUnitSaveBtnDisabled: {
+            backgroundColor: colors.border,
+        },
+        addUnitSaveText: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.background,
+        },
+    });
+}

--- a/src/features/log/EntryModal.tsx
+++ b/src/features/log/EntryModal.tsx
@@ -1,6 +1,7 @@
 import Button from "@/src/components/Button";
 import Input from "@/src/components/Input";
-import { addEntry, addServingUnit, formatDateKey, getLoggedRecipeGroups, getServingUnits, updateEntry, updateFood, type Entry, type Food, type LoggedRecipeGroup, type ServingUnit } from "@/src/db/queries";
+import UnitPicker from "@/src/components/UnitPicker";
+import { addEntry, formatDateKey, getLoggedRecipeGroups, getServingUnits, updateEntry, updateFood, type Entry, type Food, type LoggedRecipeGroup, type ServingUnit } from "@/src/db/queries";
 import { useAppStore } from "@/src/store/useAppStore";
 import { MEAL_TYPES, type MealType } from "@/src/types";
 import logger from "@/src/utils/logger";
@@ -17,7 +18,6 @@ import {
     ScrollView,
     StyleSheet,
     Text,
-    TextInput,
     View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -54,9 +54,6 @@ export default function EntryModal({
     const [recipeGroups, setRecipeGroups] = useState<LoggedRecipeGroup[]>([]);
     const [selectedGroup, setSelectedGroup] = useState<LoggedRecipeGroup | null>(null);
     const [portionMode, setPortionMode] = useState<"per-portion" | "total">("per-portion");
-    const [showAddUnit, setShowAddUnit] = useState(false);
-    const [newUnitName, setNewUnitName] = useState("");
-    const [newUnitGrams, setNewUnitGrams] = useState("");
     const amountTouched = useRef(false);
 
     // Initialize form fields and fetch recipe groups whenever the entry/food/meal/date changes.
@@ -216,19 +213,10 @@ export default function EntryModal({
         onSaved();
     }
 
-    function handleAddUnit() {
-        if (!food?.id) return;
-        const name = newUnitName.trim();
-        const grams = parseFloat(newUnitGrams);
-        if (!name || !grams || grams <= 0) return;
-        const saved = addServingUnit({ food_id: food.id, name, grams });
-        const updated = getServingUnits(food.id);
-        setFoodServingUnits(updated);
+    function handleServingUnitCreated(saved: ServingUnit, allUnits: ServingUnit[]) {
+        setFoodServingUnits(allUnits);
         setCustomServingUnit(saved);
         if (!amountTouched.current) setQuantity("1");
-        setNewUnitName("");
-        setNewUnitGrams("");
-        setShowAddUnit(false);
     }
 
     function handleClose() {
@@ -283,104 +271,23 @@ export default function EntryModal({
 
                     {/* Unit picker */}
                     <Text style={styles.sectionLabel}>{t("log.unit")}</Text>
-                    <ScrollView
-                        horizontal
-                        showsHorizontalScrollIndicator={false}
-                        contentContainerStyle={styles.unitRow}
-                    >
-                        {unitOptions.map((u) => (
-                            <Pressable
-                                key={u}
-                                onPress={() => {
-                                    setUnit(u);
-                                    setCustomServingUnit(null);
-                                    if (!amountTouched.current) setQuantity(String(defaultAmountForUnit(u)));
-                                }}
-                                style={[
-                                    styles.unitChip,
-                                    unit === u && !customServingUnit && styles.unitChipActive,
-                                ]}
-                            >
-                                <Text
-                                    style={[
-                                        styles.unitChipText,
-                                        unit === u && !customServingUnit && styles.unitChipTextActive,
-                                    ]}
-                                >
-                                    {unitLabel(u)}
-                                </Text>
-                            </Pressable>
-                        ))}
-                        {foodServingUnits.map((su) => (
-                            <Pressable
-                                key={`su-${su.id}`}
-                                onPress={() => {
-                                    if (!amountTouched.current) setQuantity("1");
-                                    setCustomServingUnit(su);
-                                }}
-                                style={[
-                                    styles.unitChip,
-                                    customServingUnit?.id === su.id && styles.unitChipActive,
-                                ]}
-                            >
-                                <Text
-                                    style={[
-                                        styles.unitChipText,
-                                        customServingUnit?.id === su.id && styles.unitChipTextActive,
-                                    ]}
-                                >
-                                    {su.name} ({su.grams}g)
-                                </Text>
-                            </Pressable>
-                        ))}
-                        {food?.id ? (
-                            <Pressable
-                                onPress={() => setShowAddUnit((v) => !v)}
-                                style={[styles.unitChip, styles.unitChipAdd]}
-                            >
-                                <Ionicons name="add" size={16} color={colors.primary} />
-                            </Pressable>
-                        ) : null}
-                    </ScrollView>
-
-                    {/* Inline add-custom-unit form */}
-                    {showAddUnit && (
-                        <View style={styles.addUnitForm}>
-                            <Text style={styles.addUnitTitle}>{t("recipes.addServingUnit")}</Text>
-                            <View style={styles.addUnitRow}>
-                                <TextInput
-                                    style={[styles.addUnitInput, { flex: 2 }]}
-                                    placeholder={t("recipes.servingUnitNamePlaceholder")}
-                                    placeholderTextColor={colors.textSecondary}
-                                    value={newUnitName}
-                                    onChangeText={setNewUnitName}
-                                />
-                                <TextInput
-                                    style={[styles.addUnitInput, { flex: 1 }]}
-                                    placeholder={t("recipes.servingUnitGrams")}
-                                    placeholderTextColor={colors.textSecondary}
-                                    value={newUnitGrams}
-                                    onChangeText={setNewUnitGrams}
-                                    keyboardType="decimal-pad"
-                                />
-                            </View>
-                            <View style={styles.addUnitActions}>
-                                <Pressable
-                                    onPress={() => { setShowAddUnit(false); setNewUnitName(""); setNewUnitGrams(""); }}
-                                    style={styles.addUnitCancelBtn}
-                                >
-                                    <Text style={styles.addUnitCancelText}>{t("common.cancel")}</Text>
-                                </Pressable>
-                                <Pressable
-                                    onPress={handleAddUnit}
-                                    style={[styles.addUnitSaveBtn, (!newUnitName.trim() || !parseFloat(newUnitGrams)) && styles.addUnitSaveBtnDisabled]}
-                                    disabled={!newUnitName.trim() || !parseFloat(newUnitGrams)}
-                                >
-                                    <Text style={styles.addUnitSaveText}>{t("common.save")}</Text>
-                                </Pressable>
-                            </View>
-                        </View>
-                    )}
+                    <UnitPicker
+                        unitOptions={unitOptions}
+                        selectedUnit={unit}
+                        onSelectUnit={(u) => {
+                            setUnit(u);
+                            setCustomServingUnit(null);
+                            if (!amountTouched.current) setQuantity(String(defaultAmountForUnit(u)));
+                        }}
+                        servingUnits={foodServingUnits}
+                        selectedServingUnit={customServingUnit}
+                        onSelectServingUnit={(su) => {
+                            if (!amountTouched.current) setQuantity("1");
+                            setCustomServingUnit(su);
+                        }}
+                        foodId={food?.id ?? null}
+                        onServingUnitCreated={handleServingUnitCreated}
+                    />
 
                     {/* Live calculation */}
                     <View style={styles.calcCard}>
@@ -567,95 +474,6 @@ function createStyles(colors: ThemeColors, insetsTop = 0) {
             marginTop: spacing.xs,
         },
         quantityInput: { marginTop: spacing.lg },
-        unitRow: {
-            flexDirection: "row",
-            gap: spacing.sm,
-            paddingBottom: spacing.sm,
-        },
-        unitChip: {
-            paddingHorizontal: spacing.md,
-            paddingVertical: spacing.sm,
-            borderRadius: borderRadius.sm,
-            backgroundColor: colors.surface,
-            borderWidth: 1,
-            borderColor: colors.border,
-        },
-        unitChipActive: {
-            backgroundColor: colors.primaryLight,
-            borderColor: colors.primary,
-        },
-        unitChipText: {
-            fontSize: fontSize.sm,
-            color: colors.textSecondary,
-        },
-        unitChipTextActive: {
-            color: colors.primary,
-            fontWeight: "600",
-        },
-        unitChipAdd: {
-            borderColor: colors.primary,
-            borderStyle: "dashed",
-            justifyContent: "center",
-            alignItems: "center",
-            paddingHorizontal: spacing.sm,
-        },
-        addUnitForm: {
-            backgroundColor: colors.surface,
-            borderRadius: borderRadius.md,
-            borderWidth: 1,
-            borderColor: colors.border,
-            padding: spacing.md,
-            marginTop: spacing.sm,
-        },
-        addUnitTitle: {
-            fontSize: fontSize.sm,
-            fontWeight: "600",
-            color: colors.text,
-            marginBottom: spacing.sm,
-        },
-        addUnitRow: {
-            flexDirection: "row",
-            gap: spacing.sm,
-        },
-        addUnitInput: {
-            borderWidth: 1,
-            borderColor: colors.border,
-            borderRadius: borderRadius.sm,
-            paddingHorizontal: spacing.sm,
-            paddingVertical: spacing.xs,
-            fontSize: fontSize.sm,
-            color: colors.text,
-            backgroundColor: colors.background,
-        },
-        addUnitActions: {
-            flexDirection: "row",
-            justifyContent: "flex-end",
-            gap: spacing.sm,
-            marginTop: spacing.sm,
-        },
-        addUnitCancelBtn: {
-            paddingHorizontal: spacing.md,
-            paddingVertical: spacing.xs,
-            borderRadius: borderRadius.sm,
-        },
-        addUnitCancelText: {
-            fontSize: fontSize.sm,
-            color: colors.textSecondary,
-        },
-        addUnitSaveBtn: {
-            paddingHorizontal: spacing.md,
-            paddingVertical: spacing.xs,
-            borderRadius: borderRadius.sm,
-            backgroundColor: colors.primary,
-        },
-        addUnitSaveBtnDisabled: {
-            backgroundColor: colors.border,
-        },
-        addUnitSaveText: {
-            fontSize: fontSize.sm,
-            fontWeight: "600",
-            color: colors.background,
-        },
         calcCard: {
             backgroundColor: colors.surface,
             borderRadius: borderRadius.md,

--- a/src/features/log/ManualFoodForm.tsx
+++ b/src/features/log/ManualFoodForm.tsx
@@ -1,6 +1,6 @@
 import Button from "@/src/components/Button";
 import Input from "@/src/components/Input";
-import { addFood, type Food } from "@/src/db/queries";
+import { addFood, addServingUnit, type Food } from "@/src/db/queries";
 import { useAppStore } from "@/src/store/useAppStore";
 import logger from "@/src/utils/logger";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
@@ -51,6 +51,9 @@ export default function ManualFoodForm({
     const [carbs, setCarbs] = useState("");
     const [fat, setFat] = useState("");
     const [defaultUnit, setDefaultUnit] = useState<FoodUnit>("g");
+    const [servingUnitRows, setServingUnitRows] = useState<
+        { name: string; grams: string }[]
+    >([]);
 
     function handleSave() {
         const trimmedName = name.trim();
@@ -66,6 +69,13 @@ export default function ManualFoodForm({
             default_unit: defaultUnit,
         });
         logger.info("[DB] Created food manually", { id: food.id, name: food.name });
+        for (const row of servingUnitRows) {
+            const trimmedName = row.name.trim();
+            const grams = parseFloat(row.grams);
+            if (trimmedName && grams > 0) {
+                addServingUnit({ food_id: food.id, name: trimmedName, grams });
+            }
+        }
         resetForm();
         onFoodCreated(food);
     }
@@ -77,6 +87,7 @@ export default function ManualFoodForm({
         setCarbs("");
         setFat("");
         setDefaultUnit("g");
+        setServingUnitRows([]);
     }
 
     function handleClose() {
@@ -194,6 +205,53 @@ export default function ManualFoodForm({
                         />
                     </View>
 
+                    {/* Serving Units */}
+                    <Text style={styles.sectionLabel}>
+                        {t("recipes.servingUnits")}
+                    </Text>
+                    {servingUnitRows.map((row, idx) => (
+                        <View key={`su-${idx}`} style={styles.servingRow}>
+                            <Input
+                                label={t("recipes.servingUnitName")}
+                                placeholder={t("recipes.servingUnitNamePlaceholder")}
+                                value={row.name}
+                                onChangeText={(v) => {
+                                    const next = [...servingUnitRows];
+                                    next[idx] = { ...row, name: v };
+                                    setServingUnitRows(next);
+                                }}
+                                containerStyle={styles.servingNameField}
+                            />
+                            <Input
+                                label={t("recipes.servingUnitGrams")}
+                                placeholder="0"
+                                suffix="g"
+                                value={row.grams}
+                                onChangeText={(v) => {
+                                    const next = [...servingUnitRows];
+                                    next[idx] = { ...row, grams: v };
+                                    setServingUnitRows(next);
+                                }}
+                                keyboardType="decimal-pad"
+                                containerStyle={styles.servingGramsField}
+                            />
+                            <Pressable
+                                onPress={() => setServingUnitRows(servingUnitRows.filter((_, i) => i !== idx))}
+                                hitSlop={8}
+                                style={styles.servingDeleteBtn}
+                            >
+                                <Ionicons name="trash-outline" size={20} color={colors.danger} />
+                            </Pressable>
+                        </View>
+                    ))}
+                    <Pressable
+                        onPress={() => setServingUnitRows([...servingUnitRows, { name: "", grams: "" }])}
+                        style={styles.addServingBtn}
+                    >
+                        <Ionicons name="add-circle-outline" size={20} color={colors.primary} />
+                        <Text style={styles.addServingText}>{t("recipes.addServingUnit")}</Text>
+                    </Pressable>
+
                     <Button
                         title={t("log.createFood")}
                         onPress={handleSave}
@@ -268,5 +326,29 @@ function createStyles(colors: ThemeColors, insetsTop = 0) {
         },
         halfField: { flex: 1 },
         saveButton: { marginTop: spacing.md },
+        servingRow: {
+            flexDirection: "row",
+            alignItems: "flex-end",
+            gap: spacing.sm,
+            marginBottom: spacing.sm,
+        },
+        servingNameField: { flex: 2 },
+        servingGramsField: { flex: 1 },
+        servingDeleteBtn: {
+            paddingBottom: spacing.sm,
+            paddingHorizontal: spacing.xs,
+        },
+        addServingBtn: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.xs,
+            marginBottom: spacing.md,
+            paddingVertical: spacing.sm,
+        },
+        addServingText: {
+            fontSize: fontSize.sm,
+            color: colors.primary,
+            fontWeight: "600",
+        },
     });
 }

--- a/src/features/recipes/RecipeItemModal.tsx
+++ b/src/features/recipes/RecipeItemModal.tsx
@@ -1,5 +1,6 @@
 import Input from "@/src/components/Input";
 import Button from "@/src/components/Button";
+import UnitPicker from "@/src/components/UnitPicker";
 import { getServingUnits, updateRecipeItem, type Food, type RecipeItem, type ServingUnit } from "@/src/db/queries";
 import { useAppStore } from "@/src/store/useAppStore";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
@@ -131,50 +132,20 @@ export default function RecipeItemModal({
 
                     {/* Unit picker */}
                     <Text style={styles.sectionLabel}>{t("log.unit")}</Text>
-                    <ScrollView
-                        horizontal
-                        showsHorizontalScrollIndicator={false}
-                        contentContainerStyle={styles.unitRow}
-                    >
-                        {unitOptions.map((u) => (
-                            <Pressable
-                                key={u}
-                                onPress={() => { setUnit(u); setCustomServingUnit(null); }}
-                                style={[
-                                    styles.unitChip,
-                                    unit === u && !customServingUnit && styles.unitChipActive,
-                                ]}
-                            >
-                                <Text
-                                    style={[
-                                        styles.unitChipText,
-                                        unit === u && !customServingUnit && styles.unitChipTextActive,
-                                    ]}
-                                >
-                                    {unitLabel(u)}
-                                </Text>
-                            </Pressable>
-                        ))}
-                        {foodServingUnits.map((su) => (
-                            <Pressable
-                                key={`su-${su.id}`}
-                                onPress={() => setCustomServingUnit(su)}
-                                style={[
-                                    styles.unitChip,
-                                    customServingUnit?.id === su.id && styles.unitChipActive,
-                                ]}
-                            >
-                                <Text
-                                    style={[
-                                        styles.unitChipText,
-                                        customServingUnit?.id === su.id && styles.unitChipTextActive,
-                                    ]}
-                                >
-                                    {su.name} ({su.grams}g)
-                                </Text>
-                            </Pressable>
-                        ))}
-                    </ScrollView>
+                    <UnitPicker
+                        unitOptions={unitOptions}
+                        selectedUnit={unit}
+                        onSelectUnit={(u) => { setUnit(u); setCustomServingUnit(null); }}
+                        servingUnits={foodServingUnits}
+                        selectedServingUnit={customServingUnit}
+                        onSelectServingUnit={(su) => setCustomServingUnit(su)}
+                        foodId={food?.id ?? null}
+                        onServingUnitCreated={(saved, allUnits) => {
+                            setFoodServingUnits(allUnits);
+                            setCustomServingUnit(saved);
+                            setQuantity("1");
+                        }}
+                    />
 
                     {/* Live macro calculation */}
                     <View style={styles.calcCard}>
@@ -277,31 +248,6 @@ function createStyles(colors: ThemeColors, insetsTop = 0) {
             color: colors.text,
             marginTop: spacing.lg,
             marginBottom: spacing.sm,
-        },
-        unitRow: {
-            flexDirection: "row",
-            gap: spacing.sm,
-            paddingBottom: spacing.sm,
-        },
-        unitChip: {
-            paddingHorizontal: spacing.md,
-            paddingVertical: spacing.sm,
-            borderRadius: borderRadius.sm,
-            backgroundColor: colors.surface,
-            borderWidth: 1,
-            borderColor: colors.border,
-        },
-        unitChipActive: {
-            backgroundColor: colors.primaryLight,
-            borderColor: colors.primary,
-        },
-        unitChipText: {
-            fontSize: fontSize.sm,
-            color: colors.textSecondary,
-        },
-        unitChipTextActive: {
-            color: colors.primary,
-            fontWeight: "600",
         },
         calcCard: {
             backgroundColor: colors.surface,


### PR DESCRIPTION
## Summary

Closes #116

Adds custom serving unit creation capability to every screen where foods can be created or edited, and unifies the duplicated unit picker UI into a shared component.

### Changes

- **New `UnitPicker` component** (`src/components/UnitPicker.tsx`): Extracted the unit chip row + custom serving unit chips + "+" add button + inline create form into a reusable component with configurable props.

- **`EntryModal`**: Refactored to use the shared `UnitPicker`. No behavior change — custom unit creation was already supported here.

- **`RecipeItemModal`**: Now uses `UnitPicker` with custom unit creation enabled. Previously could only *display* existing custom units but not create new ones.

- **`ManualFoodForm`**: Added serving unit rows (batch-editing approach matching `FoodEditorScreen`). Units are saved to DB after the food is created.

- Removed ~100 lines of duplicated unit picker styles from `EntryModal` and `RecipeItemModal`.