### PR TITLE
fix: resolve NaN display for custom units in recipe editor

### DIFF
--- a/src/features/recipes/RecipeEditorScreen.tsx
+++ b/src/features/recipes/RecipeEditorScreen.tsx
@@ -9,10 +9,12 @@ import {
     getFoodByOpenfoodfactsId,
     getRecipeById,
     getRecipeItems,
+    getServingUnits,
     searchFoodsByName,
     updateRecipe,
     type Food,
-    type RecipeItem
+    type RecipeItem,
+    type ServingUnit,
 } from "@/src/db/queries";
 import BarcodeScannerView from "@/src/features/log/BarcodeScannerView";
 import ManualFoodForm from "@/src/features/log/ManualFoodForm";
@@ -42,6 +44,7 @@ import { useTranslation } from "react-i18next";
 interface ItemWithFood {
     recipeItem: RecipeItem;
     food: Food | null;
+    servingUnits: ServingUnit[];
 }
 
 const SHEET_COLLAPSED = 160;
@@ -92,7 +95,11 @@ export default function RecipeEditorScreen() {
 
     function loadItems(id: number) {
         const rows = getRecipeItems(id);
-        setItems(rows.map((r) => ({ recipeItem: r.recipe_items, food: r.foods })));
+        setItems(rows.map((r) => ({
+            recipeItem: r.recipe_items,
+            food: r.foods,
+            servingUnits: r.foods ? getServingUnits(r.foods.id) : [],
+        })));
     }
 
     // ── Save recipe name ──────────────────────────────────
@@ -183,7 +190,8 @@ export default function RecipeEditorScreen() {
         const servingSize = food.serving_size ?? 100;
         const qtyGrams = toGrams(servingSize, foodUnit);
         const ri = addRecipeItem({ recipe_id: rid, food_id: food.id, quantity_grams: qtyGrams, quantity_unit: foodUnit });
-        const newEntry: ItemWithFood = { recipeItem: ri, food };
+        const sUnits = getServingUnits(food.id);
+        const newEntry: ItemWithFood = { recipeItem: ri, food, servingUnits: sUnits };
         setItems((prev) => [...prev, newEntry]);
         setFoodQuery("");
         setLocalResults([]);
@@ -194,7 +202,7 @@ export default function RecipeEditorScreen() {
     }
 
     // ── Item editing ──────────────────────────────────────
-    function handleModalSaved(itemId: number, quantityGrams: number, unit: FoodUnit) {
+    function handleModalSaved(itemId: number, quantityGrams: number, unit: string) {
         setItems((prev) =>
             prev.map((i) =>
                 i.recipeItem.id === itemId
@@ -257,9 +265,18 @@ export default function RecipeEditorScreen() {
 
                 {/* Items */}
                 {items.slice().reverse().map((itemWithFood) => {
-                    const { recipeItem, food } = itemWithFood;
-                    const itemUnit = (recipeItem.quantity_unit ?? "g") as FoodUnit;
-                    const displayQty = Math.round(fromGrams(recipeItem.quantity_grams, itemUnit) * 10) / 10;
+                    const { recipeItem, food, servingUnits } = itemWithFood;
+                    const matchedServing = servingUnits.find((s) => s.name === recipeItem.quantity_unit);
+                    let displayQty: number;
+                    let displayUnit: string;
+                    if (matchedServing) {
+                        displayQty = Math.round((recipeItem.quantity_grams / matchedServing.grams) * 10) / 10;
+                        displayUnit = matchedServing.name;
+                    } else {
+                        const itemUnit = (recipeItem.quantity_unit ?? "g") as FoodUnit;
+                        displayQty = Math.round(fromGrams(recipeItem.quantity_grams, itemUnit) * 10) / 10;
+                        displayUnit = unitLabel(itemUnit);
+                    }
                     const cals = food
                         ? Math.round((food.calories_per_100g * recipeItem.quantity_grams) / 100)
                         : 0;
@@ -273,7 +290,7 @@ export default function RecipeEditorScreen() {
                                     {food?.name ?? "Unknown"}
                                 </Text>
                                 <Text style={styles.itemDetail}>
-                                    {displayQty} {unitLabel(itemUnit)} · {cals} cal
+                                    {displayQty} {displayUnit} · {cals} cal
                                 </Text>
                             </Pressable>
                             <Pressable onPress={() => handleDeleteItem(recipeItem.id)} hitSlop={8}>

--- a/src/features/recipes/RecipeItemModal.tsx
+++ b/src/features/recipes/RecipeItemModal.tsx
@@ -25,7 +25,7 @@ interface RecipeItemModalProps {
     item: RecipeItem | null;
     food: Food | null;
     onClose: () => void;
-    onSaved: (itemId: number, quantityGrams: number, unit: FoodUnit) => void;
+    onSaved: (itemId: number, quantityGrams: number, unit: string) => void;
 }
 
 export default function RecipeItemModal({
@@ -86,7 +86,7 @@ export default function RecipeItemModal({
         if (!item || qty <= 0) return;
         const savedUnit = customServingUnit ? customServingUnit.name : unit;
         updateRecipeItem(item.id, { quantity_grams: qtyGrams, quantity_unit: savedUnit });
-        onSaved(item.id, qtyGrams, unit);
+        onSaved(item.id, qtyGrams, savedUnit);
     }
 
     const unitOptions = unitsForSystem(unitSystem);


### PR DESCRIPTION
## Summary

Custom serving unit names (e.g. `piece`, `serving`) stored in `quantity_unit` were being cast directly to `FoodUnit` and passed to `fromGrams()`. Since those names have no entry in the `TO_GRAMS` map, the result was `undefined`, producing `NaN` in the displayed quantity.

## Changes

- **`RecipeEditorScreen`**: Extended `ItemWithFood` with a `servingUnits` array, populated via `getServingUnits()` in both `loadItems()` and `addItemForFood()`. The item display loop now looks up the matching `ServingUnit` by name; if found it computes `count = quantity_grams / servingUnit.grams`; otherwise falls back to the existing `fromGrams()` path for standard units.
- **`RecipeItemModal`**: `onSaved` now passes the actual `savedUnit` (which may be a custom name) instead of the raw `FoodUnit`, keeping in-memory state consistent with the database so the fix also applies within the same session after editing.

## Testing

1. Create a food with a custom serving unit (e.g. `piece = 100 g`)
2. Add it to a recipe via the editor
3. Select the custom unit in the modal and save
4. Navigate away and reopen the recipe — quantity should show `1 piece` instead of `NaN piece`

Resolves #115