### PR TITLE
feat: remember last logged meal per food

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -114,6 +114,7 @@ export function initDB() {
     "ALTER TABLE goals ADD COLUMN appearance_mode TEXT NOT NULL DEFAULT 'system'",
     "ALTER TABLE foods ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE recipes ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE foods ADD COLUMN last_logged_meal TEXT",
   ];
   for (const sql of migrations) {
     try { expoDb.execSync(sql); } catch { /* column already exists */ }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,6 +14,7 @@ export const foods = sqliteTable("foods", {
     serving_size: real("serving_size").notNull().default(100),
     last_logged_amount: real("last_logged_amount"),
     last_logged_unit: text("last_logged_unit"),
+    last_logged_meal: text("last_logged_meal"),
     deleted: integer("deleted").notNull().default(0),
 });
 

--- a/src/features/log/EntryModal.tsx
+++ b/src/features/log/EntryModal.tsx
@@ -120,7 +120,7 @@ export default function EntryModal({
                 setQuantity(String(food.serving_size ?? 100));
             }
             amountTouched.current = false;
-            const meal = defaultMealType ?? "breakfast";
+            const meal = defaultMealType ?? (food.last_logged_meal as MealType | null) ?? "breakfast";
             setMealType(meal);
 
             const dateKey = formatDateKey(selectedDate);
@@ -204,10 +204,11 @@ export default function EntryModal({
                 recipeLogId: selectedGroup?.recipeLogId,
             });
 
-            // Persist last logged amount/unit on the food for future defaults
+            // Persist last logged amount/unit/meal on the food for future defaults
             updateFood(food.id, {
                 last_logged_amount: qty,
                 last_logged_unit: savedUnit,
+                last_logged_meal: mealType,
             });
 
             // Cancel today's meal reminder since the user just logged food


### PR DESCRIPTION
Closes #126

## Changes
- Added `last_logged_meal` column to `foods` table (schema + migration)
- When saving a new food entry, persist the selected meal type on the food
- When opening the entry modal for a new log (without an explicit meal from the route), default to the food's last logged meal instead of always `breakfast`

Follows the same pattern as the existing `last_logged_amount` / `last_logged_unit` defaults.