### PR TITLE
feat: Manual scheduled entries

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -181,6 +181,14 @@ export function deleteEntry(id: number) {
     db.delete(entries).where(eq(entries.id, id)).run();
 }
 
+export function confirmEntry(id: number) {
+    db.update(entries).set({ is_scheduled: 0 }).where(eq(entries.id, id)).run();
+}
+
+export function confirmRecipeLog(recipeLogId: number) {
+    db.update(entries).set({ is_scheduled: 0 }).where(eq(entries.recipe_log_id, recipeLogId)).run();
+}
+
 export function updateEntry(id: number, values: Partial<NewEntry>) {
     db.update(entries).set(values).where(eq(entries.id, id)).run();
 }
@@ -294,6 +302,7 @@ export interface LoggedRecipeGroup {
     recipeId: number;
     recipeName: string;
     portion: number;
+    isScheduled: boolean;
 }
 
 export function getLoggedRecipeGroups(date: string, mealType: string): LoggedRecipeGroup[] {
@@ -314,11 +323,19 @@ export function getLoggedRecipeGroups(date: string, mealType: string): LoggedRec
 
     return rows.map((row) => {
         const recipe = getRecipeById(row.recipeId);
+        // Check if all entries in this group are scheduled
+        const groupEntries = db
+            .select({ is_scheduled: entries.is_scheduled })
+            .from(entries)
+            .where(eq(entries.recipe_log_id, row.recipeLogId))
+            .all();
+        const isScheduled = groupEntries.length > 0 && groupEntries.every((e) => e.is_scheduled === 1);
         return {
             recipeLogId: row.recipeLogId,
             recipeId: row.recipeId,
             recipeName: recipe?.name ?? "Recipe",
             portion: row.portion,
+            isScheduled,
         };
     });
 }
@@ -332,6 +349,7 @@ export function logRecipeToMeal(
     mealType: string,
     date: string,
     portionMultiplier = 1,
+    isScheduled = 0,
 ): number {
     const recipeLog = db
         .insert(recipeLogs)
@@ -357,6 +375,7 @@ export function logRecipeToMeal(
                 date,
                 meal_type: mealType,
                 recipe_log_id: recipeLog.id,
+                is_scheduled: isScheduled,
             })
             .run();
     }
@@ -471,6 +490,7 @@ export function copyEntriesToDate(
                     date: targetDate,
                     meal_type: targetMealType ?? entry.meal_type,
                     recipe_log_id: newRl.id,
+                    is_scheduled: entry.is_scheduled,
                 })
                 .run();
         }
@@ -486,6 +506,7 @@ export function copyEntriesToDate(
                 timestamp: ts,
                 date: targetDate,
                 meal_type: targetMealType ?? entry.meal_type,
+                is_scheduled: entry.is_scheduled,
             })
             .run();
     }

--- a/src/features/log/DailyProgressBar.tsx
+++ b/src/features/log/DailyProgressBar.tsx
@@ -31,6 +31,7 @@ interface Totals {
 
 interface DailyProgressBarProps {
     totals: Totals;
+    scheduledTotals?: Totals;
     goals: Goals;
     meanWeightKg?: number | null;
     weightTrend?: "up" | "down" | "flat" | null;
@@ -44,6 +45,7 @@ function ProgressRow({
     color,
     unit,
     colors,
+    scheduled,
 }: {
     label: string;
     current: number;
@@ -51,8 +53,11 @@ function ProgressRow({
     color: string;
     unit: string;
     colors: ThemeColors;
+    scheduled?: number;
 }) {
     const ratio = goal > 0 ? Math.min(current / goal, 1) : 0;
+    const scheduledRatio = goal > 0 && scheduled ? Math.min((current + scheduled) / goal, 1) : 0;
+    const hasScheduled = scheduled != null && scheduled > 0;
     const rs = useMemo(() => createRowStyles(colors), [colors]);
 
     return (
@@ -66,6 +71,16 @@ function ProgressRow({
                 </Text>
             </View>
             <View style={rs.track}>
+                {hasScheduled && scheduledRatio > ratio && (
+                    <View
+                        style={[
+                            rs.scheduledFill,
+                            {
+                                width: `${scheduledRatio * 100}%`,
+                            },
+                        ]}
+                    />
+                )}
                 <View
                     style={[
                         rs.fill,
@@ -80,7 +95,7 @@ function ProgressRow({
     );
 }
 
-function MacroMakeupBar({ totals, colors, t }: { totals: Totals; colors: ThemeColors; t: (key: string) => string; }) {
+function MacroMakeupBar({ totals, scheduledTotals, colors, t }: { totals: Totals; scheduledTotals?: Totals; colors: ThemeColors; t: (key: string) => string; }) {
     const pCal = totals.protein * 4;
     const cCal = totals.carbs * 4;
     const fCal = totals.fat * 9;
@@ -88,25 +103,53 @@ function MacroMakeupBar({ totals, colors, t }: { totals: Totals; colors: ThemeCo
 
     if (total <= 0) return null;
 
+    const pPct = Math.round((pCal / total) * 100);
+    const cPct = Math.round((cCal / total) * 100);
+    const fPct = Math.round((fCal / total) * 100);
+
+    // Compute percentage change if scheduled entries exist
+    const hasScheduled = scheduledTotals && (scheduledTotals.protein > 0 || scheduledTotals.carbs > 0 || scheduledTotals.fat > 0);
+    let pDiff = 0, cDiff = 0, fDiff = 0;
+    if (hasScheduled) {
+        const withP = (totals.protein + scheduledTotals.protein) * 4;
+        const withC = (totals.carbs + scheduledTotals.carbs) * 4;
+        const withF = (totals.fat + scheduledTotals.fat) * 9;
+        const withTotal = withP + withC + withF;
+        if (withTotal > 0) {
+            pDiff = Math.round((withP / withTotal) * 100) - pPct;
+            cDiff = Math.round((withC / withTotal) * 100) - cPct;
+            fDiff = Math.round((withF / withTotal) * 100) - fPct;
+        }
+    }
+
+    function formatDiff(diff: number): string {
+        if (diff > 0) return ` +${diff}%`;
+        if (diff < 0) return ` ${diff}%`;
+        return ` +0%`;
+    }
+
     return (
         <View style={makeupStyles.container}>
             <View style={makeupStyles.legendRow}>
                 <View style={makeupStyles.legendItem}>
                     <View style={[makeupStyles.dot, { backgroundColor: colors.protein }]} />
                     <Text style={[makeupStyles.legendText, { color: colors.textSecondary }]}>
-                        {t("settings.protein")} {Math.round((pCal / total) * 100)}%
+                        {t("settings.protein")} {pPct}%
+                        {hasScheduled && <Text style={{ color: colors.disabled }}>{formatDiff(pDiff)}</Text>}
                     </Text>
                 </View>
                 <View style={makeupStyles.legendItem}>
                     <View style={[makeupStyles.dot, { backgroundColor: colors.carbs }]} />
                     <Text style={[makeupStyles.legendText, { color: colors.textSecondary }]}>
-                        {t("settings.carbs")} {Math.round((cCal / total) * 100)}%
+                        {t("settings.carbs")} {cPct}%
+                        {hasScheduled && <Text style={{ color: colors.disabled }}>{formatDiff(cDiff)}</Text>}
                     </Text>
                 </View>
                 <View style={makeupStyles.legendItem}>
                     <View style={[makeupStyles.dot, { backgroundColor: colors.fat }]} />
                     <Text style={[makeupStyles.legendText, { color: colors.textSecondary }]}>
-                        {t("settings.fat")} {Math.round((fCal / total) * 100)}%
+                        {t("settings.fat")} {fPct}%
+                        {hasScheduled && <Text style={{ color: colors.disabled }}>{formatDiff(fDiff)}</Text>}
                     </Text>
                 </View>
             </View>
@@ -193,11 +236,18 @@ function createRowStyles(colors: ThemeColors) {
             height: 6,
             borderRadius: 3,
         },
+        scheduledFill: {
+            position: "absolute",
+            height: 6,
+            borderRadius: 3,
+            backgroundColor: colors.disabled,
+        },
     });
 }
 
 export default function DailyProgressBar({
     totals,
+    scheduledTotals,
     goals,
     meanWeightKg,
     weightTrend,
@@ -211,9 +261,15 @@ export default function DailyProgressBar({
     const isImperial = unitSystem === "imperial";
     const KG_TO_LB = 2.20462;
 
+    // Actual (non-scheduled) totals for progress bars
+    const actualCalories = totals.calories - (scheduledTotals?.calories ?? 0);
     const calRatio =
-        goals.calories > 0 ? Math.min(totals.calories / goals.calories, 1) : 0;
-    const isOverCalories = goals.calories > 0 && totals.calories > goals.calories;
+        goals.calories > 0 ? Math.min(actualCalories / goals.calories, 1) : 0;
+    const scheduledCalRatio = scheduledTotals && goals.calories > 0
+        ? Math.min(totals.calories / goals.calories, 1)
+        : 0;
+    const hasScheduledCalories = scheduledTotals != null && scheduledTotals.calories > 0;
+    const isOverCalories = goals.calories > 0 && actualCalories > goals.calories;
 
     function toggle() {
         LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -225,7 +281,7 @@ export default function DailyProgressBar({
             {/* Calorie bar – always visible */}
             <View style={styles.headerRow}>
                 <Text style={[styles.calorieText, isOverCalories && styles.calorieTextOver]}>
-                    {Math.round(totals.calories)}{" "}
+                    {Math.round(actualCalories)}{" "}
                     <Text style={styles.goalText}>
                         / {Math.round(goals.calories)} kcal
                     </Text>
@@ -237,6 +293,16 @@ export default function DailyProgressBar({
                 />
             </View>
             <View style={styles.track}>
+                {hasScheduledCalories && scheduledCalRatio > calRatio && (
+                    <View
+                        style={[
+                            styles.scheduledFill,
+                            {
+                                width: `${scheduledCalRatio * 100}%`,
+                            },
+                        ]}
+                    />
+                )}
                 <View
                     style={[
                         styles.fill,
@@ -253,31 +319,39 @@ export default function DailyProgressBar({
                 <View style={styles.macros}>
                     <ProgressRow
                         label={t("settings.protein")}
-                        current={totals.protein}
+                        current={totals.protein - (scheduledTotals?.protein ?? 0)}
                         goal={goals.protein}
                         color={colors.protein}
                         unit="g"
                         colors={colors}
+                        scheduled={scheduledTotals?.protein}
                     />
                     <ProgressRow
                         label={t("settings.carbs")}
-                        current={totals.carbs}
+                        current={totals.carbs - (scheduledTotals?.carbs ?? 0)}
                         goal={goals.carbs}
                         color={colors.carbs}
                         unit="g"
                         colors={colors}
+                        scheduled={scheduledTotals?.carbs}
                     />
                     <ProgressRow
                         label={t("settings.fat")}
-                        current={totals.fat}
+                        current={totals.fat - (scheduledTotals?.fat ?? 0)}
                         goal={goals.fat}
                         color={colors.fat}
                         unit="g"
                         colors={colors}
+                        scheduled={scheduledTotals?.fat}
                     />
 
                     {/* Macro makeup bar */}
-                    <MacroMakeupBar totals={totals} colors={colors} t={t} />
+                    <MacroMakeupBar
+                        totals={{ calories: actualCalories, protein: totals.protein - (scheduledTotals?.protein ?? 0), carbs: totals.carbs - (scheduledTotals?.carbs ?? 0), fat: totals.fat - (scheduledTotals?.fat ?? 0) }}
+                        scheduledTotals={scheduledTotals}
+                        colors={colors}
+                        t={t}
+                    />
 
                     {meanWeightKg != null && (
                         <View style={styles.weightRow}>
@@ -344,6 +418,12 @@ function createStyles(colors: ThemeColors) {
         fill: {
             height: 8,
             borderRadius: 4,
+        },
+        scheduledFill: {
+            position: "absolute",
+            height: 8,
+            borderRadius: 4,
+            backgroundColor: colors.disabled,
         },
         macros: {
             marginTop: spacing.xs,

--- a/src/features/log/EntryModal.tsx
+++ b/src/features/log/EntryModal.tsx
@@ -167,7 +167,7 @@ export default function EntryModal({
 
     const savedUnit = customServingUnit ? customServingUnit.name : unit;
 
-    function handleSave() {
+    function handleSave(isScheduled = 0) {
         if (!food || qty <= 0) return;
 
         if (entry) {
@@ -194,6 +194,7 @@ export default function EntryModal({
                 date: formatDateKey(selectedDate),
                 meal_type: mealType,
                 recipe_log_id: selectedGroup?.recipeLogId,
+                is_scheduled: isScheduled,
             });
             logger.info("[DB] Added entry", {
                 foodId: food.id,
@@ -202,6 +203,7 @@ export default function EntryModal({
                 date: formatDateKey(selectedDate),
                 mealType: mealType,
                 recipeLogId: selectedGroup?.recipeLogId,
+                isScheduled,
             });
 
             // Persist last logged amount/unit/meal on the food for future defaults
@@ -412,12 +414,47 @@ export default function EntryModal({
                         </>
                     )}
 
-                    <Button
-                        title={t("log.saveEntry")}
-                        onPress={handleSave}
-                        disabled={qty <= 0}
-                        style={styles.saveButton}
-                    />
+                    {entry ? (
+                        <Button
+                            title={t("log.saveEntry")}
+                            onPress={() => handleSave()}
+                            disabled={qty <= 0}
+                            style={styles.saveButton}
+                        />
+                    ) : selectedGroup ? (
+                        selectedGroup.isScheduled ? (
+                            <Button
+                                title={t("log.saveEntryAsScheduled")}
+                                onPress={() => handleSave(1)}
+                                disabled={qty <= 0}
+                                style={styles.saveButton}
+                                variant="outline"
+                            />
+                        ) : (
+                            <Button
+                                title={t("log.saveEntry")}
+                                onPress={() => handleSave()}
+                                disabled={qty <= 0}
+                                style={styles.saveButton}
+                            />
+                        )
+                    ) : (
+                        <>
+                            <Button
+                                title={t("log.saveEntry")}
+                                onPress={() => handleSave()}
+                                disabled={qty <= 0}
+                                style={styles.saveButton}
+                            />
+                            <Button
+                                title={t("log.saveEntryAsScheduled")}
+                                onPress={() => handleSave(1)}
+                                disabled={qty <= 0}
+                                style={styles.scheduledButton}
+                                variant="outline"
+                            />
+                        </>
+                    )}
                 </ScrollView>
             </KeyboardAvoidingView>
         </Modal>
@@ -518,5 +555,6 @@ function createStyles(colors: ThemeColors) {
             marginTop: spacing.xs,
         },
         saveButton: { marginTop: spacing.lg },
+        scheduledButton: { marginTop: spacing.sm },
     });
 }

--- a/src/features/log/LogScreen.tsx
+++ b/src/features/log/LogScreen.tsx
@@ -1,6 +1,6 @@
 import Button from "@/src/components/Button";
 import Input from "@/src/components/Input";
-import { addWeightLog, copyEntriesToDate, deleteEntry, deleteRecipeLog, deleteWeightLog, formatDateKey, getEntriesByDate, getGoals, getWeightLogsForDate, getWeightLogsForRange, moveEntriesToDate, updateRecipeLogPortion, type Entry, type Food, type Goals, type WeightLog } from "@/src/db/queries";
+import { addWeightLog, confirmEntry, confirmRecipeLog, copyEntriesToDate, deleteEntry, deleteRecipeLog, deleteWeightLog, formatDateKey, getEntriesByDate, getGoals, getWeightLogsForDate, getWeightLogsForRange, moveEntriesToDate, updateRecipeLogPortion, type Entry, type Food, type Goals, type WeightLog } from "@/src/db/queries";
 import { useAppStore } from "@/src/store/useAppStore";
 import { MEAL_TYPES, type MealType } from "@/src/types";
 import { diffCalendarDays, diffDateKeys, parseDateKey, shiftCalendarDate } from "@/src/utils/date";
@@ -77,20 +77,26 @@ function loadGrouped(date: Date) {
 
 function computeTotals(grouped: Record<MealType, EntryWithFood[]>) {
     const all = Object.values(grouped).flat();
-    return all.reduce(
-        (acc, row) => {
-            const qty = row.entries.quantity_grams;
-            const food = row.foods;
-            if (!food) return acc;
-            return {
-                calories: acc.calories + (food.calories_per_100g * qty) / 100,
-                protein: acc.protein + (food.protein_per_100g * qty) / 100,
-                carbs: acc.carbs + (food.carbs_per_100g * qty) / 100,
-                fat: acc.fat + (food.fat_per_100g * qty) / 100,
-            };
-        },
-        { calories: 0, protein: 0, carbs: 0, fat: 0 },
-    );
+    const actual = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+    const scheduled = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+    for (const row of all) {
+        const qty = row.entries.quantity_grams;
+        const food = row.foods;
+        if (!food) continue;
+        const target = row.entries.is_scheduled === 1 ? scheduled : actual;
+        target.calories += (food.calories_per_100g * qty) / 100;
+        target.protein += (food.protein_per_100g * qty) / 100;
+        target.carbs += (food.carbs_per_100g * qty) / 100;
+        target.fat += (food.fat_per_100g * qty) / 100;
+    }
+    return {
+        calories: actual.calories + scheduled.calories,
+        protein: actual.protein + scheduled.protein,
+        carbs: actual.carbs + scheduled.carbs,
+        fat: actual.fat + scheduled.fat,
+        actual,
+        scheduled,
+    };
 }
 
 function DayPage({
@@ -101,6 +107,8 @@ function DayPage({
     onEdit,
     onEditRecipeGroup,
     onDeleteRecipeLog,
+    onConfirmEntry,
+    onConfirmRecipeLog,
     selectionMode,
     selectedEntryIds,
     onToggleEntries,
@@ -120,6 +128,8 @@ function DayPage({
     onEdit: (row: EntryWithFood) => void;
     onEditRecipeGroup: (group: RecipeGroup, multiplier: number) => void;
     onDeleteRecipeLog: (recipeLogId: number) => void;
+    onConfirmEntry?: (id: number) => void;
+    onConfirmRecipeLog?: (recipeLogId: number) => void;
     selectionMode?: boolean;
     selectedEntryIds?: Set<number>;
     onToggleEntries?: (entryIds: number[]) => void;
@@ -132,6 +142,7 @@ function DayPage({
     onAddWeight?: (weightKg: number) => void;
     onDeleteWeight?: (id: number) => void;
 }) {
+    const totals = computeTotals(grouped);
     return (
         <View style={styles.dayPage}>
             <ScrollView
@@ -139,7 +150,7 @@ function DayPage({
                 showsVerticalScrollIndicator={false}
                 nestedScrollEnabled
             >
-                <DailyProgressBar totals={computeTotals(grouped)} goals={goals} meanWeightKg={meanWeightKg} weightTrend={weightTrend} weightDaysAgo={weightDaysAgo} />
+                <DailyProgressBar totals={totals} scheduledTotals={totals.scheduled} goals={goals} meanWeightKg={meanWeightKg} weightTrend={weightTrend} weightDaysAgo={weightDaysAgo} />
                 {MEAL_TYPES.map((meal) => (
                     <MealSection
                         key={meal.key}
@@ -151,6 +162,8 @@ function DayPage({
                         onEdit={onEdit}
                         onEditRecipeGroup={onEditRecipeGroup}
                         onDeleteRecipeLog={onDeleteRecipeLog}
+                        onConfirmEntry={onConfirmEntry}
+                        onConfirmRecipeLog={onConfirmRecipeLog}
                         selectionMode={selectionMode}
                         selectedEntryIds={selectedEntryIds}
                         onToggleEntries={onToggleEntries}
@@ -318,6 +331,18 @@ export default function LogScreen() {
         loadAllDays(selectedDate);
     }
 
+    function handleConfirmEntry(id: number) {
+        confirmEntry(id);
+        logger.info("[DB] Confirmed scheduled entry", { id });
+        loadAllDays(selectedDate);
+    }
+
+    function handleConfirmRecipeLog(recipeLogId: number) {
+        confirmRecipeLog(recipeLogId);
+        logger.info("[DB] Confirmed scheduled recipe log", { recipeLogId });
+        loadAllDays(selectedDate);
+    }
+
     function handleAddWeight(weightKg: number) {
         addWeightLog(weightKg, selectedDate);
         logger.info("[DB] Logged weight", { weight_kg: weightKg });
@@ -477,6 +502,8 @@ export default function LogScreen() {
                     onEdit={handleEdit}
                     onEditRecipeGroup={handleEditRecipeGroup}
                     onDeleteRecipeLog={handleDeleteRecipeLog}
+                    onConfirmEntry={handleConfirmEntry}
+                    onConfirmRecipeLog={handleConfirmRecipeLog}
                     meanWeightKg={meanWeightKg}
                     weightTrend={weightTrend}
                     weightDaysAgo={weightDaysAgo}
@@ -489,6 +516,8 @@ export default function LogScreen() {
                     onEdit={handleEdit}
                     onEditRecipeGroup={handleEditRecipeGroup}
                     onDeleteRecipeLog={handleDeleteRecipeLog}
+                    onConfirmEntry={handleConfirmEntry}
+                    onConfirmRecipeLog={handleConfirmRecipeLog}
                     selectionMode={selectionMode}
                     selectedEntryIds={selectedEntryIds}
                     onToggleEntries={handleToggleEntries}
@@ -509,6 +538,8 @@ export default function LogScreen() {
                     onEdit={handleEdit}
                     onEditRecipeGroup={handleEditRecipeGroup}
                     onDeleteRecipeLog={handleDeleteRecipeLog}
+                    onConfirmEntry={handleConfirmEntry}
+                    onConfirmRecipeLog={handleConfirmRecipeLog}
                     meanWeightKg={meanWeightKg}
                     weightTrend={weightTrend}
                     weightDaysAgo={weightDaysAgo}

--- a/src/features/log/MealSection.tsx
+++ b/src/features/log/MealSection.tsx
@@ -23,6 +23,8 @@ interface MealSectionProps {
     onEdit?: (row: EntryWithFood) => void;
     onEditRecipeGroup?: (group: RecipeGroup, currentMultiplier: number) => void;
     onDeleteRecipeLog?: (recipeLogId: number) => void;
+    onConfirmEntry?: (id: number) => void;
+    onConfirmRecipeLog?: (recipeLogId: number) => void;
     selectionMode?: boolean;
     selectedEntryIds?: Set<number>;
     onToggleEntries?: (entryIds: number[]) => void;
@@ -96,6 +98,8 @@ export default function MealSection({
     onEdit,
     onEditRecipeGroup,
     onDeleteRecipeLog,
+    onConfirmEntry,
+    onConfirmRecipeLog,
     selectionMode,
     selectedEntryIds,
     onToggleEntries,
@@ -196,6 +200,7 @@ export default function MealSection({
                                 onDeleteEntry={onDeleteEntry}
                                 onEditRecipeGroup={onEditRecipeGroup}
                                 onDeleteRecipeLog={onDeleteRecipeLog}
+                                onConfirmRecipeLog={onConfirmRecipeLog}
                                 allMealSelected={allMealSelected}
                             />
                         ))}
@@ -206,6 +211,7 @@ export default function MealSection({
                                 row={row}
                                 onEdit={onEdit}
                                 onDeleteEntry={onDeleteEntry}
+                                onConfirmEntry={onConfirmEntry}
                                 allMealSelected={allMealSelected}
                             />
                         ))}
@@ -220,6 +226,7 @@ function EntryRow({
     row,
     onEdit,
     onDeleteEntry,
+    onConfirmEntry,
     isChild = false,
     allMealSelected,
     allGroupSelected,
@@ -227,6 +234,7 @@ function EntryRow({
     row: EntryWithFood;
     onEdit?: (row: EntryWithFood) => void;
     onDeleteEntry: (id: number) => void;
+    onConfirmEntry?: (id: number) => void;
     isChild?: boolean;
     allMealSelected?: boolean;
     allGroupSelected?: boolean;
@@ -242,6 +250,7 @@ function EntryRow({
     const cals = food ? Math.round((food.calories_per_100g * qty) / 100) : 0;
     const selectionMode = selection?.selectionMode ?? false;
     const isSelected = selection?.selectedEntryIds.has(row.entries.id) ?? false;
+    const isScheduled = row.entries.is_scheduled === 1;
 
     return (
         <Pressable
@@ -249,6 +258,7 @@ function EntryRow({
                 styles.entryRow,
                 isChild && styles.childEntryRow,
                 selectionMode && isSelected && !allMealSelected && !allGroupSelected && styles.selectedEntry,
+                isScheduled && styles.scheduledEntry,
             ]}
             onPress={() => {
                 if (selectionMode) selection?.toggleEntries([row.entries.id]);
@@ -263,25 +273,36 @@ function EntryRow({
             {isChild && <View style={styles.childConnector} />}
             <View style={styles.entryInfo}>
                 <View style={styles.entryNameRow}>
-                    <Text style={styles.entryName} numberOfLines={1}>
+                    <Text style={[styles.entryName, isScheduled && styles.scheduledText]} numberOfLines={1}>
                         {food?.name ?? t("log.unknownFood")}
                     </Text>
-                    {row.entries.is_scheduled === 1 && (
-                        <Ionicons name="calendar-outline" size={14} color={colors.primary} style={{ marginLeft: 4 }} />
+                    {isScheduled && (
+                        <Ionicons name="calendar-outline" size={14} color={colors.disabled} style={{ marginLeft: 4 }} />
                     )}
                 </View>
-                <Text style={styles.entryDetail}>
+                <Text style={[styles.entryDetail, isScheduled && styles.scheduledText]}>
                     {formatEntryQuantity(qty, entryUnit, servingGrams)} · {cals} {t("common.cal")}
                 </Text>
             </View>
             {!selectionMode && (
-                <Pressable onPress={() => onDeleteEntry(row.entries.id)} hitSlop={8}>
-                    <Ionicons
-                        name="close-circle-outline"
-                        size={20}
-                        color={colors.textTertiary}
-                    />
-                </Pressable>
+                <View style={styles.entryActions}>
+                    {isScheduled && !isChild && onConfirmEntry && (
+                        <Pressable onPress={() => onConfirmEntry(row.entries.id)} hitSlop={8} style={{ marginRight: spacing.sm }}>
+                            <Ionicons
+                                name="checkmark-circle-outline"
+                                size={20}
+                                color={colors.success}
+                            />
+                        </Pressable>
+                    )}
+                    <Pressable onPress={() => onDeleteEntry(row.entries.id)} hitSlop={8}>
+                        <Ionicons
+                            name="close-circle-outline"
+                            size={20}
+                            color={colors.textTertiary}
+                        />
+                    </Pressable>
+                </View>
             )}
         </Pressable>
     );
@@ -293,6 +314,7 @@ function RecipeGroupRow({
     onDeleteEntry,
     onEditRecipeGroup,
     onDeleteRecipeLog,
+    onConfirmRecipeLog,
     allMealSelected,
 }: {
     group: RecipeGroup;
@@ -300,6 +322,7 @@ function RecipeGroupRow({
     onDeleteEntry: (id: number) => void;
     onEditRecipeGroup?: (group: RecipeGroup, currentMultiplier: number) => void;
     onDeleteRecipeLog?: (recipeLogId: number) => void;
+    onConfirmRecipeLog?: (recipeLogId: number) => void;
     allMealSelected?: boolean;
 }) {
     const { t } = useTranslation();
@@ -340,11 +363,13 @@ function RecipeGroupRow({
         : group.recipeName;
 
     const allGroupEntryIds = group.rows.map(r => r.entries.id);
+    const isGroupScheduled = group.rows.length > 0 && group.rows.every(r => r.entries.is_scheduled === 1);
 
     return (
         <View style={[
             styles.recipeGroup,
             allGroupSelected && !allMealSelected && styles.selectedGroup,
+            isGroupScheduled && styles.scheduledEntry,
         ]}>
             <Pressable
                 style={styles.recipeHeader}
@@ -366,22 +391,31 @@ function RecipeGroupRow({
                 <Ionicons
                     name={expanded ? "chevron-down" : "chevron-forward"}
                     size={16}
-                    color={colors.textSecondary}
+                    color={isGroupScheduled ? colors.disabled : colors.textSecondary}
                 />
                 <Ionicons
                     name={isModified ? "create-outline" : "book-outline"}
                     size={16}
-                    color={isModified ? colors.textSecondary : colors.primary}
+                    color={isGroupScheduled ? colors.disabled : (isModified ? colors.textSecondary : colors.primary)}
                     style={{ marginLeft: 4 }}
                 />
-                <Text style={styles.recipeName} numberOfLines={1}>
+                <Text style={[styles.recipeName, isGroupScheduled && styles.scheduledText]} numberOfLines={1}>
                     {displayName}
                 </Text>
-                <Text style={styles.recipeDetail}>
+                <Text style={[styles.recipeDetail, isGroupScheduled && styles.scheduledText]}>
                     {t("common.itemCount", { count: group.rows.length })} · {Math.round(totalCals)} {t("common.cal")}
                 </Text>
                 {!selectionMode && (
                     <>
+                        {isGroupScheduled && onConfirmRecipeLog && (
+                            <Pressable
+                                onPress={() => onConfirmRecipeLog(group.recipeLogId)}
+                                hitSlop={8}
+                                style={{ marginRight: spacing.xs }}
+                            >
+                                <Ionicons name="checkmark-circle-outline" size={20} color={colors.success} />
+                            </Pressable>
+                        )}
                         {onEditRecipeGroup && (
                             <Pressable
                                 onPress={() => onEditRecipeGroup(group, multiplier)}
@@ -560,6 +594,16 @@ function createStyles(colors: ThemeColors) {
             fontSize: fontSize.xs,
             color: colors.textSecondary,
             marginRight: spacing.sm,
+        },
+        scheduledEntry: {
+            opacity: 0.6,
+        },
+        scheduledText: {
+            color: colors.disabled,
+        },
+        entryActions: {
+            flexDirection: "row",
+            alignItems: "center",
         },
     });
 }

--- a/src/features/log/RecipeLogModal.tsx
+++ b/src/features/log/RecipeLogModal.tsx
@@ -79,16 +79,17 @@ export default function RecipeLogModal({
         return sum + (food.calories_per_100g * row.recipe_items.quantity_grams) / 100;
     }, 0) * portion;
 
-    function handleSave() {
+    function handleSave(isScheduled = 0) {
         if (!recipe || portion <= 0) return;
-        logRecipeToMeal(recipe.id, mealType, formatDateKey(selectedDate), portion);
+        logRecipeToMeal(recipe.id, mealType, formatDateKey(selectedDate), portion, isScheduled);
         logger.info("[DB] Logged recipe to meal", {
             recipeId: recipe.id,
             mealType,
             date: formatDateKey(selectedDate),
             portionMultiplier: portion,
+            isScheduled,
         });
-        cancelMealReminderIfLogged(mealType);
+        if (!isScheduled) cancelMealReminderIfLogged(mealType);
         onSaved();
     }
 
@@ -178,7 +179,8 @@ export default function RecipeLogModal({
                         ))}
                     </View>
 
-                    <Button title={t("log.addToLog")} onPress={handleSave} style={styles.saveBtn} />
+                    <Button title={t("log.addToLog")} onPress={() => handleSave()} style={styles.saveBtn} />
+                    <Button title={t("log.addToLogAsScheduled")} onPress={() => handleSave(1)} style={styles.scheduledBtn} variant="outline" />
                 </ScrollView>
             </View>
         </Modal>
@@ -260,6 +262,7 @@ function createStyles(colors: ThemeColors, insetsTop = 0) {
             fontWeight: "600",
         },
         saveBtn: { marginTop: spacing.md },
+        scheduledBtn: { marginTop: spacing.sm },
         portionRow: {
             flexDirection: "row",
             alignItems: "center",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -144,6 +144,9 @@ const de = {
         weight: "Gewicht",
         noWeightsLogged: "Noch kein Gewicht erfasst",
         weightDaysAgo: "vor {{count}}T",
+        saveEntryAsScheduled: "Eintrag als geplant speichern",
+        addToLogAsScheduled: "Als geplant hinzufügen",
+        confirmScheduled: "Geplanten Eintrag bestätigen",
     },
     templates: {
         title: "Vorlagen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -145,6 +145,9 @@ const en = {
         weight: "Weight",
         noWeightsLogged: "No weight logged yet",
         weightDaysAgo: "{{count}}d ago",
+        saveEntryAsScheduled: "Save Entry as Scheduled",
+        addToLogAsScheduled: "Add to Log as Scheduled",
+        confirmScheduled: "Confirm scheduled entry",
     },
     templates: {
         title: "Templates",

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -15,6 +15,7 @@ export const lightColors = {
     carbs: "#F59E0B",
     fat: "#EF4444",
     weight: "#8B5CF6",
+    disabled: "#D1D5DB",
 } as const;
 
 export const darkColors = {
@@ -34,6 +35,7 @@ export const darkColors = {
     carbs: "#FBBF24",
     fat: "#F87171",
     weight: "#A78BFA",
+    disabled: "#4B5563",
 } as const;
 
 export type ThemeColors = { [K in keyof typeof lightColors]: string };


### PR DESCRIPTION
## Summary

Implements manual scheduling for food entries and recipes, closing #137.

### New Features
- **"Save Entry as Scheduled" button** on the EntryModal (add food screen) — lets users manually schedule individual food entries
- **"Add to Log as Scheduled" button** on the RecipeLogModal — lets users schedule entire recipes
- **Confirm icon** (checkmark) next to delete icon on scheduled entries and recipe groups — clicking turns the scheduled item into a normal logged entry
- **Scheduled entries are grayed out** in the meal sections for visual distinction

### Progress Bar Enhancements
- **Grayed-out bar extension** on calorie and macro progress bars showing where macros would be if scheduled items were confirmed
- **Percentage change indicators** in the macro makeup bar legend (e.g., "Protein 30% +2%")
- Calorie display now shows only actual (non-scheduled) calories, with scheduled shown via gray extension

### Smart Recipe Group Handling
- When adding a food to an already existing **scheduled** recipe group, only the "Save Entry as Scheduled" button is shown (enforces consistency)
- When adding to a **non-scheduled** recipe group, only the normal "Save Entry" button is shown
- Confirming a recipe marks all its child entries as non-scheduled at once

### Infrastructure
- Added `confirmEntry()` and `confirmRecipeLog()` DB query functions
- Extended `logRecipeToMeal()` with optional `isScheduled` parameter
- Extended `LoggedRecipeGroup` with `isScheduled` field
- Added `disabled` color to light/dark themes
- Preserved `is_scheduled` flag when copying entries
- Added i18n strings (en/de) for all new UI elements

Closes #137