### PR TITLE
feat: CRUD operation tools for AI

### DIFF
--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -193,6 +193,15 @@ export function updateEntry(id: number, values: Partial<NewEntry>) {
     db.update(entries).set(values).where(eq(entries.id, id)).run();
 }
 
+export function getEntryById(id: number) {
+    return db
+        .select()
+        .from(entries)
+        .leftJoin(foods, eq(entries.food_id, foods.id))
+        .where(eq(entries.id, id))
+        .get();
+}
+
 // ── Goals ──────────────────────────────────────────────────
 
 export function getGoals(): Goals | undefined {

--- a/src/features/log/AiChatOverlay.tsx
+++ b/src/features/log/AiChatOverlay.tsx
@@ -110,9 +110,13 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
         if (msg.role === "tool-request" && msg.toolCall) {
             setPendingToolCall(msg.toolCall);
         }
+        // Notify parent when a data-modifying tool executed successfully
+        if (msg.role === "tool-result" && msg.toolResult?.success) {
+            onDataChanged?.();
+        }
         setMessages((prev) => [...prev, msg]);
         setStreamingText("");
-    }, []);
+    }, [onDataChanged]);
 
     const handleSend = useCallback(async () => {
         const text = inputText.trim();

--- a/src/services/ai/chat.ts
+++ b/src/services/ai/chat.ts
@@ -1,5 +1,5 @@
 import { getProvider, loadAiConfig, parseMealPlanResponse, parsePartialEntries } from "./index";
-import { buildToolSystemPrompt, executeTool, parseToolCall } from "./tools";
+import { buildToolSystemPrompt, executeTool, parseToolCall, toolNeedsApproval } from "./tools";
 import type { AiProviderConfig, AiMealPlanEntry, ChatMessage, StreamCallbacks } from "./types";
 import type { AiToolCall, AiToolResult } from "./tools";
 
@@ -111,15 +111,80 @@ export async function sendChatMessage(opts: ChatSendOptions): Promise<void> {
     // Check if the AI wants to call a tool
     const toolCall = parseToolCall(response);
     if (toolCall) {
-        // Emit a tool-request message for the user to approve
-        const toolRequestMsg: UiChatMessage = {
+        if (toolNeedsApproval(toolCall.name)) {
+            // Emit a tool-request message for the user to approve
+            const toolRequestMsg: UiChatMessage = {
+                id: nextId(),
+                role: "tool-request",
+                content: `Wants to use: **${toolCall.name}**`,
+                toolCall,
+                timestamp: Date.now(),
+            };
+            opts.onMessage(toolRequestMsg);
+            return;
+        }
+
+        // Auto-execute tools that don't need approval
+        const result = executeTool(toolCall);
+        const toolResultMsg: UiChatMessage = {
             id: nextId(),
-            role: "tool-request",
-            content: `Wants to use: **${toolCall.name}**`,
-            toolCall,
+            role: "tool-result",
+            content: result.summary,
+            toolResult: result,
             timestamp: Date.now(),
         };
-        opts.onMessage(toolRequestMsg);
+        opts.onMessage(toolResultMsg);
+
+        // Feed result back to AI for a follow-up response
+        const allMessagesWithResult = [...allMessages, toolResultMsg];
+        const apiMessagesWithResult = toApiMessages(allMessagesWithResult);
+        const followUp = await callAi(config, apiMessagesWithResult, opts);
+
+        // The follow-up may itself contain another tool call
+        const followUpToolCall = parseToolCall(followUp);
+        if (followUpToolCall) {
+            if (toolNeedsApproval(followUpToolCall.name)) {
+                const toolRequestMsg: UiChatMessage = {
+                    id: nextId(),
+                    role: "tool-request",
+                    content: `Wants to use: **${followUpToolCall.name}**`,
+                    toolCall: followUpToolCall,
+                    timestamp: Date.now(),
+                };
+                opts.onMessage(toolRequestMsg);
+                return;
+            }
+
+            // Chain auto-execute for another non-approval tool
+            const result2 = executeTool(followUpToolCall);
+            const toolResultMsg2: UiChatMessage = {
+                id: nextId(),
+                role: "tool-result",
+                content: result2.summary,
+                toolResult: result2,
+                timestamp: Date.now(),
+            };
+            opts.onMessage(toolResultMsg2);
+
+            const apiMessages3 = toApiMessages([...allMessagesWithResult, toolResultMsg2]);
+            const finalResponse = await callAi(config, apiMessages3, opts);
+            const finalMsg: UiChatMessage = {
+                id: nextId(),
+                role: "assistant",
+                content: finalResponse,
+                timestamp: Date.now(),
+            };
+            opts.onMessage(finalMsg);
+            return;
+        }
+
+        const followUpMsg: UiChatMessage = {
+            id: nextId(),
+            role: "assistant",
+            content: followUp,
+            timestamp: Date.now(),
+        };
+        opts.onMessage(followUpMsg);
         return;
     }
 

--- a/src/services/ai/tools.ts
+++ b/src/services/ai/tools.ts
@@ -1,4 +1,18 @@
-import { addEntry, getAllFoods, getAllRecipes, getGoals, getRecipeItems } from "@/src/db/queries";
+import {
+    addEntry,
+    deleteEntry,
+    getAllFoods,
+    getAllRecipes,
+    getEntriesByDate,
+    getEntryById,
+    getFoodById,
+    getGoals,
+    getRecipeItems,
+    searchFoodsByName,
+    searchRecipesByName,
+    updateEntry,
+} from "@/src/db/queries";
+import { formatDateKey, parseDateKey } from "@/src/utils/date";
 import logger from "@/src/utils/logger";
 import { buildMealPlanPrompt } from "./index";
 import type { AiFoodPayload, AiGoalsPayload, AiMealPlanEntry, AiRecipePayload } from "./types";
@@ -16,6 +30,8 @@ export interface ToolParameterProperty {
 export interface AiToolDefinition {
     name: string;
     description: string;
+    /** Whether the tool requires user approval before execution. Defaults to true. */
+    needsApproval: boolean;
     parameters: {
         type: "object";
         properties: Record<string, ToolParameterProperty>;
@@ -38,11 +54,14 @@ export interface AiToolResult {
 
 // ── Tool definitions ──────────────────────────────────────
 
+const VALID_MEAL_TYPES = ["breakfast", "lunch", "dinner", "snack"] as const;
+
 const createMealPlanTool: AiToolDefinition = {
     name: "create_meal_plan",
     description:
         "Generate a meal plan for the user based on their food library, macro goals, and preferences. " +
         "The plan entries will be added as scheduled entries to the user's log.",
+    needsApproval: true,
     parameters: {
         type: "object",
         properties: {
@@ -63,7 +82,149 @@ const createMealPlanTool: AiToolDefinition = {
     },
 };
 
-export const AI_TOOLS: AiToolDefinition[] = [createMealPlanTool];
+const readEntriesTool: AiToolDefinition = {
+    name: "read_entries",
+    description:
+        "Read all food log entries for a specific date. Returns entry IDs, food names, quantities, meal types, and macro totals. " +
+        "Use this to answer questions about what the user ate on a given day.",
+    needsApproval: false,
+    parameters: {
+        type: "object",
+        properties: {
+            date: {
+                type: "string",
+                description: "The date to read entries for, in YYYY-MM-DD format.",
+            },
+        },
+        required: ["date"],
+    },
+};
+
+const createEntryTool: AiToolDefinition = {
+    name: "create_entry",
+    description:
+        "Log a food entry to the user's diary. Requires a valid food_id from the user's food library. " +
+        "Use search_templates first to find the correct food_id.",
+    needsApproval: true,
+    parameters: {
+        type: "object",
+        properties: {
+            food_id: {
+                type: "number",
+                description: "The ID of the food from the user's library.",
+            },
+            quantity_grams: {
+                type: "number",
+                description: "Amount in grams.",
+            },
+            date: {
+                type: "string",
+                description: "The date for the entry, in YYYY-MM-DD format.",
+            },
+            meal_type: {
+                type: "string",
+                description: "The meal type.",
+                enum: ["breakfast", "lunch", "dinner", "snack"],
+            },
+        },
+        required: ["food_id", "quantity_grams", "date", "meal_type"],
+    },
+};
+
+const moveEntryTool: AiToolDefinition = {
+    name: "move_entry",
+    description:
+        "Move an existing food log entry to a different date and/or meal type. " +
+        "Use read_entries first to get the entry_id.",
+    needsApproval: true,
+    parameters: {
+        type: "object",
+        properties: {
+            entry_id: {
+                type: "number",
+                description: "The ID of the entry to move.",
+            },
+            target_date: {
+                type: "string",
+                description: "The new date in YYYY-MM-DD format. Omit to keep current date.",
+            },
+            target_meal_type: {
+                type: "string",
+                description: "The new meal type. Omit to keep current meal type.",
+                enum: ["breakfast", "lunch", "dinner", "snack"],
+            },
+        },
+        required: ["entry_id"],
+    },
+};
+
+const updateEntryTool: AiToolDefinition = {
+    name: "update_entry",
+    description:
+        "Update the quantity of an existing food log entry. " +
+        "Use read_entries first to get the entry_id.",
+    needsApproval: true,
+    parameters: {
+        type: "object",
+        properties: {
+            entry_id: {
+                type: "number",
+                description: "The ID of the entry to update.",
+            },
+            quantity_grams: {
+                type: "number",
+                description: "The new amount in grams.",
+            },
+        },
+        required: ["entry_id", "quantity_grams"],
+    },
+};
+
+const removeEntryTool: AiToolDefinition = {
+    name: "remove_entry",
+    description:
+        "Remove a food log entry from the user's diary. " +
+        "Use read_entries first to get the entry_id.",
+    needsApproval: true,
+    parameters: {
+        type: "object",
+        properties: {
+            entry_id: {
+                type: "number",
+                description: "The ID of the entry to remove.",
+            },
+        },
+        required: ["entry_id"],
+    },
+};
+
+const searchTemplatesTool: AiToolDefinition = {
+    name: "search_templates",
+    description:
+        "Search the user's food library and recipes by name. Returns matching foods with their IDs, macros, and serving info. " +
+        "Use this to find food_id values before creating entries.",
+    needsApproval: false,
+    parameters: {
+        type: "object",
+        properties: {
+            query: {
+                type: "string",
+                description: "Search term to match against food and recipe names.",
+            },
+        },
+        required: ["query"],
+    },
+};
+
+export const AI_TOOLS: AiToolDefinition[] = [
+    createMealPlanTool,
+    readEntriesTool,
+    createEntryTool,
+    moveEntryTool,
+    updateEntryTool,
+    removeEntryTool,
+    searchTemplatesTool,
+];
 
 // ── Tool registry (name → executor) ──────────────────────
 
@@ -135,11 +296,216 @@ function executeCreateMealPlan(args: Record<string, unknown>): AiToolResult {
     };
 }
 
+function isValidDateKey(date: string): boolean {
+    return /^\d{4}-\d{2}-\d{2}$/.test(date) && !isNaN(parseDateKey(date).getTime());
+}
+
+function isValidMealType(meal: unknown): meal is typeof VALID_MEAL_TYPES[number] {
+    return typeof meal === "string" && VALID_MEAL_TYPES.includes(meal as any);
+}
+
+function executeReadEntries(args: Record<string, unknown>): AiToolResult {
+    const date = String(args.date ?? "");
+    if (!isValidDateKey(date)) {
+        return { success: false, summary: "Invalid date format. Use YYYY-MM-DD." };
+    }
+
+    const rows = getEntriesByDate(parseDateKey(date));
+    const result = rows.map((row) => ({
+        entry_id: row.entries.id,
+        food_id: row.entries.food_id,
+        food_name: row.foods?.name ?? "Unknown",
+        quantity_grams: row.entries.quantity_grams,
+        quantity_unit: row.entries.quantity_unit,
+        meal_type: row.entries.meal_type,
+        is_scheduled: row.entries.is_scheduled,
+        calories: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.calories_per_100g).toFixed(1) : 0,
+        protein: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.protein_per_100g).toFixed(1) : 0,
+        carbs: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.carbs_per_100g).toFixed(1) : 0,
+        fat: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.fat_per_100g).toFixed(1) : 0,
+    }));
+
+    return {
+        success: true,
+        summary: `Found ${result.length} entries for ${date}.`,
+        data: result,
+    };
+}
+
+function executeCreateEntry(args: Record<string, unknown>): AiToolResult {
+    const foodId = Number(args.food_id);
+    const quantityGrams = Number(args.quantity_grams);
+    const date = String(args.date ?? "");
+    const mealType = String(args.meal_type ?? "");
+
+    if (!foodId || isNaN(foodId)) {
+        return { success: false, summary: "Invalid food_id." };
+    }
+    if (!quantityGrams || quantityGrams <= 0) {
+        return { success: false, summary: "quantity_grams must be a positive number." };
+    }
+    if (!isValidDateKey(date)) {
+        return { success: false, summary: "Invalid date format. Use YYYY-MM-DD." };
+    }
+    if (!isValidMealType(mealType)) {
+        return { success: false, summary: `Invalid meal_type. Must be one of: ${VALID_MEAL_TYPES.join(", ")}.` };
+    }
+
+    const food = getFoodById(foodId);
+    if (!food) {
+        return { success: false, summary: `Food with id ${foodId} not found. Use search_templates to find valid food IDs.` };
+    }
+
+    const entry = addEntry({
+        food_id: foodId,
+        quantity_grams: quantityGrams,
+        quantity_unit: "g",
+        timestamp: Date.now(),
+        date,
+        meal_type: mealType,
+    });
+
+    return {
+        success: true,
+        summary: `Added ${quantityGrams}g of "${food.name}" to ${mealType} on ${date}.`,
+        data: { entry_id: entry.id, food_name: food.name, quantity_grams: quantityGrams, date, meal_type: mealType },
+    };
+}
+
+function executeMoveEntry(args: Record<string, unknown>): AiToolResult {
+    const entryId = Number(args.entry_id);
+    const targetDate = args.target_date != null ? String(args.target_date) : undefined;
+    const targetMealType = args.target_meal_type != null ? String(args.target_meal_type) : undefined;
+
+    if (!entryId || isNaN(entryId)) {
+        return { success: false, summary: "Invalid entry_id." };
+    }
+    if (!targetDate && !targetMealType) {
+        return { success: false, summary: "Provide at least target_date or target_meal_type." };
+    }
+    if (targetDate && !isValidDateKey(targetDate)) {
+        return { success: false, summary: "Invalid target_date format. Use YYYY-MM-DD." };
+    }
+    if (targetMealType && !isValidMealType(targetMealType)) {
+        return { success: false, summary: `Invalid target_meal_type. Must be one of: ${VALID_MEAL_TYPES.join(", ")}.` };
+    }
+
+    const row = getEntryById(entryId);
+    if (!row) {
+        return { success: false, summary: `Entry with id ${entryId} not found. Use read_entries to find valid entry IDs.` };
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (targetDate) updates.date = targetDate;
+    if (targetMealType) updates.meal_type = targetMealType;
+    updateEntry(entryId, updates);
+
+    const newDate = targetDate ?? row.entries.date;
+    const newMeal = targetMealType ?? row.entries.meal_type;
+
+    return {
+        success: true,
+        summary: `Moved entry ${entryId} ("${row.foods?.name ?? "Unknown"}") to ${newMeal} on ${newDate}.`,
+        data: { entry_id: entryId, food_name: row.foods?.name, date: newDate, meal_type: newMeal },
+    };
+}
+
+function executeUpdateEntry(args: Record<string, unknown>): AiToolResult {
+    const entryId = Number(args.entry_id);
+    const quantityGrams = Number(args.quantity_grams);
+
+    if (!entryId || isNaN(entryId)) {
+        return { success: false, summary: "Invalid entry_id." };
+    }
+    if (!quantityGrams || quantityGrams <= 0) {
+        return { success: false, summary: "quantity_grams must be a positive number." };
+    }
+
+    const row = getEntryById(entryId);
+    if (!row) {
+        return { success: false, summary: `Entry with id ${entryId} not found. Use read_entries to find valid entry IDs.` };
+    }
+
+    updateEntry(entryId, { quantity_grams: quantityGrams });
+
+    return {
+        success: true,
+        summary: `Updated entry ${entryId} ("${row.foods?.name ?? "Unknown"}") to ${quantityGrams}g.`,
+        data: { entry_id: entryId, food_name: row.foods?.name, quantity_grams: quantityGrams },
+    };
+}
+
+function executeRemoveEntry(args: Record<string, unknown>): AiToolResult {
+    const entryId = Number(args.entry_id);
+
+    if (!entryId || isNaN(entryId)) {
+        return { success: false, summary: "Invalid entry_id." };
+    }
+
+    const row = getEntryById(entryId);
+    if (!row) {
+        return { success: false, summary: `Entry with id ${entryId} not found. Use read_entries to find valid entry IDs.` };
+    }
+
+    deleteEntry(entryId);
+
+    return {
+        success: true,
+        summary: `Removed entry ${entryId} ("${row.foods?.name ?? "Unknown"}", ${row.entries.quantity_grams}g from ${row.entries.meal_type} on ${row.entries.date}).`,
+        data: { entry_id: entryId, food_name: row.foods?.name },
+    };
+}
+
+function executeSearchTemplates(args: Record<string, unknown>): AiToolResult {
+    const query = String(args.query ?? "").trim();
+    if (!query) {
+        return { success: false, summary: "Search query cannot be empty." };
+    }
+
+    const matchedFoods = searchFoodsByName(query).map((f) => ({
+        type: "food" as const,
+        id: f.id,
+        name: f.name,
+        calories_per_100g: f.calories_per_100g,
+        protein_per_100g: f.protein_per_100g,
+        carbs_per_100g: f.carbs_per_100g,
+        fat_per_100g: f.fat_per_100g,
+        default_unit: f.default_unit,
+        serving_size: f.serving_size,
+    }));
+
+    const matchedRecipes = searchRecipesByName(query).map((r) => ({
+        type: "recipe" as const,
+        id: r.id,
+        name: r.name,
+    }));
+
+    const results = [...matchedFoods, ...matchedRecipes];
+
+    return {
+        success: true,
+        summary: `Found ${matchedFoods.length} food(s) and ${matchedRecipes.length} recipe(s) matching "${query}".`,
+        data: results,
+    };
+}
+
 const toolExecutors: Record<string, ToolExecutor> = {
     create_meal_plan: executeCreateMealPlan,
+    read_entries: executeReadEntries,
+    create_entry: executeCreateEntry,
+    move_entry: executeMoveEntry,
+    update_entry: executeUpdateEntry,
+    remove_entry: executeRemoveEntry,
+    search_templates: executeSearchTemplates,
 };
 
 // ── Public API ────────────────────────────────────────────
+
+/** Check whether a tool requires user approval before execution. */
+export function toolNeedsApproval(toolName: string): boolean {
+    const tool = AI_TOOLS.find((t) => t.name === toolName);
+    return tool?.needsApproval ?? true;
+}
 
 /** Execute a tool by name. Returns the result synchronously. */
 export function executeTool(call: AiToolCall): AiToolResult {
@@ -178,19 +544,25 @@ export function importMealPlanEntries(entries: AiMealPlanEntry[]): number {
 
 /** Build the system prompt describing available tools. */
 export function buildToolSystemPrompt(): string {
+    const today = formatDateKey(new Date());
+
     const toolDescriptions = AI_TOOLS.map((tool) => {
         const params = Object.entries(tool.parameters.properties)
             .map(([name, prop]) => {
                 const req = tool.parameters.required.includes(name) ? " (required)" : " (optional)";
-                return `    - ${name}${req}: ${prop.description}`;
+                const enumStr = prop.enum ? ` [${prop.enum.join(", ")}]` : "";
+                return `    - ${name}${req}: ${prop.description}${enumStr}`;
             })
             .join("\n");
-        return `Tool: ${tool.name}\n  Description: ${tool.description}\n  Parameters:\n${params}`;
+        const approval = tool.needsApproval ? "Requires user approval." : "Runs automatically.";
+        return `Tool: ${tool.name}\n  Description: ${tool.description}\n  ${approval}\n  Parameters:\n${params}`;
     }).join("\n\n");
 
     return [
         "You are a helpful nutrition and meal planning assistant inside a food tracking app called MacroFlow.",
         "You can help users with their diet by using available tools.",
+        "",
+        `TODAY'S DATE: ${today}`,
         "",
         "AVAILABLE TOOLS:",
         toolDescriptions,
@@ -207,6 +579,9 @@ export function buildToolSystemPrompt(): string {
         "- If you don't need a tool, just respond normally in plain text.",
         "- Be concise and helpful. Use the user's language when possible.",
         "- When a meal plan is generated, briefly summarize what was created.",
+        "- Before creating an entry, ALWAYS use search_templates first to find the correct food_id. Never guess IDs.",
+        "- Before modifying or removing an entry, ALWAYS use read_entries first to find the correct entry_id.",
+        "- When the user says 'today', use the date provided above. Calculate other relative dates from it.",
     ].join("\n");
 }
 


### PR DESCRIPTION
## Summary

Adds 6 new AI tools for managing food log entries via the chat interface.

### New tools

| Tool | Approval | Description |
|------|----------|-------------|
| `read_entries` | Auto | Read all entries for a given date |
| `search_templates` | Auto | Search foods & recipes by name |
| `create_entry` | Required | Log a food entry |
| `move_entry` | Required | Move entry to different date/meal |
| `update_entry` | Required | Update entry quantity |
| `remove_entry` | Required | Delete an entry |

### Key design decisions

- **Input validation**: All tools verify AI-provided inputs (IDs exist, dates are valid, meal types are valid) to guard against hallucinated values
- **Approval flow**: Non-destructive tools (read, search) auto-execute and feed results back to AI. Destructive tools require user approval via the existing approve/deny UI
- **Tool chaining**: Auto-executed tools support up to 2 chained calls (e.g. search → create) so the AI can look up a food ID and then request to log it
- **Date context**: System prompt now includes today's date so the AI can resolve relative dates ('today', 'yesterday')
- **Data change notifications**: UI is notified via `onDataChanged` whenever any tool modifies log data

### Files changed

- `src/services/ai/tools.ts` — Tool definitions, executors, updated system prompt
- `src/services/ai/chat.ts` — Auto-execute logic for non-approval tools
- `src/features/log/AiChatOverlay.tsx` — Data change detection in message handler
- `src/db/queries.ts` — Added `getEntryById` query helper

Closes #142