### PR TITLE
Improve AI tool calling reliability

### DIFF
--- a/src/features/ai/MealPlanScreen.tsx
+++ b/src/features/ai/MealPlanScreen.tsx
@@ -125,7 +125,7 @@ export default function MealPlanScreen() {
             let raw: string;
 
             if (provider.supportsStreaming && provider.chatStream) {
-                raw = await provider.chatStream(
+                const response = await provider.chatStream(
                     config,
                     messages,
                     {
@@ -138,11 +138,13 @@ export default function MealPlanScreen() {
                             }
                         },
                     },
-                    abort.signal,
+                    { signal: abort.signal },
                 );
+                raw = response.type === "text" ? response.content : "";
             } else {
                 setStreamStatus("connecting");
-                raw = await provider.chat(config, messages);
+                const response = await provider.chat(config, messages);
+                raw = response.type === "text" ? response.content : "";
             }
 
             // Final parse with the complete response

--- a/src/features/log/AiChatOverlay.tsx
+++ b/src/features/log/AiChatOverlay.tsx
@@ -57,6 +57,7 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
     const [loading, setLoading] = useState(false);
     const [streamingText, setStreamingText] = useState("");
     const [pendingToolCall, setPendingToolCall] = useState<AiToolCall | null>(null);
+    const [pendingToolCallId, setPendingToolCallId] = useState<string | undefined>(undefined);
     const [streamingToolData, setStreamingToolData] = useState<AiMealPlanEntry[] | null>(null);
 
     const scrollRef = useRef<ScrollView>(null);
@@ -109,6 +110,7 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
     const addMessage = useCallback((msg: UiChatMessage) => {
         if (msg.role === "tool-request" && msg.toolCall) {
             setPendingToolCall(msg.toolCall);
+            setPendingToolCallId(msg.toolCallId);
         }
         // Notify parent when a data-modifying tool executed successfully
         if (msg.role === "tool-result" && msg.toolResult?.success) {
@@ -156,7 +158,9 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
         if (!pendingToolCall || loading) return;
 
         const toolCall = pendingToolCall;
+        const toolCallId = pendingToolCallId;
         setPendingToolCall(null);
+        setPendingToolCallId(undefined);
         setLoading(true);
         setStreamingText("");
         const abort = new AbortController();
@@ -166,6 +170,7 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
             await executeApprovedTool({
                 messages: messagesRef.current,
                 toolCall,
+                toolCallId,
                 onMessage: addMessage,
                 onStreamToken: (accumulated) => setStreamingText(accumulated),
                 onStreamingToolData: (data) => {
@@ -189,13 +194,15 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
             setStreamingToolData(null);
             abortRef.current = null;
         }
-    }, [pendingToolCall, loading, addMessage, t]);
+    }, [pendingToolCall, pendingToolCallId, loading, addMessage, t]);
 
     const handleDeclineTool = useCallback(async () => {
         if (!pendingToolCall || loading) return;
 
         const toolCall = pendingToolCall;
+        const toolCallId = pendingToolCallId;
         setPendingToolCall(null);
+        setPendingToolCallId(undefined);
         setLoading(true);
         setStreamingText("");
         const abort = new AbortController();
@@ -205,6 +212,7 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
             await declineToolCall({
                 messages: messagesRef.current,
                 toolCall,
+                toolCallId,
                 onMessage: addMessage,
                 onStreamToken: (accumulated) => setStreamingText(accumulated),
                 signal: abort.signal,
@@ -222,7 +230,7 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
             setStreamingText("");
             abortRef.current = null;
         }
-    }, [pendingToolCall, loading, addMessage, t]);
+    }, [pendingToolCall, pendingToolCallId, loading, addMessage, t]);
 
     // Handle meal plan import from tool result
     const handleMealPlanImport = useCallback((msgId: string) => {

--- a/src/services/ai/chat.ts
+++ b/src/services/ai/chat.ts
@@ -1,6 +1,6 @@
 import { getProvider, loadAiConfig, parseMealPlanResponse, parsePartialEntries } from "./index";
-import { buildToolSystemPrompt, executeTool, parseToolCall, toolNeedsApproval } from "./tools";
-import type { AiProviderConfig, AiMealPlanEntry, ChatMessage, StreamCallbacks } from "./types";
+import { buildNativeToolSystemPrompt, buildToolSystemPrompt, executeTool, parseToolCall, toOpenAiTools, toolNeedsApproval } from "./tools";
+import type { AiChatResponse, AiProviderConfig, AiMealPlanEntry, ChatMessage, StreamCallbacks } from "./types";
 import type { AiToolCall, AiToolResult } from "./tools";
 
 // ── Chat message types for the UI ─────────────────────────
@@ -23,6 +23,8 @@ export interface UiChatMessage {
     toolResult?: AiToolResult;
     /** Structured data for tool result UI (e.g. meal plan entries) */
     toolResultData?: ToolResultData;
+    /** Native tool_call ID from the API (used to build proper tool role messages) */
+    toolCallId?: string;
     /** Timestamp */
     timestamp: number;
 }
@@ -47,6 +49,8 @@ interface ToolApprovalOptions {
     onStreamToken?: (accumulated: string) => void;
     onStreamingToolData?: (data: ToolResultData) => void;
     signal?: AbortSignal;
+    /** Native tool_call ID if this approval came from native tool calling */
+    toolCallId?: string;
 }
 
 let msgCounter = 0;
@@ -54,8 +58,18 @@ function nextId(): string {
     return `msg_${Date.now()}_${++msgCounter}`;
 }
 
-/** Convert UI messages to API-compatible ChatMessage array. */
-function toApiMessages(uiMessages: UiChatMessage[]): ChatMessage[] {
+/** Format tool result content for the AI, including data payload. */
+function formatToolResultForAi(msg: UiChatMessage): string {
+    const summary = msg.content;
+    const data = msg.toolResult?.data;
+    if (data != null) {
+        return `${summary}\n${JSON.stringify(data)}`;
+    }
+    return summary;
+}
+
+/** Convert UI messages to API-compatible ChatMessage array for prompt-based (fallback) tool calling. */
+function toFallbackApiMessages(uiMessages: UiChatMessage[]): ChatMessage[] {
     const systemMsg: ChatMessage = {
         role: "system",
         content: buildToolSystemPrompt(),
@@ -75,7 +89,7 @@ function toApiMessages(uiMessages: UiChatMessage[]): ChatMessage[] {
             case "tool-result":
                 return {
                     role: "user" as const,
-                    content: `Tool result: ${m.content}`,
+                    content: `Tool result: ${formatToolResultForAi(m)}`,
                 };
             default:
                 return { role: "user" as const, content: m.content };
@@ -83,6 +97,90 @@ function toApiMessages(uiMessages: UiChatMessage[]): ChatMessage[] {
     });
 
     return [systemMsg, ...history];
+}
+
+/** Convert UI messages to API-compatible ChatMessage array for native tool calling. */
+function toNativeApiMessages(uiMessages: UiChatMessage[]): ChatMessage[] {
+    const systemMsg: ChatMessage = {
+        role: "system",
+        content: buildNativeToolSystemPrompt(),
+    };
+
+    const history: ChatMessage[] = [];
+    for (const m of uiMessages) {
+        switch (m.role) {
+            case "user":
+                history.push({ role: "user", content: m.content });
+                break;
+            case "assistant":
+                history.push({ role: "assistant", content: m.content });
+                break;
+            case "tool-request":
+                // Represent as an assistant message with tool_calls (OpenAI format)
+                if (m.toolCallId && m.toolCall) {
+                    history.push({
+                        role: "assistant",
+                        content: "",
+                        tool_calls: [{
+                            id: m.toolCallId,
+                            type: "function",
+                            function: {
+                                name: m.toolCall.name,
+                                arguments: JSON.stringify(m.toolCall.arguments),
+                            },
+                        }],
+                    });
+                } else {
+                    history.push({ role: "assistant", content: `I want to use the tool: ${m.toolCall?.name}` });
+                }
+                break;
+            case "tool-result":
+                // Use the tool role with tool_call_id if available (native), otherwise fall back
+                if (m.toolCallId) {
+                    // Ensure there's a preceding assistant(tool_calls) message.
+                    // Auto-executed tools don't emit a tool-request to the UI, so we
+                    // synthesize the required assistant message from the stored toolCall.
+                    const prev = history[history.length - 1];
+                    const hasPrecedingToolCalls = prev?.role === "assistant" && "tool_calls" in prev;
+                    if (!hasPrecedingToolCalls && m.toolCall) {
+                        history.push({
+                            role: "assistant",
+                            content: "",
+                            tool_calls: [{
+                                id: m.toolCallId,
+                                type: "function",
+                                function: {
+                                    name: m.toolCall.name,
+                                    arguments: JSON.stringify(m.toolCall.arguments),
+                                },
+                            }],
+                        });
+                    }
+                    history.push({
+                        role: "tool",
+                        content: formatToolResultForAi(m),
+                        tool_call_id: m.toolCallId,
+                    });
+                } else {
+                    history.push({ role: "user", content: `Tool result: ${formatToolResultForAi(m)}` });
+                }
+                break;
+            default:
+                history.push({ role: "user", content: m.content });
+        }
+    }
+
+    return [systemMsg, ...history];
+}
+
+/** Extract an AiToolCall from an AiChatResponse if it's a tool_call. */
+function responseToToolCall(response: AiChatResponse): (AiToolCall & { toolCallId?: string }) | null {
+    if (response.type !== "tool_call") return null;
+    return {
+        name: response.name,
+        arguments: response.arguments,
+        toolCallId: response.id,
+    };
 }
 
 /** Send a user message and get the AI response. May trigger a tool call. */
@@ -103,21 +201,23 @@ export async function sendChatMessage(opts: ChatSendOptions): Promise<void> {
 
     // Build API messages from history + new user message
     const allMessages = [...opts.messages, userMsg];
-    const apiMessages = toApiMessages(allMessages);
+    const provider = getProvider(config.provider);
+    const useNative = !!provider.supportsToolCalling;
+    const apiMessages = useNative ? toNativeApiMessages(allMessages) : toFallbackApiMessages(allMessages);
 
-    // Call the AI
-    const response = await callAi(config, apiMessages, opts);
+    // Call the AI (with tools if supported)
+    const response = await callAi(config, apiMessages, opts, useNative);
 
     // Check if the AI wants to call a tool
-    const toolCall = parseToolCall(response);
+    const toolCall = responseToToolCall(response);
     if (toolCall) {
         if (toolNeedsApproval(toolCall.name)) {
-            // Emit a tool-request message for the user to approve
             const toolRequestMsg: UiChatMessage = {
                 id: nextId(),
                 role: "tool-request",
                 content: `Wants to use: **${toolCall.name}**`,
                 toolCall,
+                toolCallId: toolCall.toolCallId,
                 timestamp: Date.now(),
             };
             opts.onMessage(toolRequestMsg);
@@ -126,22 +226,38 @@ export async function sendChatMessage(opts: ChatSendOptions): Promise<void> {
 
         // Auto-execute tools that don't need approval
         const result = executeTool(toolCall);
+
+        // For native tool calling, the API requires an assistant message with tool_calls
+        // before the tool result. Create a synthetic tool-request (not shown in UI).
+        const syntheticToolRequest: UiChatMessage = {
+            id: nextId(),
+            role: "tool-request",
+            content: "",
+            toolCall,
+            toolCallId: toolCall.toolCallId,
+            timestamp: Date.now(),
+        };
+
         const toolResultMsg: UiChatMessage = {
             id: nextId(),
             role: "tool-result",
             content: result.summary,
             toolResult: result,
+            toolCall,
+            toolCallId: toolCall.toolCallId,
             timestamp: Date.now(),
         };
         opts.onMessage(toolResultMsg);
 
         // Feed result back to AI for a follow-up response
-        const allMessagesWithResult = [...allMessages, toolResultMsg];
-        const apiMessagesWithResult = toApiMessages(allMessagesWithResult);
-        const followUp = await callAi(config, apiMessagesWithResult, opts);
+        const allMessagesWithResult = [...allMessages, syntheticToolRequest, toolResultMsg];
+        const apiMessagesWithResult = useNative
+            ? toNativeApiMessages(allMessagesWithResult)
+            : toFallbackApiMessages(allMessagesWithResult);
+        const followUp = await callAi(config, apiMessagesWithResult, opts, useNative);
 
         // The follow-up may itself contain another tool call
-        const followUpToolCall = parseToolCall(followUp);
+        const followUpToolCall = responseToToolCall(followUp);
         if (followUpToolCall) {
             if (toolNeedsApproval(followUpToolCall.name)) {
                 const toolRequestMsg: UiChatMessage = {
@@ -149,6 +265,7 @@ export async function sendChatMessage(opts: ChatSendOptions): Promise<void> {
                     role: "tool-request",
                     content: `Wants to use: **${followUpToolCall.name}**`,
                     toolCall: followUpToolCall,
+                    toolCallId: followUpToolCall.toolCallId,
                     timestamp: Date.now(),
                 };
                 opts.onMessage(toolRequestMsg);
@@ -157,31 +274,48 @@ export async function sendChatMessage(opts: ChatSendOptions): Promise<void> {
 
             // Chain auto-execute for another non-approval tool
             const result2 = executeTool(followUpToolCall);
+
+            const syntheticToolRequest2: UiChatMessage = {
+                id: nextId(),
+                role: "tool-request",
+                content: "",
+                toolCall: followUpToolCall,
+                toolCallId: followUpToolCall.toolCallId,
+                timestamp: Date.now(),
+            };
+
             const toolResultMsg2: UiChatMessage = {
                 id: nextId(),
                 role: "tool-result",
                 content: result2.summary,
                 toolResult: result2,
+                toolCall: followUpToolCall,
+                toolCallId: followUpToolCall.toolCallId,
                 timestamp: Date.now(),
             };
             opts.onMessage(toolResultMsg2);
 
-            const apiMessages3 = toApiMessages([...allMessagesWithResult, toolResultMsg2]);
-            const finalResponse = await callAi(config, apiMessages3, opts);
+            const allMessages3 = [...allMessagesWithResult, syntheticToolRequest2, toolResultMsg2];
+            const apiMessages3 = useNative
+                ? toNativeApiMessages(allMessages3)
+                : toFallbackApiMessages(allMessages3);
+            const finalResponse = await callAi(config, apiMessages3, opts, useNative);
+            const finalContent = finalResponse.type === "text" ? finalResponse.content : "";
             const finalMsg: UiChatMessage = {
                 id: nextId(),
                 role: "assistant",
-                content: finalResponse,
+                content: finalContent,
                 timestamp: Date.now(),
             };
             opts.onMessage(finalMsg);
             return;
         }
 
+        const followUpContent = followUp.type === "text" ? followUp.content : "";
         const followUpMsg: UiChatMessage = {
             id: nextId(),
             role: "assistant",
-            content: followUp,
+            content: followUpContent,
             timestamp: Date.now(),
         };
         opts.onMessage(followUpMsg);
@@ -189,10 +323,11 @@ export async function sendChatMessage(opts: ChatSendOptions): Promise<void> {
     }
 
     // Regular text response
+    const textContent = response.type === "text" ? response.content : "";
     const assistantMsg: UiChatMessage = {
         id: nextId(),
         role: "assistant",
-        content: response,
+        content: textContent,
         timestamp: Date.now(),
     };
     opts.onMessage(assistantMsg);
@@ -223,8 +358,8 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
         if (planData.type === "meal_plan_request") {
             const validIds = new Set(planData.validFoodIds);
 
-            // Make a separate AI call; stream partial entries to the UI
-            const planResponse = await callAi(config, planData.messages, {
+            // Make a separate AI call WITHOUT tools (expects pure JSON output)
+            const planResponse = await callAiRaw(config, planData.messages, {
                 ...opts,
                 onStreamToken: (accumulated) => {
                     // Parse partial entries and forward to UI for live preview
@@ -245,6 +380,7 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
                     content: `Meal plan generated with ${plan.entries.length} entries. Review below:`,
                     toolResult: { success: true, summary: `${plan.entries.length} entries ready` },
                     toolResultData: { mealPlanEntries: plan.entries },
+                    toolCallId: opts.toolCallId,
                     timestamp: Date.now(),
                 };
                 opts.onMessage(toolResultMsg);
@@ -255,6 +391,7 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
                     role: "tool-result",
                     content: `Failed to parse meal plan: ${e.message}`,
                     toolResult: { success: false, summary: e.message },
+                    toolCallId: opts.toolCallId,
                     timestamp: Date.now(),
                 };
                 opts.onMessage(errorMsg);
@@ -269,6 +406,7 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
         role: "tool-result",
         content: result.summary,
         toolResult: result,
+        toolCallId: opts.toolCallId,
         timestamp: Date.now(),
     };
     opts.onMessage(toolResultMsg);
@@ -276,14 +414,17 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
     if (!result.success) return;
 
     // Feed result back to AI for a follow-up response
+    const provider = getProvider(config.provider);
+    const useNative = !!provider.supportsToolCalling;
     const allMessages = [...opts.messages, toolResultMsg];
-    const apiMessages = toApiMessages(allMessages);
+    const apiMessages = useNative ? toNativeApiMessages(allMessages) : toFallbackApiMessages(allMessages);
 
-    const followUp = await callAi(config, apiMessages, opts);
+    const followUp = await callAi(config, apiMessages, opts, useNative);
+    const followUpContent = followUp.type === "text" ? followUp.content : "";
     const followUpMsg: UiChatMessage = {
         id: nextId(),
         role: "assistant",
-        content: followUp,
+        content: followUpContent,
         timestamp: Date.now(),
     };
     opts.onMessage(followUpMsg);
@@ -301,30 +442,84 @@ export async function declineToolCall(opts: ToolApprovalOptions): Promise<void> 
         role: "tool-result",
         content: "The user declined this action.",
         toolResult: { success: false, summary: "User declined" },
+        toolCallId: opts.toolCallId,
         timestamp: Date.now(),
     };
     opts.onMessage(declineMsg);
 
+    const provider = getProvider(config.provider);
+    const useNative = !!provider.supportsToolCalling;
     const allMessages = [...opts.messages, declineMsg];
-    const apiMessages = toApiMessages(allMessages);
+    const apiMessages = useNative ? toNativeApiMessages(allMessages) : toFallbackApiMessages(allMessages);
     apiMessages.push({
         role: "user",
         content: "I declined the tool use. Please suggest an alternative or ask what I'd like instead.",
     });
 
-    const followUp = await callAi(config, apiMessages, opts);
+    const followUp = await callAi(config, apiMessages, opts, useNative);
+    const followUpContent = followUp.type === "text" ? followUp.content : "";
     const followUpMsg: UiChatMessage = {
         id: nextId(),
         role: "assistant",
-        content: followUp,
+        content: followUpContent,
         timestamp: Date.now(),
     };
     opts.onMessage(followUpMsg);
 }
 
-// ── Internal helper ───────────────────────────────────────
+// ── Internal helpers ──────────────────────────────────────
 
+/**
+ * Call the AI with optional tool support. Returns a structured AiChatResponse.
+ * - Native: passes tools to the API, returns structured tool_call or text.
+ * - Fallback: uses prompt-based system message, parses text for tool calls.
+ */
 async function callAi(
+    config: AiProviderConfig,
+    messages: ChatMessage[],
+    opts: { onStreamStatus?: (s: string) => void; onStreamToken?: (t: string) => void; signal?: AbortSignal },
+    useNativeTools: boolean,
+): Promise<AiChatResponse> {
+    const provider = getProvider(config.provider);
+    const tools = useNativeTools ? toOpenAiTools() : undefined;
+    const chatOptions = { tools, signal: opts.signal };
+
+    if (provider.supportsStreaming && provider.chatStream) {
+        const callbacks: StreamCallbacks = {
+            onStatus: (status) => opts.onStreamStatus?.(status),
+            onToken: (accumulated) => opts.onStreamToken?.(accumulated),
+        };
+        const response = await provider.chatStream(config, messages, callbacks, chatOptions);
+
+        // For fallback mode, check if the text response contains a tool call
+        if (!useNativeTools && response.type === "text") {
+            const parsed = parseToolCall(response.content);
+            if (parsed) {
+                return { type: "tool_call", id: `fallback_${Date.now()}`, name: parsed.name, arguments: parsed.arguments };
+            }
+        }
+        return response;
+    }
+
+    opts.onStreamStatus?.("connecting");
+    const response = await provider.chat(config, messages, chatOptions);
+    opts.onStreamStatus?.("done");
+
+    // For fallback mode, check if the text response contains a tool call
+    if (!useNativeTools && response.type === "text") {
+        const parsed = parseToolCall(response.content);
+        if (parsed) {
+            return { type: "tool_call", id: `fallback_${Date.now()}`, name: parsed.name, arguments: parsed.arguments };
+        }
+    }
+    return response;
+}
+
+/**
+ * Call the AI and return raw text only (no tool support).
+ * Used for secondary calls like meal plan generation that expect pure text/JSON output.
+ */
+async function callAiRaw(
     config: AiProviderConfig,
     messages: ChatMessage[],
     opts: { onStreamStatus?: (s: string) => void; onStreamToken?: (t: string) => void; signal?: AbortSignal },
@@ -336,11 +531,12 @@ async function callAi(
             onStatus: (status) => opts.onStreamStatus?.(status),
             onToken: (accumulated) => opts.onStreamToken?.(accumulated),
         };
-        return provider.chatStream(config, messages, callbacks, opts.signal);
+        const response = await provider.chatStream(config, messages, callbacks, { signal: opts.signal });
+        return response.type === "text" ? response.content : "";
     }
 
     opts.onStreamStatus?.("connecting");
-    const result = await provider.chat(config, messages);
+    const response = await provider.chat(config, messages);
     opts.onStreamStatus?.("done");
-    return result;
+    return response.type === "text" ? response.content : "";
 }

--- a/src/services/ai/nvidia.ts
+++ b/src/services/ai/nvidia.ts
@@ -1,15 +1,34 @@
 import logger from "@/src/utils/logger";
-import type { AiProvider, AiProviderConfig, ChatMessage, StreamCallbacks } from "./types";
+import type { AiChatResponse, AiProvider, AiProviderConfig, ChatMessage, ChatOptions, StreamCallbacks } from "./types";
 
 const DEFAULT_BASE_URL = "https://integrate.api.nvidia.com/v1";
 const DEFAULT_MODEL = "meta/llama-3.1-70b-instruct";
 
+interface NvidiaToolCallPart {
+    id?: string;
+    type?: string;
+    function?: { name?: string; arguments?: string };
+}
+
 interface NvidiaChatResponse {
-    choices?: { message?: { content?: string } }[];
+    choices?: {
+        message?: {
+            content?: string | null;
+            tool_calls?: NvidiaToolCallPart[];
+        };
+        finish_reason?: string;
+    }[];
 }
 
 interface NvidiaStreamChunk {
-    choices?: { delta?: { content?: string; reasoning_content?: string } }[];
+    choices?: {
+        delta?: {
+            content?: string | null;
+            reasoning_content?: string;
+            tool_calls?: NvidiaToolCallPart[];
+        };
+        finish_reason?: string | null;
+    }[];
 }
 
 /** Try to extract a human-readable error from the API response body. */
@@ -30,15 +49,40 @@ function parseApiError(status: number, body: string): string {
     return `NVIDIA API error (${status})`;
 }
 
+/** Convert a native tool_calls response into an AiChatResponse. */
+function toolCallToResponse(tc: NvidiaToolCallPart): AiChatResponse {
+    const name = tc.function?.name ?? "";
+    const id = tc.id ?? `tc_${Date.now()}`;
+    let args: Record<string, unknown> = {};
+    try {
+        args = JSON.parse(tc.function?.arguments ?? "{}");
+    } catch {
+        logger.warn("[AI/NVIDIA] Failed to parse tool_call arguments", { raw: tc.function?.arguments });
+    }
+    return { type: "tool_call", id, name, arguments: args };
+}
+
 export const nvidiaProvider: AiProvider = {
     id: "nvidia",
     supportsStreaming: true,
+    supportsToolCalling: true,
 
-    async chat(config: AiProviderConfig, messages: ChatMessage[]): Promise<string> {
+    async chat(config: AiProviderConfig, messages: ChatMessage[], options?: ChatOptions): Promise<AiChatResponse> {
         const baseUrl = (config.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, "");
         const model = config.model || DEFAULT_MODEL;
 
-        logger.info("[AI/NVIDIA] Sending chat request", { baseUrl, model });
+        logger.info("[AI/NVIDIA] Sending chat request", { baseUrl, model, hasTools: !!options?.tools });
+
+        const body: Record<string, unknown> = {
+            model,
+            messages,
+            temperature: 0.3,
+            max_tokens: 4096,
+        };
+        if (options?.tools?.length) {
+            body.tools = options.tools;
+            body.tool_choice = "auto";
+        }
 
         const res = await fetch(`${baseUrl}/chat/completions`, {
             method: "POST",
@@ -46,50 +90,69 @@ export const nvidiaProvider: AiProvider = {
                 "Content-Type": "application/json",
                 Authorization: `Bearer ${config.apiKey}`,
             },
-            body: JSON.stringify({
-                model,
-                messages,
-                temperature: 0.3,
-                max_tokens: 4096,
-            }),
+            body: JSON.stringify(body),
         });
 
         if (!res.ok) {
-            const body = await res.text().catch(() => "");
-            logger.error("[AI/NVIDIA] Request failed", { status: res.status, body });
-            throw new Error(parseApiError(res.status, body));
+            const respBody = await res.text().catch(() => "");
+            logger.error("[AI/NVIDIA] Request failed", { status: res.status, body: respBody });
+            throw new Error(parseApiError(res.status, respBody));
         }
 
         const data: NvidiaChatResponse = await res.json();
-        const content = data.choices?.[0]?.message?.content;
+        const choice = data.choices?.[0]?.message;
 
+        // Check for native tool calls first
+        if (choice?.tool_calls?.length) {
+            return toolCallToResponse(choice.tool_calls[0]);
+        }
+
+        const content = choice?.content;
         if (!content) {
             throw new Error("NVIDIA API returned an empty response");
         }
 
-        return content;
+        return { type: "text", content };
     },
 
     async chatStream(
         config: AiProviderConfig,
         messages: ChatMessage[],
         callbacks: StreamCallbacks,
-        signal?: AbortSignal,
-    ): Promise<string> {
+        options?: ChatOptions,
+    ): Promise<AiChatResponse> {
         const baseUrl = (config.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, "");
         const model = config.model || DEFAULT_MODEL;
 
-        logger.info("[AI/NVIDIA] Sending streaming chat request", { baseUrl, model });
+        logger.info("[AI/NVIDIA] Sending streaming chat request", { baseUrl, model, hasTools: !!options?.tools });
         callbacks.onStatus("connecting");
+
+        const body: Record<string, unknown> = {
+            model,
+            messages,
+            temperature: 0.3,
+            max_tokens: 4096,
+            stream: true,
+        };
+        if (options?.tools?.length) {
+            body.tools = options.tools;
+            body.tool_choice = "auto";
+        }
 
         // React Native's fetch doesn't support ReadableStream on res.body,
         // so we use XMLHttpRequest with onprogress for SSE streaming.
-        return new Promise<string>((resolve, reject) => {
+        return new Promise<AiChatResponse>((resolve, reject) => {
             const xhr = new XMLHttpRequest();
             let accumulated = "";
             let processedLength = 0;
             let hasContent = false;
             let settled = false;
+
+            // Accumulate streamed tool_call fragments
+            let toolCallId = "";
+            let toolCallName = "";
+            let toolCallArgs = "";
+            let isToolCall = false;
 
             function settle(fn: () => void) {
                 if (!settled) {
@@ -98,6 +161,7 @@ export const nvidiaProvider: AiProvider = {
                 }
             }
 
+            const signal = options?.signal;
             if (signal) {
                 signal.addEventListener("abort", () => {
                     xhr.abort();
@@ -110,10 +174,6 @@ export const nvidiaProvider: AiProvider = {
             xhr.setRequestHeader("Authorization", `Bearer ${config.apiKey}`);
 
             xhr.onreadystatechange = () => {
-                // HEADERS_RECEIVED — check status early
-                if (xhr.readyState === 2 && xhr.status !== 0 && xhr.status !== 200) {
-                    // Let onerror / onload handle the body
-                }
                 // LOADING — process incremental data
                 if (xhr.readyState === 3 || xhr.readyState === 4) {
                     const text = xhr.responseText;
@@ -135,6 +195,19 @@ export const nvidiaProvider: AiProvider = {
 
                                 if (delta?.reasoning_content) {
                                     callbacks.onStatus("thinking");
+                                    continue;
+                                }
+
+                                // Handle streamed tool_calls deltas
+                                if (delta?.tool_calls?.length) {
+                                    const tc = delta.tool_calls[0];
+                                    if (!isToolCall) {
+                                        isToolCall = true;
+                                        callbacks.onStatus("generating");
+                                    }
+                                    if (tc.id) toolCallId = tc.id;
+                                    if (tc.function?.name) toolCallName += tc.function.name;
+                                    if (tc.function?.arguments) toolCallArgs += tc.function.arguments;
                                     continue;
                                 }
 
@@ -163,13 +236,31 @@ export const nvidiaProvider: AiProvider = {
                     return;
                 }
 
+                // If we accumulated a tool call, return it
+                if (isToolCall && toolCallName) {
+                    let args: Record<string, unknown> = {};
+                    try {
+                        args = JSON.parse(toolCallArgs || "{}");
+                    } catch {
+                        logger.warn("[AI/NVIDIA] Failed to parse streamed tool_call arguments", { raw: toolCallArgs });
+                    }
+                    callbacks.onStatus("done");
+                    settle(() => resolve({
+                        type: "tool_call",
+                        id: toolCallId || `tc_${Date.now()}`,
+                        name: toolCallName,
+                        arguments: args,
+                    }));
+                    return;
+                }
+
                 if (!accumulated) {
                     settle(() => reject(new Error("NVIDIA API returned an empty streaming response")));
                     return;
                 }
 
                 callbacks.onStatus("done");
-                settle(() => resolve(accumulated));
+                settle(() => resolve({ type: "text", content: accumulated }));
             };
 
             xhr.onerror = () => {
@@ -182,13 +273,7 @@ export const nvidiaProvider: AiProvider = {
             };
 
             callbacks.onStatus("thinking");
-            xhr.send(JSON.stringify({
-                model,
-                messages,
-                temperature: 0.3,
-                max_tokens: 4096,
-                stream: true,
-            }));
+            xhr.send(JSON.stringify(body));
         });
     },
 };

--- a/src/services/ai/tools.ts
+++ b/src/services/ai/tools.ts
@@ -15,7 +15,7 @@ import {
 import { formatDateKey, parseDateKey } from "@/src/utils/date";
 import logger from "@/src/utils/logger";
 import { buildMealPlanPrompt } from "./index";
-import type { AiFoodPayload, AiGoalsPayload, AiMealPlanEntry, AiRecipePayload } from "./types";
+import type { AiFoodPayload, AiGoalsPayload, AiMealPlanEntry, AiRecipePayload, OpenAiTool } from "./types";
 
 // ── Tool definition types ─────────────────────────────────
 
@@ -225,6 +225,18 @@ export const AI_TOOLS: AiToolDefinition[] = [
     removeEntryTool,
     searchTemplatesTool,
 ];
+
+/** Convert internal tool definitions to the OpenAI-compatible tools format. */
+export function toOpenAiTools(): OpenAiTool[] {
+    return AI_TOOLS.map((tool) => ({
+        type: "function" as const,
+        function: {
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.parameters,
+        },
+    }));
+}
 
 // ── Tool registry (name → executor) ──────────────────────
 
@@ -542,7 +554,7 @@ export function importMealPlanEntries(entries: AiMealPlanEntry[]): number {
     return count;
 }
 
-/** Build the system prompt describing available tools. */
+/** Build the system prompt describing available tools (used as fallback when native tool calling is unavailable). */
 export function buildToolSystemPrompt(): string {
     const today = formatDateKey(new Date());
 
@@ -568,13 +580,33 @@ export function buildToolSystemPrompt(): string {
         toolDescriptions,
         "",
         "TOOL CALLING FORMAT:",
-        "When you want to use a tool, respond with ONLY a JSON block in this exact format:",
+        "When you want to use a tool, respond with ONLY a JSON block in this exact format — no other text before or after:",
         '```tool',
         '{"name": "tool_name", "arguments": {"param1": "value1"}}',
         '```',
         "",
+        "EXAMPLES:",
+        "",
+        'User: "What did I eat today?"',
+        "Response:",
+        '```tool',
+        `{"name": "read_entries", "arguments": {"date": "${today}"}}`,
+        '```',
+        "",
+        'User: "Log 200g of chicken breast for lunch"',
+        "Response:",
+        '```tool',
+        '{"name": "search_templates", "arguments": {"query": "chicken breast"}}',
+        '```',
+        "",
+        'After receiving search_templates result with food_id 5:',
+        '```tool',
+        `{"name": "create_entry", "arguments": {"food_id": 5, "quantity_grams": 200, "date": "${today}", "meal_type": "lunch"}}`,
+        '```',
+        "",
         "IMPORTANT RULES:",
         "- Only call ONE tool at a time.",
+        "- When calling a tool, respond with ONLY the tool block above — no extra text.",
         "- After a tool executes, you will receive the result and can respond to the user.",
         "- If you don't need a tool, just respond normally in plain text.",
         "- Be concise and helpful. Use the user's language when possible.",
@@ -585,15 +617,59 @@ export function buildToolSystemPrompt(): string {
     ].join("\n");
 }
 
-/** Try to parse a tool call from an AI response. Returns null if no tool call found. */
+/** Build a minimal system prompt for use with native tool calling (no tool format instructions needed). */
+export function buildNativeToolSystemPrompt(): string {
+    const today = formatDateKey(new Date());
+
+    return [
+        "You are a helpful nutrition and meal planning assistant inside a food tracking app called MacroFlow.",
+        "You can help users with their diet by using the provided tools.",
+        "",
+        `TODAY'S DATE: ${today}`,
+        "",
+        "RULES:",
+        "- Only call ONE tool at a time.",
+        "- Be concise and helpful. Use the user's language when possible.",
+        "- When a meal plan is generated, briefly summarize what was created.",
+        "- Before creating an entry, ALWAYS use search_templates first to find the correct food_id. Never guess IDs.",
+        "- Before modifying or removing an entry, ALWAYS use read_entries first to find the correct entry_id.",
+        "- When the user says 'today', use the date provided above. Calculate other relative dates from it.",
+    ].join("\n");
+}
+
+/** Try to parse a tool call from an AI text response (prompt-based fallback). Returns null if no tool call found. */
 export function parseToolCall(response: string): AiToolCall | null {
-    // Look for ```tool ... ``` blocks
+    // Strategy 1: Look for ```tool ... ``` blocks (primary format)
     const toolBlockRegex = /```tool\s*\n?([\s\S]*?)\n?```/;
     const match = response.match(toolBlockRegex);
-    if (!match) return null;
+    if (match) {
+        const parsed = tryParseToolJson(match[1].trim());
+        if (parsed) return parsed;
+    }
 
+    // Strategy 2: Look for ```json ... ``` or ``` ... ``` blocks containing tool JSON
+    const genericBlockRegex = /```(?:json)?\s*\n?([\s\S]*?)\n?```/;
+    const genericMatch = response.match(genericBlockRegex);
+    if (genericMatch) {
+        const parsed = tryParseToolJson(genericMatch[1].trim());
+        if (parsed) return parsed;
+    }
+
+    // Strategy 3: Try to find a raw JSON object with "name" field in the response
+    const jsonObjectRegex = /\{[^{}]*"name"\s*:\s*"[^"]+"\s*[,}][\s\S]*?\}/;
+    const jsonMatch = response.match(jsonObjectRegex);
+    if (jsonMatch) {
+        const parsed = tryParseToolJson(jsonMatch[0]);
+        if (parsed) return parsed;
+    }
+
+    return null;
+}
+
+/** Try to parse a JSON string as a tool call. Returns null on failure. */
+function tryParseToolJson(jsonStr: string): AiToolCall | null {
     try {
-        const parsed = JSON.parse(match[1].trim());
+        const parsed = JSON.parse(jsonStr);
         if (parsed.name && typeof parsed.name === "string") {
             return {
                 name: parsed.name,
@@ -603,6 +679,5 @@ export function parseToolCall(response: string): AiToolCall | null {
     } catch {
         // Not valid JSON
     }
-
     return null;
 }

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -56,11 +56,45 @@ export interface AiMealPlanResponse {
     entries: AiMealPlanEntry[];
 }
 
-/** Chat message format for the API. */
-export interface ChatMessage {
-    role: "system" | "user" | "assistant";
-    content: string;
+// ── Chat message types ────────────────────────────────────
+
+/** A tool call embedded in an assistant message (OpenAI format). */
+export interface AssistantToolCall {
+    id: string;
+    type: "function";
+    function: { name: string; arguments: string };
 }
+
+/** Chat message format for the API. Supports system, user, assistant (with optional tool_calls), and tool roles. */
+export type ChatMessage =
+    | { role: "system"; content: string }
+    | { role: "user"; content: string }
+    | { role: "assistant"; content: string; tool_calls?: AssistantToolCall[] }
+    | { role: "tool"; content: string; tool_call_id: string };
+
+// ── OpenAI-compatible tool definition format ──────────────
+
+export interface OpenAiToolFunction {
+    name: string;
+    description: string;
+    parameters: {
+        type: "object";
+        properties: Record<string, { type: string; description: string; enum?: string[] }>;
+        required: string[];
+    };
+}
+
+export interface OpenAiTool {
+    type: "function";
+    function: OpenAiToolFunction;
+}
+
+// ── AI response types ─────────────────────────────────────
+
+/** Structured response from AI — either plain text or a tool call. */
+export type AiChatResponse =
+    | { type: "text"; content: string }
+    | { type: "tool_call"; id: string; name: string; arguments: Record<string, unknown> };
 
 /** Status phases during streaming generation. */
 export type StreamStatus = "connecting" | "thinking" | "generating" | "done";
@@ -71,21 +105,30 @@ export interface StreamCallbacks {
     onToken: (accumulated: string) => void;
 }
 
+/** Options for a chat request, optionally with tools. */
+export interface ChatOptions {
+    tools?: OpenAiTool[];
+    signal?: AbortSignal;
+}
+
 /** Abstract AI provider interface. */
 export interface AiProvider {
     readonly id: AiProviderId;
     /** Whether this provider supports streaming responses. */
     readonly supportsStreaming?: boolean;
-    /** Send a chat completion request and return the assistant's text. */
+    /** Whether this provider supports native OpenAI-style tool/function calling. */
+    readonly supportsToolCalling?: boolean;
+    /** Send a chat completion request and return the response. */
     chat(
         config: AiProviderConfig,
         messages: ChatMessage[],
-    ): Promise<string>;
+        options?: ChatOptions,
+    ): Promise<AiChatResponse>;
     /** Stream a chat completion, calling back with status updates and tokens. */
     chatStream?(
         config: AiProviderConfig,
         messages: ChatMessage[],
         callbacks: StreamCallbacks,
-        signal?: AbortSignal,
-    ): Promise<string>;
+        options?: ChatOptions,
+    ): Promise<AiChatResponse>;
 }


### PR DESCRIPTION
## Summary
- switch the NVIDIA provider to native OpenAI-compatible tool calling with structured tool calls
- keep prompt-based parsing as a fallback and harden the fallback prompt/parser
- preserve tool call history correctly across follow-up messages and include structured tool result data for the model

## Validation
- npx tsc --noEmit
- npx eslint src/services/ai/ src/features/ai/ src/features/log/AiChatOverlay.tsx

Closes #145