### PR TITLE
fix: edit recipe has no header

### DIFF
--- a/app/templates/_layout.tsx
+++ b/app/templates/_layout.tsx
@@ -1,5 +1,15 @@
-import { Slot } from "expo-router";
+import { useThemeColors } from "@/src/utils/ThemeProvider";
+import { Stack } from "expo-router";
 
 export default function RecipesLayout() {
-    return <Slot />;
+    const colors = useThemeColors();
+    return (
+        <Stack
+            screenOptions={{
+                headerStyle: { backgroundColor: colors.surface },
+                headerTintColor: colors.text,
+                headerShadowVisible: false,
+            }}
+        />
+    );
 }


### PR DESCRIPTION
## Summary

The templates layout was using `<Slot />` which doesn't render any navigation chrome. This meant that `Stack.Screen` options set by `RecipeEditorScreen` and `FoodEditorScreen` had no effect — no header was shown and content extended into the status bar.

## Fix

Replaced `<Slot />` with `<Stack />` in `app/templates/_layout.tsx`, matching the pattern used by the `app/log/_layout.tsx` layout. This enables proper header rendering and safe area handling for all screens in the templates route group.

Resolves #148