### PR TITLE
feat: add macro validation feedback loop for meal plan refinement

### DIFF
--- a/src/features/ai/MealPlanScreen.tsx
+++ b/src/features/ai/MealPlanScreen.tsx
@@ -2,11 +2,8 @@ import Button from "@/src/components/Button";
 import Input from "@/src/components/Input";
 import { addEntry, getAllFoods, getAllRecipes, getGoals, getRecipeItems } from "@/src/db/queries";
 import {
-    buildMealPlanPrompt,
-    getProvider,
+    generateMealPlan,
     loadAiConfig,
-    parseMealPlanResponse,
-    parsePartialEntries,
 } from "@/src/services/ai";
 import type { AiFoodPayload, AiGoalsPayload, AiMealPlanEntry, AiRecipePayload, StreamStatus } from "@/src/services/ai/types";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
@@ -47,6 +44,7 @@ export default function MealPlanScreen() {
             case "connecting": return t("ai.statusConnecting");
             case "thinking": return t("ai.statusThinking");
             case "generating": return t("ai.statusGenerating");
+            case "refining": return t("ai.statusRefining");
             default: return t("ai.generating");
         }
     }, [streamStatus, t]);
@@ -114,41 +112,20 @@ export default function MealPlanScreen() {
             setStreamStatus(null);
             setResult(null);
 
-            const messages = buildMealPlanPrompt(foodPayload, recipePayload, goalsPayload, {
-                likedFoods,
-                dislikedFoods,
-                days: numDays,
+            const validIds = new Set(allFoods.map((f) => f.id));
+
+            const plan = await generateMealPlan({
+                config,
+                foods: foodPayload,
+                recipes: recipePayload,
+                goals: goalsPayload,
+                prefs: { likedFoods, dislikedFoods, days: numDays },
+                validFoodIds: validIds,
+                onStatus: (status) => setStreamStatus(status),
+                onPartialEntries: (entries) => setResult(entries),
+                signal: abort.signal,
             });
 
-            const provider = getProvider(config.provider);
-            const validIds = new Set(allFoods.map((f) => f.id));
-            let raw: string;
-
-            if (provider.supportsStreaming && provider.chatStream) {
-                const response = await provider.chatStream(
-                    config,
-                    messages,
-                    {
-                        onStatus: (status) => setStreamStatus(status),
-                        onToken: (accumulated) => {
-                            // Extract complete entries from partial JSON as they stream in
-                            const partial = parsePartialEntries(accumulated, validIds);
-                            if (partial.length > 0) {
-                                setResult(partial);
-                            }
-                        },
-                    },
-                    { signal: abort.signal },
-                );
-                raw = response.type === "text" ? response.content : "";
-            } else {
-                setStreamStatus("connecting");
-                const response = await provider.chat(config, messages);
-                raw = response.type === "text" ? response.content : "";
-            }
-
-            // Final parse with the complete response
-            const plan = parseMealPlanResponse(raw, validIds, goalsPayload, foodPayload);
             setResult(plan.entries);
         } catch (e: any) {
             if (e.name === "AbortError") return;

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -285,6 +285,7 @@ const de = {
         statusConnecting: "Verbindung zum KI-Anbieter…",
         statusThinking: "KI denkt nach…",
         statusGenerating: "Essensplan wird generiert…",
+        statusRefining: "Makroziele werden verfeinert…",
         noStreamingHint: "Wird generiert — das kann etwas dauern. Bitte warten.",
         planPreview: "PLAN-VORSCHAU",
         importPlan: "In Log importieren",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -284,6 +284,7 @@ const en = {
         statusConnecting: "Connecting to AI provider…",
         statusThinking: "AI is thinking…",
         statusGenerating: "Generating meal plan…",
+        statusRefining: "Refining macro targets…",
         noStreamingHint: "Generating — this might take a while. Please wait.",
         planPreview: "PLAN PREVIEW",
         importPlan: "Import to Log",

--- a/src/services/ai/chat.ts
+++ b/src/services/ai/chat.ts
@@ -1,4 +1,4 @@
-import { getProvider, loadAiConfig, parseMealPlanResponse, parsePartialEntries } from "./index";
+import { generateMealPlan, getProvider, loadAiConfig } from "./index";
 import { buildNativeToolSystemPrompt, buildToolSystemPrompt, executeTool, parseToolCall, toOpenAiTools, toolNeedsApproval } from "./tools";
 import type { AiChatResponse, AiProviderConfig, AiMealPlanEntry, ChatMessage, StreamCallbacks } from "./types";
 import type { AiToolCall, AiToolResult } from "./tools";
@@ -345,7 +345,7 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
     // Execute the tool
     const result = executeTool(toolCall);
 
-    // Special handling for meal plan tool: generate plan, return entries for UI preview
+    // Special handling for meal plan tool: generate plan with refinement, return entries for UI preview
     if (toolCall.name === "create_meal_plan" && result.success && result.data) {
         const planData = result.data as {
             type: string;
@@ -353,27 +353,28 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
             validFoodIds: number[];
             goals: any;
             foods: any;
+            recipes: any;
+            prefs: any;
         };
 
         if (planData.type === "meal_plan_request") {
             const validIds = new Set(planData.validFoodIds);
 
-            // Make a separate AI call WITHOUT tools (expects pure JSON output)
-            const planResponse = await callAiRaw(config, planData.messages, {
-                ...opts,
-                onStreamToken: (accumulated) => {
-                    // Parse partial entries and forward to UI for live preview
-                    const partial = parsePartialEntries(accumulated, validIds);
-                    if (partial.length > 0) {
-                        opts.onStreamingToolData?.({ mealPlanEntries: partial });
-                    }
-                },
-            });
-
             try {
-                const plan = parseMealPlanResponse(planResponse, validIds, planData.goals, planData.foods);
+                const plan = await generateMealPlan({
+                    config,
+                    foods: planData.foods,
+                    recipes: planData.recipes,
+                    goals: planData.goals,
+                    prefs: planData.prefs,
+                    validFoodIds: validIds,
+                    onStatus: (status) => opts.onStreamStatus?.(status),
+                    onPartialEntries: (entries) => {
+                        opts.onStreamingToolData?.({ mealPlanEntries: entries });
+                    },
+                    signal: opts.signal,
+                });
 
-                // Return entries as data so the UI can preview before importing
                 const toolResultMsg: UiChatMessage = {
                     id: nextId(),
                     role: "tool-result",
@@ -513,30 +514,4 @@ async function callAi(
         }
     }
     return response;
-}
-
-/**
- * Call the AI and return raw text only (no tool support).
- * Used for secondary calls like meal plan generation that expect pure text/JSON output.
- */
-async function callAiRaw(
-    config: AiProviderConfig,
-    messages: ChatMessage[],
-    opts: { onStreamStatus?: (s: string) => void; onStreamToken?: (t: string) => void; signal?: AbortSignal },
-): Promise<string> {
-    const provider = getProvider(config.provider);
-
-    if (provider.supportsStreaming && provider.chatStream) {
-        const callbacks: StreamCallbacks = {
-            onStatus: (status) => opts.onStreamStatus?.(status),
-            onToken: (accumulated) => opts.onStreamToken?.(accumulated),
-        };
-        const response = await provider.chatStream(config, messages, callbacks, { signal: opts.signal });
-        return response.type === "text" ? response.content : "";
-    }
-
-    opts.onStreamStatus?.("connecting");
-    const response = await provider.chat(config, messages);
-    opts.onStreamStatus?.("done");
-    return response.type === "text" ? response.content : "";
 }

--- a/src/services/ai/index.ts
+++ b/src/services/ai/index.ts
@@ -246,3 +246,168 @@ export function parseMealPlanResponse(
 
     return { entries };
 }
+
+/** Check if daily macro totals are within tolerance. Returns issues for days that aren't. */
+export function validateMealPlanMacros(
+    entries: AiMealPlanEntry[],
+    goals: AiGoalsPayload,
+    foods: AiFoodPayload[],
+    tolerance = 0.15,
+): { isValid: boolean; issues: string[] } {
+    const foodMap = new Map(foods.map((f) => [f.id, f]));
+    const dailyTotals = new Map<string, { cal: number; p: number; c: number; f: number }>();
+
+    for (const entry of entries) {
+        const food = foodMap.get(entry.food_id);
+        if (!food) continue;
+        const factor = entry.quantity_grams / 100;
+        const day = dailyTotals.get(entry.date) ?? { cal: 0, p: 0, c: 0, f: 0 };
+        day.cal += food.calories_per_100g * factor;
+        day.p += food.protein_per_100g * factor;
+        day.c += food.carbs_per_100g * factor;
+        day.f += food.fat_per_100g * factor;
+        dailyTotals.set(entry.date, day);
+    }
+
+    const issues: string[] = [];
+    for (const [date, totals] of dailyTotals) {
+        const dayIssues: string[] = [];
+        if (goals.calories > 0 && Math.abs(totals.cal - goals.calories) / goals.calories > tolerance) {
+            dayIssues.push(`calories: got ${Math.round(totals.cal)} kcal, target ${goals.calories} kcal`);
+        }
+        if (goals.protein > 0 && Math.abs(totals.p - goals.protein) / goals.protein > tolerance) {
+            dayIssues.push(`protein: got ${Math.round(totals.p)}g, target ${goals.protein}g`);
+        }
+        if (goals.carbs > 0 && Math.abs(totals.c - goals.carbs) / goals.carbs > tolerance) {
+            dayIssues.push(`carbs: got ${Math.round(totals.c)}g, target ${goals.carbs}g`);
+        }
+        if (goals.fat > 0 && Math.abs(totals.f - goals.fat) / goals.fat > tolerance) {
+            dayIssues.push(`fat: got ${Math.round(totals.f)}g, target ${goals.fat}g`);
+        }
+        if (dayIssues.length > 0) {
+            issues.push(`${date}: ${dayIssues.join(", ")}`);
+        }
+    }
+
+    return { isValid: issues.length === 0, issues };
+}
+
+/** Build a refinement message asking the AI to correct macro mismatches. */
+export function buildRefinementMessage(
+    previousResponse: string,
+    issues: string[],
+): ChatMessage {
+    return {
+        role: "user",
+        content: [
+            "Your previous meal plan has macro mismatches. Please fix the following issues by adjusting quantities or swapping foods:",
+            "",
+            ...issues,
+            "",
+            "Return the COMPLETE corrected meal plan in the same JSON format. Respond with ONLY valid JSON, no explanation.",
+        ].join("\n"),
+    };
+}
+
+// ── High-level meal plan generation with refinement ───────
+
+const MAX_REFINEMENTS = 2;
+
+export interface GenerateMealPlanOptions {
+    config: AiProviderConfig;
+    foods: AiFoodPayload[];
+    recipes: AiRecipePayload[];
+    goals: AiGoalsPayload;
+    prefs: MealPlanPreferences;
+    validFoodIds: Set<number>;
+    onStatus?: (status: import("./types").StreamStatus) => void;
+    onPartialEntries?: (entries: AiMealPlanEntry[]) => void;
+    signal?: AbortSignal;
+}
+
+/**
+ * Generate a meal plan with automatic refinement.
+ * After the initial generation, validates daily macros against goals.
+ * If mismatches are found, sends them back to the AI for correction (up to 2 rounds).
+ * Streaming preview (onPartialEntries) remains active during refinements.
+ */
+export async function generateMealPlan(opts: GenerateMealPlanOptions): Promise<AiMealPlanResponse> {
+    const { config, foods, recipes, goals, prefs, validFoodIds, onStatus, onPartialEntries, signal } = opts;
+
+    const messages = buildMealPlanPrompt(foods, recipes, goals, prefs);
+    const provider = getProvider(config.provider);
+
+    // Initial generation
+    let raw: string;
+    if (provider.supportsStreaming && provider.chatStream) {
+        const response = await provider.chatStream(
+            config,
+            messages,
+            {
+                onStatus: (status) => onStatus?.(status),
+                onToken: (accumulated) => {
+                    const partial = parsePartialEntries(accumulated, validFoodIds);
+                    if (partial.length > 0) onPartialEntries?.(partial);
+                },
+            },
+            { signal },
+        );
+        raw = response.type === "text" ? response.content : "";
+    } else {
+        onStatus?.("connecting");
+        const response = await provider.chat(config, messages);
+        raw = response.type === "text" ? response.content : "";
+    }
+
+    let plan = parseMealPlanResponse(raw, validFoodIds, goals, foods);
+    onPartialEntries?.(plan.entries);
+
+    // Refinement loop
+    const conversationHistory: ChatMessage[] = [...messages, { role: "assistant", content: raw }];
+
+    for (let i = 0; i < MAX_REFINEMENTS; i++) {
+        if (signal?.aborted) break;
+
+        const validation = validateMealPlanMacros(plan.entries, goals, foods);
+        if (validation.isValid) break;
+
+        logger.info("[AI] Meal plan refinement round", { round: i + 1, issues: validation.issues.length });
+        onStatus?.("refining");
+
+        const refinementMsg = buildRefinementMessage(raw, validation.issues);
+        conversationHistory.push(refinementMsg);
+
+        let refinedRaw: string;
+        if (provider.supportsStreaming && provider.chatStream) {
+            const response = await provider.chatStream(
+                config,
+                conversationHistory,
+                {
+                    onStatus: () => onStatus?.("refining"),
+                    onToken: (accumulated) => {
+                        const partial = parsePartialEntries(accumulated, validFoodIds);
+                        if (partial.length > 0) onPartialEntries?.(partial);
+                    },
+                },
+                { signal },
+            );
+            refinedRaw = response.type === "text" ? response.content : "";
+        } else {
+            const response = await provider.chat(config, conversationHistory);
+            refinedRaw = response.type === "text" ? response.content : "";
+        }
+
+        try {
+            const refinedPlan = parseMealPlanResponse(refinedRaw, validFoodIds, goals, foods);
+            plan = refinedPlan;
+            raw = refinedRaw;
+            conversationHistory.push({ role: "assistant", content: refinedRaw });
+            onPartialEntries?.(plan.entries);
+        } catch {
+            logger.warn("[AI] Refinement parse failed, keeping previous result", { round: i + 1 });
+            break;
+        }
+    }
+
+    return plan;
+}

--- a/src/services/ai/tools.ts
+++ b/src/services/ai/tools.ts
@@ -344,6 +344,8 @@ function executeCreateMealPlan(args: Record<string, unknown>): AiToolResult {
             validFoodIds: allFoods.map((f) => f.id),
             goals: goalsPayload,
             foods: foodPayload,
+            recipes: recipePayload,
+            prefs: { likedFoods, dislikedFoods, days },
         },
     };
 }

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -97,7 +97,7 @@ export type AiChatResponse =
     | { type: "tool_call"; id: string; name: string; arguments: Record<string, unknown> };
 
 /** Status phases during streaming generation. */
-export type StreamStatus = "connecting" | "thinking" | "generating" | "done";
+export type StreamStatus = "connecting" | "thinking" | "generating" | "refining" | "done";
 
 /** Callbacks for streaming chat responses. */
 export interface StreamCallbacks {


### PR DESCRIPTION
## Summary

Adds a refinement loop to the meal plan generation service. After the initial plan is generated, daily macro totals are validated against goals (±15% tolerance). If mismatches are found, the issues are sent back to the AI for correction — up to 2 refinement rounds.

### Changes
- **`src/services/ai/index.ts`**: Added `validateMealPlanMacros()`, `buildRefinementMessage()`, and a new `generateMealPlan()` function that encapsulates the full generation + refinement lifecycle
- **`src/services/ai/types.ts`**: Added `"refining"` stream status
- **`src/services/ai/chat.ts`**: Updated `executeApprovedTool()` to use `generateMealPlan()` instead of raw AI calls — removed `callAiRaw()`
- **`src/services/ai/tools.ts`**: Pass recipes/prefs through tool result data for `generateMealPlan()`
- **`src/features/ai/MealPlanScreen.tsx`**: Simplified to use `generateMealPlan()` — refinement logic removed from UI
- **`src/i18n/locales/en.ts`** / **`de.ts`**: Added `statusRefining` translation

### How it works
1. Initial generation streams with live preview (unchanged UX)
2. After completion, `validateMealPlanMacros()` checks each day's totals
3. If any day exceeds ±15% tolerance → sends specific issues to AI → gets corrected plan
4. Up to 2 refinement rounds, then accepts best result
5. Parse failures during refinement gracefully fall back to previous result
6. Both the standalone MealPlanScreen and the chat tool use the same `generateMealPlan()` path

Closes #152