### PR TITLE
fix: apply dark theme background to food editor screen

### DIFF
--- a/src/features/templates/FoodEditorScreen.tsx
+++ b/src/features/templates/FoodEditorScreen.tsx
@@ -11,7 +11,7 @@ export default function FoodEditorScreen() {
     const colors = useThemeColors();
 
     return (
-        <View style={styles.flex}>
+        <View style={[styles.flex, { backgroundColor: colors.background }]}>
             <Stack.Screen
                 options={{
                     headerShown: true,


### PR DESCRIPTION
## Summary

The Edit Food / New Food screen was showing a white background in dark mode because the wrapper `View` in `FoodEditorScreen` had no `backgroundColor` set. Added `colors.background` to the wrapper view, consistent with `ManualFoodForm` and all other screens.

Resolves #161