### PR TITLE
fix: refresh servingUnits after modal save to prevent NaN display

### DIFF
--- a/src/features/templates/RecipeEditorScreen.tsx
+++ b/src/features/templates/RecipeEditorScreen.tsx
@@ -202,11 +202,15 @@ export default function RecipeEditorScreen() {
     // ── Item editing ──────────────────────────────────────
     function handleModalSaved(itemId: number, quantityGrams: number, unit: string) {
         setItems((prev) =>
-            prev.map((i) =>
-                i.recipeItem.id === itemId
-                    ? { ...i, recipeItem: { ...i.recipeItem, quantity_grams: quantityGrams, quantity_unit: unit } }
-                    : i,
-            ),
+            prev.map((i) => {
+                if (i.recipeItem.id !== itemId) return i;
+                const freshServingUnits = i.food ? getServingUnits(i.food.id) : i.servingUnits;
+                return {
+                    ...i,
+                    recipeItem: { ...i.recipeItem, quantity_grams: quantityGrams, quantity_unit: unit },
+                    servingUnits: freshServingUnits,
+                };
+            }),
         );
         setEditingItem(null);
     }


### PR DESCRIPTION
## Summary

Resolves #165

## Root Cause

When a new custom serving unit was created inside `RecipeItemModal` and the item was saved, `handleModalSaved` in `RecipeEditorScreen` updated `quantity_grams` and `quantity_unit` in state but kept the **stale** `servingUnits` array from when the food was first added.

The display loop then tried to find the new unit name in `servingUnits`, failed, and fell through to `fromGrams(qtyGrams, customUnitName)` — which returns `NaN` for any unrecognised unit string.

## Fix

Re-fetch `servingUnits` from the DB for the affected food inside `handleModalSaved` so the item row always reflects the up-to-date unit list after saving.