### PR TITLE
feat: persistent AI chat sessions

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -89,6 +89,25 @@ export function initDB() {
       weight_time TEXT NOT NULL DEFAULT '07:30'
     );
 
+    CREATE TABLE IF NOT EXISTS chat_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL DEFAULT 'New Chat',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS chat_messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id INTEGER NOT NULL REFERENCES chat_sessions(id),
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      tool_call_json TEXT,
+      tool_result_json TEXT,
+      tool_result_data_json TEXT,
+      tool_call_id TEXT,
+      timestamp INTEGER NOT NULL
+    );
+
     INSERT OR IGNORE INTO goals (id) VALUES (1);
     INSERT OR IGNORE INTO notification_settings (id) VALUES (1);
   `);

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,8 +1,8 @@
-import { and, eq, gte, like, lte, sql } from "drizzle-orm";
+import { and, desc, eq, gte, like, lte, sql } from "drizzle-orm";
 import logger from "../utils/logger";
 import { diffCalendarDays, formatDateKey as formatLocalDateKey, parseDateKey } from "../utils/date";
 import { db } from "./index";
-import { entries, foods, goals, notificationSettings, recipeItems, recipeLogs, recipes, servingUnits, weightLogs } from "./schema";
+import { chatMessages, chatSessions, entries, foods, goals, notificationSettings, recipeItems, recipeLogs, recipes, servingUnits, weightLogs } from "./schema";
 
 export type Food = typeof foods.$inferSelect;
 export type NewFood = typeof foods.$inferInsert;
@@ -621,4 +621,55 @@ export function getNotificationSettings(): NotificationSettings | undefined {
 
 export function setNotificationSettings(values: Partial<Omit<NotificationSettings, "id">>) {
     db.update(notificationSettings).set(values).where(eq(notificationSettings.id, 1)).run();
+}
+
+// ── Chat Sessions ──────────────────────────────────────────
+
+export type ChatSession = typeof chatSessions.$inferSelect;
+export type ChatMessageRow = typeof chatMessages.$inferSelect;
+
+export function createChatSession(title?: string): ChatSession {
+    const now = Date.now();
+    return db.insert(chatSessions).values({
+        title: title ?? "New Chat",
+        created_at: now,
+        updated_at: now,
+    }).returning().get();
+}
+
+export function getAllChatSessions(): ChatSession[] {
+    return db.select().from(chatSessions).orderBy(desc(chatSessions.updated_at)).all();
+}
+
+export function deleteChatSession(sessionId: number) {
+    db.delete(chatMessages).where(eq(chatMessages.session_id, sessionId)).run();
+    db.delete(chatSessions).where(eq(chatSessions.id, sessionId)).run();
+}
+
+export function updateChatSessionTitle(sessionId: number, title: string) {
+    db.update(chatSessions).set({ title, updated_at: Date.now() }).where(eq(chatSessions.id, sessionId)).run();
+}
+
+export function touchChatSession(sessionId: number) {
+    db.update(chatSessions).set({ updated_at: Date.now() }).where(eq(chatSessions.id, sessionId)).run();
+}
+
+export function addChatMessage(msg: {
+    session_id: number;
+    role: string;
+    content: string;
+    tool_call_json?: string | null;
+    tool_result_json?: string | null;
+    tool_result_data_json?: string | null;
+    tool_call_id?: string | null;
+    timestamp: number;
+}): ChatMessageRow {
+    return db.insert(chatMessages).values(msg).returning().get();
+}
+
+export function getChatMessages(sessionId: number): ChatMessageRow[] {
+    return db.select().from(chatMessages)
+        .where(eq(chatMessages.session_id, sessionId))
+        .orderBy(chatMessages.timestamp)
+        .all();
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -92,3 +92,22 @@ export const notificationSettings = sqliteTable("notification_settings", {
     snack_enabled: integer("snack_enabled").notNull().default(1),
     weight_enabled: integer("weight_enabled").notNull().default(1),
 });
+
+export const chatSessions = sqliteTable("chat_sessions", {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    title: text("title").notNull().default("New Chat"),
+    created_at: integer("created_at").notNull(),
+    updated_at: integer("updated_at").notNull(),
+});
+
+export const chatMessages = sqliteTable("chat_messages", {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    session_id: integer("session_id").notNull().references(() => chatSessions.id),
+    role: text("role").notNull(),
+    content: text("content").notNull(),
+    tool_call_json: text("tool_call_json"),
+    tool_result_json: text("tool_result_json"),
+    tool_result_data_json: text("tool_result_data_json"),
+    tool_call_id: text("tool_call_id"),
+    timestamp: integer("timestamp").notNull(),
+});

--- a/src/features/log/AiChatOverlay.tsx
+++ b/src/features/log/AiChatOverlay.tsx
@@ -114,6 +114,7 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
     // ── Session state ─────────────────────────────────────
     const [sessions, setSessions] = useState<ChatSession[]>([]);
     const [activeSessionId, setActiveSessionId] = useState<number | null>(null);
+    const [isAtLatestSession, setIsAtLatestSession] = useState(true);
     const sessionListRef = useRef<FlatList>(null);
 
     const scrollRef = useRef<ScrollView>(null);
@@ -162,18 +163,27 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
         }, [onVisibilityChange]),
     );
 
-    // On mount: always start with a fresh session (issue #156 requirement).
-    // Load existing sessions for the selector.
+    // On mount: reuse the most recent session if it is empty, otherwise create a
+    // fresh one. This prevents a pile-up of empty sessions across app restarts.
     useEffect(() => {
         const existing = getAllChatSessions();
-        const fresh = createChatSession(t("chat.newSession"));
-        setSessions([fresh, ...existing]);
-        setActiveSessionId(fresh.id);
+        const newest = existing[0];
+        const newestIsEmpty = newest ? getChatMessages(newest.id).length === 0 : false;
+
+        if (newestIsEmpty && newest) {
+            setSessions(existing);
+            setActiveSessionId(newest.id);
+        } else {
+            const fresh = createChatSession(t("chat.newSession"));
+            setSessions([fresh, ...existing]);
+            setActiveSessionId(fresh.id);
+        }
         setMessages([]);
+        setIsAtLatestSession(true);
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     /** Switch to a different session, loading its messages from the DB. */
-    const switchSession = useCallback((sessionId: number) => {
+    const switchSession = useCallback((sessionId: number, allSessions?: ChatSession[]) => {
         if (sessionId === activeSessionId || loading) return;
         setPendingToolCall(null);
         setPendingToolCallId(undefined);
@@ -182,11 +192,19 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
         setActiveSessionId(sessionId);
         const rows = getChatMessages(sessionId);
         setMessages(rows.map(rowToUiMessage));
-    }, [activeSessionId, loading]);
+        const list = allSessions ?? sessions;
+        setIsAtLatestSession(list.length === 0 || list[0].id === sessionId);
+    }, [activeSessionId, loading, sessions]);
 
-    /** Create a new session and switch to it. */
+    /** Create a new session and switch to it. Reuses the current session if it is empty. */
     const handleNewSession = useCallback(() => {
         if (loading) return;
+        // Don't pile up empty sessions — reuse active one if it has no messages
+        if (messages.length === 0 && activeSessionId != null) {
+            setIsAtLatestSession(true);
+            setTimeout(() => sessionListRef.current?.scrollToOffset({ offset: 0, animated: true }), 50);
+            return;
+        }
         const fresh = createChatSession(t("chat.newSession"));
         setSessions((prev) => [fresh, ...prev]);
         setActiveSessionId(fresh.id);
@@ -195,8 +213,9 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
         setPendingToolCallId(undefined);
         setStreamingText("");
         setStreamingToolData(null);
+        setIsAtLatestSession(true);
         setTimeout(() => sessionListRef.current?.scrollToOffset({ offset: 0, animated: true }), 50);
-    }, [loading, t]);
+    }, [loading, t, messages.length, activeSessionId]);
 
     /** Long-press to delete a session. */
     const handleDeleteSession = useCallback((session: ChatSession) => {
@@ -489,6 +508,17 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
                             </Pressable>
                         )}
                     />
+                    {/* Jump-to-latest button — shown only when an older session is active */}
+                    {!isAtLatestSession && (
+                        <Pressable
+                            onPress={handleNewSession}
+                            style={[styles.scrollToLatestBtn, { backgroundColor: colors.primary }]}
+                            hitSlop={8}
+                        >
+                            <Ionicons name="arrow-back" size={14} color="#fff" />
+                            <Text style={styles.scrollToLatestText}>{t("chat.latest")}</Text>
+                        </Pressable>
+                    )}
                 </View>
 
                 {/* Messages */}
@@ -737,6 +767,23 @@ function createStyles(colors: ThemeColors) {
         sessionChipText: {
             fontSize: fontSize.xs,
             fontWeight: "500",
+        },
+        scrollToLatestBtn: {
+            flexDirection: "row",
+            alignItems: "center",
+            alignSelf: "flex-end",
+            gap: 4,
+            marginHorizontal: spacing.md,
+            marginTop: spacing.xs,
+            marginBottom: spacing.xs,
+            paddingHorizontal: spacing.sm,
+            paddingVertical: spacing.xs,
+            borderRadius: borderRadius.sm,
+        },
+        scrollToLatestText: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: "#fff",
         },
         messageList: {
             flex: 1,

--- a/src/features/log/AiChatOverlay.tsx
+++ b/src/features/log/AiChatOverlay.tsx
@@ -1,5 +1,16 @@
 import BottomSheet, { type BottomSheetRef } from "@/src/components/BottomSheet";
 import Button from "@/src/components/Button";
+import {
+    addChatMessage,
+    createChatSession,
+    deleteChatSession,
+    getAllChatSessions,
+    getChatMessages,
+    touchChatSession,
+    updateChatSessionTitle,
+    type ChatMessageRow,
+    type ChatSession,
+} from "@/src/db/queries";
 import { loadAiConfig } from "@/src/services/ai";
 import type { UiChatMessage } from "@/src/services/ai/chat";
 import {
@@ -18,7 +29,9 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 import {
     ActivityIndicator,
+    Alert,
     Dimensions,
+    FlatList,
     Keyboard,
     Pressable,
     ScrollView,
@@ -37,6 +50,41 @@ const INPUT_BAR_MARGIN = spacing.sm;
 
 /** Total vertical space consumed by the floating chat input bar. */
 export const CHAT_BAR_TOTAL_HEIGHT = INPUT_BAR_HEIGHT + INPUT_BAR_MARGIN * 2;
+
+// ── DB ↔ UiChatMessage conversion ────────────────────────
+
+function rowToUiMessage(row: ChatMessageRow): UiChatMessage {
+    return {
+        id: `db_${row.id}`,
+        role: row.role as UiChatMessage["role"],
+        content: row.content,
+        toolCall: row.tool_call_json ? JSON.parse(row.tool_call_json) : undefined,
+        toolResult: row.tool_result_json ? JSON.parse(row.tool_result_json) : undefined,
+        toolResultData: row.tool_result_data_json ? JSON.parse(row.tool_result_data_json) : undefined,
+        toolCallId: row.tool_call_id ?? undefined,
+        timestamp: row.timestamp,
+    };
+}
+
+function persistMessage(sessionId: number, msg: UiChatMessage) {
+    addChatMessage({
+        session_id: sessionId,
+        role: msg.role,
+        content: msg.content,
+        tool_call_json: msg.toolCall ? JSON.stringify(msg.toolCall) : null,
+        tool_result_json: msg.toolResult ? JSON.stringify(msg.toolResult) : null,
+        tool_result_data_json: msg.toolResultData ? JSON.stringify(msg.toolResultData) : null,
+        tool_call_id: msg.toolCallId ?? null,
+        timestamp: msg.timestamp,
+    });
+    touchChatSession(sessionId);
+}
+
+/** Derive a short title from the first user message. */
+function deriveSessionTitle(text: string): string {
+    const trimmed = text.trim();
+    return trimmed.length > 30 ? `${trimmed.slice(0, 30)}…` : trimmed;
+}
 
 interface AiChatOverlayProps {
     /** Height of the bottom tab bar so we can position above it. */
@@ -62,6 +110,11 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
     const [pendingToolCall, setPendingToolCall] = useState<AiToolCall | null>(null);
     const [pendingToolCallId, setPendingToolCallId] = useState<string | undefined>(undefined);
     const [streamingToolData, setStreamingToolData] = useState<AiMealPlanEntry[] | null>(null);
+
+    // ── Session state ─────────────────────────────────────
+    const [sessions, setSessions] = useState<ChatSession[]>([]);
+    const [activeSessionId, setActiveSessionId] = useState<number | null>(null);
+    const sessionListRef = useRef<FlatList>(null);
 
     const scrollRef = useRef<ScrollView>(null);
     const abortRef = useRef<AbortController | null>(null);
@@ -109,6 +162,71 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
         }, [onVisibilityChange]),
     );
 
+    // On mount: always start with a fresh session (issue #156 requirement).
+    // Load existing sessions for the selector.
+    useEffect(() => {
+        const existing = getAllChatSessions();
+        const fresh = createChatSession(t("chat.newSession"));
+        setSessions([fresh, ...existing]);
+        setActiveSessionId(fresh.id);
+        setMessages([]);
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    /** Switch to a different session, loading its messages from the DB. */
+    const switchSession = useCallback((sessionId: number) => {
+        if (sessionId === activeSessionId || loading) return;
+        setPendingToolCall(null);
+        setPendingToolCallId(undefined);
+        setStreamingText("");
+        setStreamingToolData(null);
+        setActiveSessionId(sessionId);
+        const rows = getChatMessages(sessionId);
+        setMessages(rows.map(rowToUiMessage));
+    }, [activeSessionId, loading]);
+
+    /** Create a new session and switch to it. */
+    const handleNewSession = useCallback(() => {
+        if (loading) return;
+        const fresh = createChatSession(t("chat.newSession"));
+        setSessions((prev) => [fresh, ...prev]);
+        setActiveSessionId(fresh.id);
+        setMessages([]);
+        setPendingToolCall(null);
+        setPendingToolCallId(undefined);
+        setStreamingText("");
+        setStreamingToolData(null);
+        setTimeout(() => sessionListRef.current?.scrollToOffset({ offset: 0, animated: true }), 50);
+    }, [loading, t]);
+
+    /** Long-press to delete a session. */
+    const handleDeleteSession = useCallback((session: ChatSession) => {
+        if (loading) return;
+        Alert.alert(
+            t("chat.deleteSession"),
+            t("chat.deleteSessionConfirm"),
+            [
+                { text: t("chat.cancel"), style: "cancel" },
+                {
+                    text: t("chat.deleteSession"),
+                    style: "destructive",
+                    onPress: () => {
+                        deleteChatSession(session.id);
+                        setSessions((prev) => prev.filter((s) => s.id !== session.id));
+                        // If the deleted session was active, switch to the first remaining or create a new one
+                        if (session.id === activeSessionId) {
+                            const remaining = sessions.filter((s) => s.id !== session.id);
+                            if (remaining.length > 0) {
+                                switchSession(remaining[0].id);
+                            } else {
+                                handleNewSession();
+                            }
+                        }
+                    },
+                },
+            ],
+        );
+    }, [loading, t, activeSessionId, sessions, switchSession, handleNewSession]);
+
     // Scroll to bottom when messages change
     useEffect(() => {
         if (messages.length > 0 || streamingText) {
@@ -143,9 +261,26 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
         if (msg.role === "tool-result" && msg.toolResult?.success) {
             onDataChanged?.();
         }
+        // Persist to DB
+        if (activeSessionId != null) {
+            persistMessage(activeSessionId, msg);
+            // Auto-title the session from the first user message
+            if (msg.role === "user") {
+                setMessages((prev) => {
+                    if (prev.every((m) => m.role !== "user")) {
+                        const title = deriveSessionTitle(msg.content);
+                        updateChatSessionTitle(activeSessionId, title);
+                        setSessions((s) => s.map((sess) => sess.id === activeSessionId ? { ...sess, title, updated_at: Date.now() } : sess));
+                    }
+                    return [...prev, msg];
+                });
+                setStreamingText("");
+                return;
+            }
+        }
         setMessages((prev) => [...prev, msg]);
         setStreamingText("");
-    }, [onDataChanged]);
+    }, [onDataChanged, activeSessionId]);
 
     const handleSend = useCallback(async () => {
         const text = inputText.trim();
@@ -311,6 +446,49 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
                     <Pressable onPress={closeSheet} hitSlop={8}>
                         <Ionicons name="chevron-down" size={22} color={colors.textSecondary} />
                     </Pressable>
+                </View>
+
+                {/* Session selector */}
+                <View style={styles.sessionBar}>
+                    <FlatList
+                        ref={sessionListRef}
+                        horizontal
+                        data={sessions}
+                        keyExtractor={(s) => String(s.id)}
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={styles.sessionListContent}
+                        ListHeaderComponent={
+                            <Pressable
+                                onPress={handleNewSession}
+                                style={[styles.sessionChip, styles.sessionNewChip, { borderColor: colors.primary }]}
+                            >
+                                <Ionicons name="add" size={16} color={colors.primary} />
+                            </Pressable>
+                        }
+                        renderItem={({ item }) => (
+                            <Pressable
+                                onPress={() => switchSession(item.id)}
+                                onLongPress={() => handleDeleteSession(item)}
+                                style={[
+                                    styles.sessionChip,
+                                    {
+                                        backgroundColor: item.id === activeSessionId ? colors.primary : colors.surface,
+                                        borderColor: item.id === activeSessionId ? colors.primary : colors.border,
+                                    },
+                                ]}
+                            >
+                                <Text
+                                    style={[
+                                        styles.sessionChipText,
+                                        { color: item.id === activeSessionId ? "#fff" : colors.text },
+                                    ]}
+                                    numberOfLines={1}
+                                >
+                                    {item.title}
+                                </Text>
+                            </Pressable>
+                        )}
+                    />
                 </View>
 
                 {/* Messages */}
@@ -533,6 +711,32 @@ function createStyles(colors: ThemeColors) {
             fontSize: fontSize.lg,
             fontWeight: "600",
             color: colors.text,
+        },
+        sessionBar: {
+            borderBottomWidth: 1,
+            borderBottomColor: colors.border,
+            paddingVertical: spacing.xs,
+        },
+        sessionListContent: {
+            paddingHorizontal: spacing.md,
+            gap: spacing.xs,
+        },
+        sessionChip: {
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.xs + 2,
+            borderRadius: borderRadius.lg,
+            borderWidth: 1,
+            maxWidth: 160,
+        },
+        sessionNewChip: {
+            backgroundColor: "transparent",
+            alignItems: "center",
+            justifyContent: "center",
+            paddingHorizontal: spacing.sm,
+        },
+        sessionChipText: {
+            fontSize: fontSize.xs,
+            fontWeight: "500",
         },
         messageList: {
             flex: 1,

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -309,6 +309,7 @@ const de = {
         deleteSession: "Chat löschen",
         deleteSessionConfirm: "Diese Chat-Sitzung löschen?",
         cancel: "Abbrechen",
+        latest: "Aktuell",
     },
 } as const;
 

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -305,6 +305,10 @@ const de = {
         importMealPlan: "In Log importieren",
         mealPlanImported: "{{count}} Einträge in dein Log importiert.",
         mealPlanDismissed: "Essensplan verworfen.",
+        newSession: "Neuer Chat",
+        deleteSession: "Chat löschen",
+        deleteSessionConfirm: "Diese Chat-Sitzung löschen?",
+        cancel: "Abbrechen",
     },
 } as const;
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -308,6 +308,7 @@ const en = {
         deleteSession: "Delete Chat",
         deleteSessionConfirm: "Delete this chat session?",
         cancel: "Cancel",
+        latest: "Latest",
     },
 } as const;
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -304,6 +304,10 @@ const en = {
         importMealPlan: "Import to Log",
         mealPlanImported: "{{count}} entries imported to your log.",
         mealPlanDismissed: "Meal plan dismissed.",
+        newSession: "New Chat",
+        deleteSession: "Delete Chat",
+        deleteSessionConfirm: "Delete this chat session?",
+        cancel: "Cancel",
     },
 } as const;
 


### PR DESCRIPTION
closes #156

## Changes

### Database
- New `chat_sessions` table (id, title, created_at, updated_at)
- New `chat_messages` table (id, session_id, role, content, tool_call_json, tool_result_json, tool_result_data_json, tool_call_id, timestamp)
- Migration included in `initDB()` via `CREATE TABLE IF NOT EXISTS`

### Session management
- Horizontal session selector slider at the top of the chat sheet
- Selecting a session loads its full message history from SQLite
- Only the active session's messages are sent as context to the AI
- Long-press a session chip to delete it (with confirmation)
- Sessions are auto-titled from the first user message
- On app mount: reuses the most recent session if it has no messages (prevents empty-session pile-up); otherwise creates a fresh one
- "New Chat" (+) button creates a new session; also reuses the active one if it's empty

### Jump-to-latest button
- A small "Latest" pill appears below the session slider whenever the user is viewing an older session
- Tapping it switches back to (or creates) the latest session and scrolls the slider to the start

### Persistence
- Every message (user, assistant, tool-request, tool-result incl. tool call payloads and structured tool result data) is persisted to SQLite immediately on arrival
- Session `updated_at` is touched on every new message
- Messages are loaded from DB when switching sessions

### i18n
- Added `newSession`, `deleteSession`, `deleteSessionConfirm`, `cancel`, `latest` keys for English and German