### PR TITLE
fix: scroll chat messages above keyboard when input is focused

### DIFF
--- a/src/features/log/AiChatOverlay.tsx
+++ b/src/features/log/AiChatOverlay.tsx
@@ -135,6 +135,7 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
     useEffect(() => {
         const showSub = Keyboard.addListener("keyboardDidShow", (e) => {
             setKeyboardHeight(e.endCoordinates.height);
+            setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 50);
         });
         const hideSub = Keyboard.addListener("keyboardDidHide", () => {
             setKeyboardHeight(0);
@@ -641,7 +642,7 @@ export default function AiChatOverlay({ tabBarHeight, onVisibilityChange, onData
                     style={styles.messageList}
                     contentContainerStyle={[
                         styles.messageListContent,
-                        { paddingBottom: INPUT_BAR_HEIGHT + spacing.lg },
+                        { paddingBottom: INPUT_BAR_HEIGHT + spacing.lg + (keyboardHeight > 0 ? keyboardHeight - visibleTabBarHeight : 0) },
                     ]}
                     keyboardShouldPersistTaps="handled"
                     showsVerticalScrollIndicator={false}


### PR DESCRIPTION
## Summary

Resolves #171

When the user taps the chat input and the virtual keyboard appears, the chat `ScrollView`'s bottom padding now grows by the keyboard's height offset. This ensures the last message remains scrollable above the input bar and the keyboard.

Additionally, the view automatically scrolls to the bottom when the keyboard shows, so the latest message is always visible immediately.

## Changes

- **`src/features/log/AiChatOverlay.tsx`**: Added keyboard height to `ScrollView` `contentContainerStyle.paddingBottom` when keyboard is visible; added `scrollToEnd` call on `keyboardDidShow`.