### PR TITLE
fix: include toolCall in decline message to prevent AI_MissingToolResultsError

### DIFF
--- a/src/features/ai/services/chat.ts
+++ b/src/features/ai/services/chat.ts
@@ -251,6 +251,7 @@ export async function declineToolCall(opts: ToolApprovalOptions): Promise<void> 
         role: "tool-result",
         content: "The user declined this action.",
         toolResult: { success: false, summary: "User declined" },
+        toolCall: opts.toolCall,
         toolCallId: opts.toolCallId,
         timestamp: Date.now(),
     };


### PR DESCRIPTION
## Summary

Resolves #178

## Root Cause

When a user declined a tool call, `declineToolCall` in `chat.ts` built a `tool-result` message without the `toolCall` field. In `toApiMessages`, the `"tool-result"` branch checks `m.toolCallId && m.toolCall` — missing `toolCall` caused it to fall into the else branch and emit a plain `user` message.

The preceding assistant message already had the tool-call content, but now had no matching `tool-result`, causing the AI SDK to throw `AI_MissingToolResultsError`. This also bricked all subsequent chat turns.

## Fix

Added `toolCall: opts.toolCall` to the `declineMsg` object so `toApiMessages` produces the correct `tool → tool-result` pairing.