### PR TITLE
feat(ai): add OpenAI provider + per-provider settings persistence

### DIFF
--- a/src/features/ai/screens/AiSettingsScreen.tsx
+++ b/src/features/ai/screens/AiSettingsScreen.tsx
@@ -1,14 +1,17 @@
 import Button from "@/src/shared/atoms/Button";
 import Input from "@/src/shared/atoms/Input";
 import {
-    deleteAiConfig,
+    deleteProviderSettings,
     getProviderDefaults,
-    loadAiConfig,
-    saveAiConfig,
+    loadActiveProvider,
+    loadProviderSettings,
+    saveActiveProvider,
+    saveProviderSettings,
     createModelFromConfig,
+    type AiProviderId,
+    type ProviderSettings,
 } from "../services/aiConfig";
 import { generateText } from "ai";
-import type { AiProviderId } from "../services/aiConfig";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { Ionicons } from "@expo/vector-icons";
@@ -43,44 +46,49 @@ export default function AiSettingsScreen() {
     const router = useRouter();
 
     const [provider, setProvider] = useState<AiProviderId>("nvidia");
-    const [apiKey, setApiKey] = useState("");
-    const [baseUrl, setBaseUrl] = useState("");
-    const [model, setModel] = useState("");
+    const [configs, setConfigs] = useState<Partial<Record<AiProviderId, ProviderSettings>>>({});
     const [saving, setSaving] = useState(false);
     const [testing, setTesting] = useState(false);
     const [loaded, setLoaded] = useState(false);
 
+    const current: ProviderSettings = configs[provider] ?? { apiKey: "", ...getProviderDefaults(provider) };
+
     useEffect(() => {
-        loadAiConfig().then((cfg) => {
-            if (cfg) {
-                setProvider(cfg.provider);
-                setApiKey(cfg.apiKey);
-                setBaseUrl(cfg.baseUrl);
-                setModel(cfg.model);
-            } else {
-                const defaults = getProviderDefaults("nvidia");
-                setBaseUrl(defaults.baseUrl);
-                setModel(defaults.model);
+        async function init() {
+            const active = await loadActiveProvider();
+            const drafts: Partial<Record<AiProviderId, ProviderSettings>> = {};
+            for (const opt of PROVIDER_OPTIONS) {
+                const saved = await loadProviderSettings(opt.key);
+                const defaults = getProviderDefaults(opt.key);
+                drafts[opt.key] = saved ?? { apiKey: "", baseUrl: defaults.baseUrl, model: defaults.model };
             }
+            setProvider(active);
+            setConfigs(drafts);
             setLoaded(true);
-        });
+        }
+        init();
     }, []);
+
+    function updateField(field: keyof ProviderSettings, value: string) {
+        setConfigs((prev) => ({
+            ...prev,
+            [provider]: { ...prev[provider]!, [field]: value },
+        }));
+    }
 
     function handleProviderChange(id: AiProviderId) {
         setProvider(id);
-        const defaults = getProviderDefaults(id);
-        setBaseUrl(defaults.baseUrl);
-        setModel(defaults.model);
     }
 
     async function handleSave() {
-        if (!apiKey.trim()) {
+        if (!current.apiKey.trim()) {
             Alert.alert(t("ai.settings"), t("ai.apiKeyRequired"));
             return;
         }
         try {
             setSaving(true);
-            await saveAiConfig({ provider, apiKey: apiKey.trim(), baseUrl: baseUrl.trim(), model: model.trim() });
+            await saveProviderSettings(provider, { apiKey: current.apiKey.trim(), baseUrl: current.baseUrl.trim(), model: current.model.trim() });
+            await saveActiveProvider(provider);
             Alert.alert(t("ai.settings"), t("ai.configSaved"));
         } catch {
             Alert.alert(t("ai.settings"), t("common.unknownError"));
@@ -90,7 +98,7 @@ export default function AiSettingsScreen() {
     }
 
     async function handleTest() {
-        if (!apiKey.trim()) {
+        if (!current.apiKey.trim()) {
             Alert.alert(t("ai.settings"), t("ai.apiKeyRequired"));
             return;
         }
@@ -98,9 +106,9 @@ export default function AiSettingsScreen() {
             setTesting(true);
             const modelInstance = createModelFromConfig({
                 provider,
-                apiKey: apiKey.trim(),
-                baseUrl: baseUrl.trim(),
-                model: model.trim(),
+                apiKey: current.apiKey.trim(),
+                baseUrl: current.baseUrl.trim(),
+                model: current.model.trim(),
             });
             await generateText({
                 model: modelInstance,
@@ -124,11 +132,12 @@ export default function AiSettingsScreen() {
                     text: t("common.delete"),
                     style: "destructive",
                     onPress: async () => {
-                        await deleteAiConfig();
-                        setApiKey("");
+                        await deleteProviderSettings(provider);
                         const defaults = getProviderDefaults(provider);
-                        setBaseUrl(defaults.baseUrl);
-                        setModel(defaults.model);
+                        setConfigs((prev) => ({
+                            ...prev,
+                            [provider]: { apiKey: "", baseUrl: defaults.baseUrl, model: defaults.model },
+                        }));
                     },
                 },
             ],
@@ -175,8 +184,8 @@ export default function AiSettingsScreen() {
             {/* API Key */}
             <Input
                 label={t("ai.apiKey")}
-                value={apiKey}
-                onChangeText={setApiKey}
+                value={current.apiKey}
+                onChangeText={(v) => updateField("apiKey", v)}
                 placeholder={API_KEY_PLACEHOLDERS[provider]}
                 secureTextEntry
                 autoCapitalize="none"
@@ -187,9 +196,9 @@ export default function AiSettingsScreen() {
             {/* Base URL */}
             <Input
                 label={t("ai.baseUrl")}
-                value={baseUrl}
-                onChangeText={setBaseUrl}
-                placeholder="https://integrate.api.nvidia.com/v1"
+                value={current.baseUrl}
+                onChangeText={(v) => updateField("baseUrl", v)}
+                placeholder={getProviderDefaults(provider).baseUrl}
                 autoCapitalize="none"
                 autoCorrect={false}
                 keyboardType="url"
@@ -199,9 +208,9 @@ export default function AiSettingsScreen() {
             {/* Model */}
             <Input
                 label={t("ai.model")}
-                value={model}
-                onChangeText={setModel}
-                placeholder="meta/llama-3.1-70b-instruct"
+                value={current.model}
+                onChangeText={(v) => updateField("model", v)}
+                placeholder={getProviderDefaults(provider).model}
                 autoCapitalize="none"
                 autoCorrect={false}
                 containerStyle={styles.field}
@@ -224,7 +233,7 @@ export default function AiSettingsScreen() {
                 />
             </View>
 
-            {apiKey.trim().length > 0 && (
+            {current.apiKey.trim().length > 0 && (
                 <Button
                     title={t("ai.deleteConfig")}
                     variant="ghost"

--- a/src/features/ai/screens/AiSettingsScreen.tsx
+++ b/src/features/ai/screens/AiSettingsScreen.tsx
@@ -5,8 +5,9 @@ import {
     getProviderDefaults,
     loadAiConfig,
     saveAiConfig,
-    getProvider,
+    createModelFromConfig,
 } from "../services/aiConfig";
+import { generateText } from "ai";
 import type { AiProviderId } from "../services/aiConfig";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
@@ -26,7 +27,13 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const PROVIDER_OPTIONS: { key: AiProviderId; label: string }[] = [
     { key: "nvidia", label: "NVIDIA" },
+    { key: "openai", label: "OpenAI" },
 ];
+
+const API_KEY_PLACEHOLDERS: Record<AiProviderId, string> = {
+    nvidia: "nvapi-...",
+    openai: "sk-...",
+};
 
 export default function AiSettingsScreen() {
     const { t } = useTranslation();
@@ -89,11 +96,16 @@ export default function AiSettingsScreen() {
         }
         try {
             setTesting(true);
-            const p = getProvider(provider);
-            await p.chat(
-                { provider, apiKey: apiKey.trim(), baseUrl: baseUrl.trim(), model: model.trim() },
-                [{ role: "user", content: "Reply with: OK" }],
-            );
+            const modelInstance = createModelFromConfig({
+                provider,
+                apiKey: apiKey.trim(),
+                baseUrl: baseUrl.trim(),
+                model: model.trim(),
+            });
+            await generateText({
+                model: modelInstance,
+                messages: [{ role: "user", content: "Reply with: OK" }],
+            });
             Alert.alert(t("ai.settings"), t("ai.connectionSuccess"));
         } catch (e: any) {
             Alert.alert(t("ai.connectionFailed"), e.message ?? t("common.unknownError"));
@@ -165,7 +177,7 @@ export default function AiSettingsScreen() {
                 label={t("ai.apiKey")}
                 value={apiKey}
                 onChangeText={setApiKey}
-                placeholder="nvapi-..."
+                placeholder={API_KEY_PLACEHOLDERS[provider]}
                 secureTextEntry
                 autoCapitalize="none"
                 autoCorrect={false}

--- a/src/features/ai/services/aiConfig.ts
+++ b/src/features/ai/services/aiConfig.ts
@@ -16,25 +16,83 @@ export {
     generateMealPlan, parseMealPlanResponse, parsePartialEntries, validateMealPlanMacros, type GenerateMealPlanOptions
 } from "./mealPlanService";
 
-// ── Secure config persistence ─────────────────────────────
-const STORE_KEY = "ai_provider_config";
+// ── Per-provider settings type ────────────────────────────
+export type ProviderSettings = { apiKey: string; baseUrl: string; model: string };
 
-export async function saveAiConfig(config: AiProviderConfig): Promise<void> {
-    await SecureStore.setItemAsync(STORE_KEY, JSON.stringify(config));
+// ── Storage keys ──────────────────────────────────────────
+/** Legacy key kept only for one-time migration. */
+const LEGACY_STORE_KEY = "ai_provider_config";
+const ACTIVE_PROVIDER_KEY = "ai_active_provider";
+
+function configKeyFor(id: AiProviderId): string {
+    return `ai_config_${id}`;
 }
 
-export async function loadAiConfig(): Promise<AiProviderConfig | null> {
-    const raw = await SecureStore.getItemAsync(STORE_KEY);
+// ── Per-provider CRUD ─────────────────────────────────────
+
+export async function saveProviderSettings(id: AiProviderId, settings: ProviderSettings): Promise<void> {
+    await SecureStore.setItemAsync(configKeyFor(id), JSON.stringify(settings));
+}
+
+export async function loadProviderSettings(id: AiProviderId): Promise<ProviderSettings | null> {
+    const raw = await SecureStore.getItemAsync(configKeyFor(id));
     if (!raw) return null;
     try {
-        return JSON.parse(raw) as AiProviderConfig;
+        return JSON.parse(raw) as ProviderSettings;
     } catch {
         return null;
     }
 }
 
+export async function deleteProviderSettings(id: AiProviderId): Promise<void> {
+    await SecureStore.deleteItemAsync(configKeyFor(id));
+}
+
+export async function loadActiveProvider(): Promise<AiProviderId> {
+    const raw = await SecureStore.getItemAsync(ACTIVE_PROVIDER_KEY);
+    return (raw as AiProviderId | null) ?? "nvidia";
+}
+
+export async function saveActiveProvider(id: AiProviderId): Promise<void> {
+    await SecureStore.setItemAsync(ACTIVE_PROVIDER_KEY, id);
+}
+
+// ── Aggregate helpers (backward-compatible) ───────────────
+
+/** Save a full provider config and mark it as active. */
+export async function saveAiConfig(config: AiProviderConfig): Promise<void> {
+    const { provider, ...settings } = config;
+    await saveProviderSettings(provider, settings);
+    await saveActiveProvider(provider);
+}
+
+/**
+ * Load the active provider's config.
+ * Migrates the legacy single-key format on first call.
+ */
+export async function loadAiConfig(): Promise<AiProviderConfig | null> {
+    const active = await loadActiveProvider();
+    const settings = await loadProviderSettings(active);
+    if (settings) return { provider: active, ...settings };
+
+    // One-time migration from old single-key storage
+    const raw = await SecureStore.getItemAsync(LEGACY_STORE_KEY);
+    if (!raw) return null;
+    try {
+        const legacy = JSON.parse(raw) as AiProviderConfig;
+        await saveProviderSettings(legacy.provider, { apiKey: legacy.apiKey, baseUrl: legacy.baseUrl, model: legacy.model });
+        await saveActiveProvider(legacy.provider);
+        await SecureStore.deleteItemAsync(LEGACY_STORE_KEY);
+        return legacy;
+    } catch {
+        return null;
+    }
+}
+
+/** Delete the active provider's saved config. */
 export async function deleteAiConfig(): Promise<void> {
-    await SecureStore.deleteItemAsync(STORE_KEY);
+    const active = await loadActiveProvider();
+    await deleteProviderSettings(active);
 }
 
 // ── Defaults per provider ─────────────────────────────────

--- a/src/features/ai/services/chat.ts
+++ b/src/features/ai/services/chat.ts
@@ -1,3 +1,4 @@
+import logger from "@/src/utils/logger";
 import type { CoreMessage } from "ai";
 import { streamText } from "ai";
 import type { AiProviderConfig } from "../types";
@@ -287,6 +288,7 @@ async function callAi(
     opts.onStreamStatus?.("connecting");
 
     // console.log("API messages:", JSON.stringify(messages));
+    logger.info("Sending messages to AI", { provider: config.provider, model: config.model, messageCount: messages.length });
 
     const result = streamText({
         model,

--- a/src/features/ai/services/providers.ts
+++ b/src/features/ai/services/providers.ts
@@ -10,6 +10,10 @@ export const PROVIDER_DEFAULTS: Record<AiProviderId, { baseUrl: string; model: s
         baseUrl: "https://integrate.api.nvidia.com/v1",
         model: "meta/llama-3.1-70b-instruct",
     },
+    openai: {
+        baseUrl: "https://api.openai.com/v1",
+        model: "gpt-4o-mini",
+    },
 };
 
 // ── Model factory ─────────────────────────────────────────

--- a/src/features/ai/services/providers.ts
+++ b/src/features/ai/services/providers.ts
@@ -12,7 +12,7 @@ export const PROVIDER_DEFAULTS: Record<AiProviderId, { baseUrl: string; model: s
     },
     openai: {
         baseUrl: "https://api.openai.com/v1",
-        model: "gpt-4o-mini",
+        model: "gpt-5.4-mini",
     },
 };
 

--- a/src/features/ai/types.ts
+++ b/src/features/ai/types.ts
@@ -1,5 +1,5 @@
 /** Supported AI provider identifiers. */
-export type AiProviderId = "nvidia";
+export type AiProviderId = "nvidia" | "openai";
 
 /** Configuration needed to connect to an AI provider. */
 export interface AiProviderConfig {


### PR DESCRIPTION
## Summary

Closes #180

Adds OpenAI as a second AI provider and makes each provider's configuration (API key, base URL, model) independent — switching providers no longer overwrites the other provider's settings.

## Changes

### New provider
- **`types.ts`** — extend `AiProviderId` with `"openai"`
- **`providers.ts`** — add OpenAI defaults (`https://api.openai.com/v1`, `gpt-4o-mini`)
- **`AiSettingsScreen.tsx`** — add OpenAI chip and dynamic API key placeholder (`sk-...`)

### Per-provider persistence
- **`aiConfig.ts`** — each provider's config is stored in its own SecureStore key (`ai_config_nvidia`, `ai_config_openai`, …); a separate `ai_active_provider` key tracks which provider is selected. Added: `saveProviderSettings`, `loadProviderSettings`, `deleteProviderSettings`, `loadActiveProvider`, `saveActiveProvider`. Existing `loadAiConfig` / `saveAiConfig` / `deleteAiConfig` are preserved for backward compatibility and include a one-time migration from the old single-key format.
- **`AiSettingsScreen.tsx`** — state replaced with a per-provider `configs` map; switching the provider chip now shows that provider's own saved values instead of resetting the fields.

### Bug fix
- The test-connection button was broken for all providers (called non-existent `getProvider()`); replaced with `createModelFromConfig` + `generateText` from the AI SDK.