### PR TITLE
feat: persistent AI memory

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -100,6 +100,7 @@ export default function TabsLayout() {
             <Tabs.Screen name="settings" options={{ href: null }} />
             <Tabs.Screen name="ai-settings" options={{ href: null }} />
             <Tabs.Screen name="meal-plan" options={{ href: null }} />
+            <Tabs.Screen name="ai-memories" options={{ href: null }} />
         </Tabs>
     );
 }

--- a/app/(tabs)/ai-memories.tsx
+++ b/app/(tabs)/ai-memories.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/src/features/ai/screens/AiMemoriesScreen";

--- a/src/features/ai/constants/toolDefinitions.ts
+++ b/src/features/ai/constants/toolDefinitions.ts
@@ -153,6 +153,23 @@ const readRecentMacrosTool: AiToolDefinition = {
     },
 };
 
+const saveMemoryTool: AiToolDefinition = {
+    name: "save_memory",
+    description:
+        "Permanently save a piece of information about the user (e.g. food preferences, dietary restrictions, goals) " +
+        "so you remember it in future conversations. " +
+        "Use this whenever the user shares personal preferences or information that would be useful to recall later. " +
+        "Keep memories concise and factual (e.g. \"User dislikes fish and broccoli\", \"User prefers high-protein breakfasts\").",
+    needsApproval: false,
+    parameters: {
+        type: "object",
+        properties: {
+            content: { type: "string", description: "The information to remember. Keep it short and factual." },
+        },
+        required: ["content"],
+    },
+};
+
 export const AI_TOOLS: AiToolDefinition[] = [
     createMealPlanTool,
     readEntriesTool,
@@ -163,4 +180,5 @@ export const AI_TOOLS: AiToolDefinition[] = [
     searchTemplatesTool,
     readRecentEntriesTool,
     readRecentMacrosTool,
+    saveMemoryTool,
 ];

--- a/src/features/ai/helpers/chat.ts
+++ b/src/features/ai/helpers/chat.ts
@@ -1,6 +1,7 @@
 import logger from "@/src/utils/logger";
 import type { CoreMessage, LanguageModel } from "ai";
 import { streamText } from "ai";
+import { getAllMemories } from "../services/aiMemoriesDb";
 import type { UiChatMessage } from "../types/chatTypes";
 import type { AiCallResult, AiProviderConfig } from "../types/types";
 import { buildToolSystemPrompt, toAiSdkTools } from "./tools";
@@ -64,7 +65,7 @@ export function formatToolResultForAi(msg: UiChatMessage): string {
 export function toApiMessages(uiMessages: UiChatMessage[]): CoreMessage[] {
     const systemMsg: CoreMessage = {
         role: "system",
-        content: buildToolSystemPrompt(),
+        content: buildToolSystemPrompt(getAllMemories().map((m) => m.content)),
     };
 
     const history: CoreMessage[] = [];

--- a/src/features/ai/helpers/tools.ts
+++ b/src/features/ai/helpers/tools.ts
@@ -14,10 +14,10 @@ export function toolNeedsApproval(toolName: string): boolean {
 
 // ── System prompt for AI SDK native tool calling ──────────
 
-export function buildToolSystemPrompt(): string {
+export function buildToolSystemPrompt(memories: string[] = []): string {
     const today = formatDateKey(new Date());
 
-    return [
+    const parts = [
         "You are a helpful nutrition and meal planning assistant inside a food tracking app called MacroFlow.",
         "You can help users with their diet by using the provided tools or your own knowledge.",
         "",
@@ -33,7 +33,18 @@ export function buildToolSystemPrompt(): string {
         "- Before creating an entry, ALWAYS use search_templates first to find the correct food_id. Never guess IDs.",
         "- Before modifying or removing an entry, ALWAYS use read_entries first to find the correct entry_id.",
         "- When the user says 'today', use the date provided above. Calculate other relative dates from it.",
-    ].join("\n");
+        "- When the user shares new preferences or personal information, use the save_memory tool to store it.",
+    ];
+
+    if (memories.length > 0) {
+        parts.push(
+            "",
+            "MEMORIES (things you know about this user):",
+            ...memories.map((m) => `- ${m}`),
+        );
+    }
+
+    return parts.join("\n");
 }
 
 

--- a/src/features/ai/hooks/useAiMemories.ts
+++ b/src/features/ai/hooks/useAiMemories.ts
@@ -1,0 +1,58 @@
+import { addMemory, deleteMemory, getAllMemories, updateMemory, type AiMemory } from "../services/aiMemoriesDb";
+import { useCallback, useState } from "react";
+
+export function useAiMemories() {
+    const [memories, setMemories] = useState<AiMemory[]>(() => getAllMemories());
+    const [newText, setNewText] = useState("");
+    const [editId, setEditId] = useState<number | null>(null);
+    const [editText, setEditText] = useState("");
+
+    const refresh = useCallback(() => setMemories(getAllMemories()), []);
+
+    function handleAdd() {
+        const text = newText.trim();
+        if (!text) return;
+        addMemory(text);
+        setNewText("");
+        refresh();
+    }
+
+    function startEdit(memory: AiMemory) {
+        setEditId(memory.id);
+        setEditText(memory.content);
+    }
+
+    function cancelEdit() {
+        setEditId(null);
+        setEditText("");
+    }
+
+    function handleSaveEdit() {
+        if (editId === null) return;
+        const text = editText.trim();
+        if (!text) return;
+        updateMemory(editId, text);
+        setEditId(null);
+        setEditText("");
+        refresh();
+    }
+
+    function handleDelete(id: number) {
+        deleteMemory(id);
+        refresh();
+    }
+
+    return {
+        memories,
+        newText,
+        setNewText,
+        editId,
+        editText,
+        setEditText,
+        handleAdd,
+        startEdit,
+        cancelEdit,
+        handleSaveEdit,
+        handleDelete,
+    };
+}

--- a/src/features/ai/screens/AiMemoriesScreen.tsx
+++ b/src/features/ai/screens/AiMemoriesScreen.tsx
@@ -1,0 +1,141 @@
+import Button from "@/src/shared/atoms/Button";
+import Input from "@/src/shared/atoms/Input";
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAiMemories } from "../hooks/useAiMemories";
+
+export default function AiMemoriesScreen() {
+    const { t } = useTranslation();
+    const colors = useThemeColors();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
+    const router = useRouter();
+
+    const {
+        memories, newText, setNewText,
+        editId, editText, setEditText,
+        handleAdd, startEdit, cancelEdit, handleSaveEdit, handleDelete,
+    } = useAiMemories();
+
+    function confirmDelete(id: number) {
+        Alert.alert(
+            t("memory.deleteTitle"),
+            t("memory.deleteConfirm"),
+            [
+                { text: t("common.cancel"), style: "cancel" },
+                { text: t("common.delete"), style: "destructive", onPress: () => handleDelete(id) },
+            ],
+        );
+    }
+
+    return (
+        <ScrollView
+            style={styles.screen}
+            contentContainerStyle={[styles.content, { paddingTop: insets.top + spacing.lg }]}
+            keyboardShouldPersistTaps="handled"
+        >
+            <View style={styles.headerRow}>
+                <Pressable onPress={() => router.navigate("/(tabs)/more" as any)} style={styles.backBtn} hitSlop={8}>
+                    <Ionicons name="chevron-back" size={24} color={colors.primary} />
+                </Pressable>
+                <Text style={styles.heading}>{t("memory.title")}</Text>
+            </View>
+
+            <Text style={styles.description}>{t("memory.description")}</Text>
+
+            {memories.length === 0 && (
+                <Text style={styles.emptyText}>{t("memory.empty")}</Text>
+            )}
+
+            {memories.map((memory) => (
+                <View key={memory.id} style={styles.memoryCard}>
+                    {editId === memory.id ? (
+                        <View style={styles.editRow}>
+                            <Input
+                                value={editText}
+                                onChangeText={setEditText}
+                                containerStyle={styles.editInput}
+                                autoFocus
+                                multiline
+                            />
+                            <View style={styles.editActions}>
+                                <Button title={t("common.save")} onPress={handleSaveEdit} style={styles.saveBtn} />
+                                <Button title={t("common.cancel")} onPress={cancelEdit} variant="outline" style={styles.cancelBtn} />
+                            </View>
+                        </View>
+                    ) : (
+                        <View style={styles.memoryRow}>
+                            <Ionicons name="bookmark-outline" size={16} color={colors.primary} style={styles.memoryIcon} />
+                            <Text style={styles.memoryText}>{memory.content}</Text>
+                            <View style={styles.memoryActions}>
+                                <Pressable onPress={() => startEdit(memory)} hitSlop={8} style={styles.iconBtn}>
+                                    <Ionicons name="pencil-outline" size={18} color={colors.textSecondary} />
+                                </Pressable>
+                                <Pressable onPress={() => confirmDelete(memory.id)} hitSlop={8} style={styles.iconBtn}>
+                                    <Ionicons name="trash-outline" size={18} color={colors.danger} />
+                                </Pressable>
+                            </View>
+                        </View>
+                    )}
+                </View>
+            ))}
+
+            <Text style={styles.sectionLabel}>{t("memory.addNew")}</Text>
+            <Input
+                value={newText}
+                onChangeText={setNewText}
+                placeholder={t("memory.addPlaceholder")}
+                multiline
+                containerStyle={styles.addInput}
+            />
+            <Button title={t("memory.add")} onPress={handleAdd} style={styles.addBtn} />
+        </ScrollView>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        screen: { flex: 1, backgroundColor: colors.background },
+        content: { padding: spacing.lg, paddingBottom: 40 },
+        headerRow: { flexDirection: "row", alignItems: "center", marginBottom: spacing.lg, gap: spacing.sm },
+        backBtn: { padding: spacing.xs },
+        heading: { fontSize: fontSize.xl, fontWeight: "700", color: colors.text },
+        description: { fontSize: fontSize.sm, color: colors.textSecondary, marginBottom: spacing.lg },
+        emptyText: { fontSize: fontSize.sm, color: colors.textTertiary, textAlign: "center", marginVertical: spacing.xl },
+        memoryCard: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+            padding: spacing.md,
+            marginBottom: spacing.sm,
+        },
+        memoryRow: { flexDirection: "row", alignItems: "flex-start", gap: spacing.sm },
+        memoryIcon: { marginTop: 2 },
+        memoryText: { flex: 1, fontSize: fontSize.sm, color: colors.text, lineHeight: 20 },
+        memoryActions: { flexDirection: "row", gap: spacing.xs },
+        iconBtn: { padding: spacing.xs },
+        editRow: { gap: spacing.sm },
+        editInput: { flex: 1 },
+        editActions: { flexDirection: "row", gap: spacing.sm },
+        saveBtn: { flex: 1 },
+        cancelBtn: { flex: 1 },
+        sectionLabel: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            textTransform: "uppercase",
+            letterSpacing: 0.8,
+            marginTop: spacing.lg,
+            marginBottom: spacing.sm,
+        },
+        addInput: { marginBottom: spacing.sm },
+        addBtn: {},
+    });
+}

--- a/src/features/ai/services/aiMemoriesDb.ts
+++ b/src/features/ai/services/aiMemoriesDb.ts
@@ -1,0 +1,29 @@
+import { db } from "@/src/services/db";
+import { aiMemories } from "@/src/services/db/schema";
+import { eq } from "drizzle-orm";
+
+export type AiMemory = typeof aiMemories.$inferSelect;
+
+export function getAllMemories(): AiMemory[] {
+    return db.select().from(aiMemories).orderBy(aiMemories.created_at).all();
+}
+
+export function addMemory(content: string): AiMemory {
+    const rows = db
+        .insert(aiMemories)
+        .values({ content: content.trim(), created_at: Date.now() })
+        .returning()
+        .all();
+    return rows[0];
+}
+
+export function updateMemory(id: number, content: string): void {
+    db.update(aiMemories)
+        .set({ content: content.trim() })
+        .where(eq(aiMemories.id, id))
+        .run();
+}
+
+export function deleteMemory(id: number): void {
+    db.delete(aiMemories).where(eq(aiMemories.id, id)).run();
+}

--- a/src/features/ai/services/toolExecutors.ts
+++ b/src/features/ai/services/toolExecutors.ts
@@ -6,6 +6,7 @@ import logger from "@/src/utils/logger";
 import { VALID_MEAL_TYPES } from "../constants/toolDefinitions";
 import type { AiToolCall, AiToolResult } from "../types/toolDefinitionTypes";
 import type { AiFoodPayload, AiGoalsPayload, AiRecipePayload } from "../types/types";
+import { addMemory } from "./aiMemoriesDb";
 import { buildMealPlanPrompt } from "./mealPlanService";
 
 // ── Validators ────────────────────────────────────────────
@@ -233,6 +234,15 @@ function executeReadRecentMacros(args: Record<string, unknown>): AiToolResult {
 
 // ── Registry + public API ─────────────────────────────────
 
+function executeSaveMemory(args: Record<string, unknown>): AiToolResult {
+    const content = String(args.content ?? "").trim();
+    if (!content) return { success: false, summary: "Memory content cannot be empty." };
+    if (content.length > 500) return { success: false, summary: "Memory content is too long. Max 500 characters." };
+
+    addMemory(content);
+    return { success: true, summary: `Memory saved: "${content}"` };
+}
+
 const toolExecutors: Record<string, ToolExecutor> = {
     create_meal_plan: executeCreateMealPlan,
     read_entries: executeReadEntries,
@@ -243,6 +253,7 @@ const toolExecutors: Record<string, ToolExecutor> = {
     search_templates: executeSearchTemplates,
     read_recent_entries: executeReadRecentEntries,
     read_recent_macros: executeReadRecentMacros,
+    save_memory: executeSaveMemory,
 };
 
 export function executeTool(call: AiToolCall): AiToolResult {

--- a/src/features/more/screens/MoreScreen.tsx
+++ b/src/features/more/screens/MoreScreen.tsx
@@ -28,6 +28,7 @@ export default function MoreScreen() {
         { icon: "archive", labelKey: "more.backup", route: "/(tabs)/backup", color: "#4ECDC4" },
         { icon: "sparkles", labelKey: "more.mealPlan", route: "/(tabs)/meal-plan", color: "#A855F7" },
         { icon: "hardware-chip", labelKey: "more.aiSettings", route: "/(tabs)/ai-settings", color: "#F59E0B" },
+        { icon: "bookmark", labelKey: "more.aiMemories", route: "/(tabs)/ai-memories", color: "#10B981" },
     ];
 
     return (

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -241,6 +241,17 @@ const de = {
         backup: "Datensicherung",
         aiSettings: "KI-Einstellungen",
         mealPlan: "KI-Essensplan",
+        aiMemories: "KI-Erinnerungen",
+    },
+    memory: {
+        title: "KI-Erinnerungen",
+        description: "Die KI merkt sich diese Informationen über dich in allen Gesprächen. Sei präzise und kurz, um die AI nicht zu überladen.",
+        empty: "Noch keine Erinnerungen — die KI speichert hier, was du ihr erzählst.",
+        addNew: "ERINNERUNG HINZUFÜGEN",
+        addPlaceholder: "z.B. Ich mag keinen Fisch und keinen Brokkoli",
+        add: "Erinnerung hinzufügen",
+        deleteTitle: "Erinnerung löschen",
+        deleteConfirm: "Diese Erinnerung entfernen?",
     },
     dbTest: {
         title: "DB-Ende-zu-Ende-Test",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -240,6 +240,17 @@ const en = {
         backup: "Backup Data",
         aiSettings: "AI Settings",
         mealPlan: "AI Meal Plan",
+        aiMemories: "AI Memories",
+    },
+    memory: {
+        title: "AI Memories",
+        description: "The AI remembers these facts about you across all conversations. Keep it concise to avoid overwhelming the AI.",
+        empty: "No memories yet — the AI will save things you tell it here.",
+        addNew: "ADD MEMORY",
+        addPlaceholder: "e.g. I dislike fish and broccoli",
+        add: "Add Memory",
+        deleteTitle: "Delete Memory",
+        deleteConfirm: "Remove this memory?",
     },
     dbTest: {
         title: "DB End-to-End Test",

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -108,6 +108,12 @@ export function initDB() {
       timestamp INTEGER NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS ai_memories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      content TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
     INSERT OR IGNORE INTO goals (id) VALUES (1);
     INSERT OR IGNORE INTO notification_settings (id) VALUES (1);
   `);

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -111,3 +111,9 @@ export const chatMessages = sqliteTable("chat_messages", {
     tool_call_id: text("tool_call_id"),
     timestamp: integer("timestamp").notNull(),
 });
+
+export const aiMemories = sqliteTable("ai_memories", {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    content: text("content").notNull(),
+    created_at: integer("created_at").notNull(),
+});


### PR DESCRIPTION
## Summary

Closes #157

Implements persistent AI memory so the AI remembers user preferences across conversations.

## Changes

### Database
- Added `ai_memories` table to schema and `initDB()`

### AI Tool
- Added `save_memory` tool (no approval needed) — the AI can silently save facts about the user
- Registered executor in `toolExecutors`
- Added rule to system prompt instructing AI to save preferences automatically

### AI Chat
- Memories are loaded and injected into the system prompt at the start of every conversation

### UI — AI Memories screen
- New "AI Memories" entry in the More tab menu
- Screen that lists all stored memories with edit and delete per item
- Add new memories manually via text input
- Route: `/(tabs)/ai-memories`

### i18n
- Added `more.aiMemories` and `memory.*` keys to both `en.ts` and `de.ts`