### PR TITLE
fix: Add missing toolCall to tool-result messages in executeApprovedTool

### DIFF
--- a/src/features/ai/services/chat.ts
+++ b/src/features/ai/services/chat.ts
@@ -191,6 +191,7 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
                     content: `Meal plan generated with ${plan.entries.length} entries. Review below:`,
                     toolResult: { success: true, summary: `${plan.entries.length} entries ready` },
                     toolResultData: { mealPlanEntries: plan.entries },
+                    toolCall: opts.toolCall,
                     toolCallId: opts.toolCallId,
                     timestamp: Date.now(),
                 };
@@ -202,6 +203,7 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
                     role: "tool-result",
                     content: `Failed to parse meal plan: ${e.message}`,
                     toolResult: { success: false, summary: e.message },
+                    toolCall: opts.toolCall,
                     toolCallId: opts.toolCallId,
                     timestamp: Date.now(),
                 };
@@ -216,6 +218,7 @@ export async function executeApprovedTool(opts: ToolApprovalOptions): Promise<vo
         role: "tool-result",
         content: result.summary,
         toolResult: result,
+        toolCall: opts.toolCall,
         toolCallId: opts.toolCallId,
         timestamp: Date.now(),
     };


### PR DESCRIPTION
## Summary

Resolves #187

## Root cause

When a user approves a tool call (e.g. "create food template"), `executeApprovedTool` executes the tool and builds a `UiChatMessage` with `role: "tool-result"`. That message was missing the `toolCall` property.

In `toApiMessages()`, the `tool-result` branch checks `m.toolCallId && m.toolCall`. Without `toolCall` the condition is false, so the message is serialised as a plain `user` message instead of the required `tool` role message. The AI then sees an assistant `tool-call` with no corresponding `tool-result`, triggering `AI_MissingToolResultsError`.

Because the broken `tool-result` message is persisted in the message history, every subsequent chat message hit the same error, bricking the chat session.

## Fix

Added `toolCall: opts.toolCall` to all three `tool-result` message objects inside `executeApprovedTool`:
- Main result path
- Meal plan success path
- Meal plan error path

The auto-approval path in `sendChatMessage` and the decline path in `declineToolCall` already set this property correctly.