### PR TITLE
feat: consistent AI unit support

### DIFF
--- a/src/features/ai/constants/toolDefinitions/entryToolDefinitions.ts
+++ b/src/features/ai/constants/toolDefinitions/entryToolDefinitions.ts
@@ -55,17 +55,24 @@ const logFoodTool: AiToolDefinition = {
     name: "log_food",
     description:
         "Log a food entry to the user's diary. Requires a valid food_id from the user's food library. " +
-        "Use search_library first to find the correct food_id.",
+        "Use search_library first to find the correct food_id and available units.",
     needsApproval: true,
     parameters: {
         type: "object",
         properties: {
             food_id: { type: "number", description: "The ID of the food from the user's library." },
-            quantity_grams: { type: "number", description: "Amount in grams." },
+            quantity: { type: "number", description: "The amount in the specified unit." },
+            unit: {
+                type: "string",
+                description:
+                    "The unit for the quantity. Can be a standard unit (g, ml, oz, fl_oz, cup, tbsp, tsp, lb) " +
+                    "or a custom serving unit name from the food's serving_units (as returned by search_library). " +
+                    "Defaults to the food's default_unit if omitted.",
+            },
             date: { type: "string", description: "The date for the entry, in YYYY-MM-DD format." },
             meal_type: { type: "string", description: "The meal type.", enum: ["breakfast", "lunch", "dinner", "snack"] },
         },
-        required: ["food_id", "quantity_grams", "date", "meal_type"],
+        required: ["food_id", "quantity", "date", "meal_type"],
     },
 };
 
@@ -96,9 +103,15 @@ const updateLogEntryTool: AiToolDefinition = {
         type: "object",
         properties: {
             entry_id: { type: "number", description: "The ID of the entry to update." },
-            quantity_grams: { type: "number", description: "The new amount in grams." },
+            quantity: { type: "number", description: "The new amount in the specified unit." },
+            unit: {
+                type: "string",
+                description:
+                    "The unit for the quantity. Can be a standard unit (g, ml, oz, fl_oz, cup, tbsp, tsp, lb) " +
+                    "or a custom serving unit name. If omitted, the entry's current unit is kept.",
+            },
         },
-        required: ["entry_id", "quantity_grams"],
+        required: ["entry_id", "quantity"],
     },
 };
 

--- a/src/features/ai/constants/toolDefinitions/templateToolDefinitions.ts
+++ b/src/features/ai/constants/toolDefinitions/templateToolDefinitions.ts
@@ -5,8 +5,8 @@ import type { AiToolDefinition } from "../../types/toolDefinitionTypes";
 const searchLibraryTool: AiToolDefinition = {
     name: "search_library",
     description:
-        "Search the user's food library and recipes by name. Returns matching foods with their IDs, macros, and serving info. " +
-        "Use this to find food_id values before logging food or managing templates. " +
+        "Search the user's food library and recipes by name. Returns matching foods with their IDs, macros, serving info, and available serving units. " +
+        "Use this to find food_id values and unit options before logging food or managing templates. " +
         "It's a simple text inclusion search, so searching for 'chicken' will match 'grilled chicken breast' and 'chicken salad' (if they exist), etc. " +
         "Searching for something like \"dinner\" or \"healthy recipes\" will most likely NOT return relevant results, so DON'T use it for that.",
     needsApproval: false,
@@ -155,9 +155,15 @@ const addRecipeItemTool: AiToolDefinition = {
         properties: {
             recipe_id: { type: "number", description: "The ID of the recipe to add the ingredient to." },
             food_id: { type: "number", description: "The ID of the food to add as an ingredient." },
-            quantity_grams: { type: "number", description: "The amount of this ingredient in grams." },
+            quantity: { type: "number", description: "The amount of this ingredient in the specified unit." },
+            unit: {
+                type: "string",
+                description:
+                    "The unit for the quantity. Can be a standard unit (g, ml, oz, fl_oz, cup, tbsp, tsp, lb) " +
+                    "or a custom serving unit name. Defaults to the food's default_unit if omitted.",
+            },
         },
-        required: ["recipe_id", "food_id", "quantity_grams"],
+        required: ["recipe_id", "food_id", "quantity"],
     },
 };
 

--- a/src/features/ai/helpers/tools.ts
+++ b/src/features/ai/helpers/tools.ts
@@ -34,6 +34,12 @@ export function buildToolSystemPrompt(memories: string[] = []): string {
         "- Before modifying or removing an entry, ALWAYS use read_entries first to find the correct entry_id.",
         "- When the user says 'today', use the date provided above. Calculate other relative dates from it.",
         "- When the user shares new preferences or personal information, use the save_memory tool to store it.",
+        "",
+        "UNITS:",
+        "- When logging or updating food entries you can use any standard unit (g, ml, oz, fl_oz, cup, tbsp, tsp, lb) or a custom serving unit defined on the food.",
+        "- Use search_library to see which units are available for a food (serving_units field).",
+        "- Prefer the food's custom serving units or default_unit when they make sense (e.g. '1 piece' instead of guessing grams).",
+        "- If no custom unit fits, use a standard unit that is natural for the food (e.g. ml for liquids, g for solids).",
     ];
 
     if (memories.length > 0) {

--- a/src/features/ai/services/toolExecutors/entryToolExecutors.ts
+++ b/src/features/ai/services/toolExecutors/entryToolExecutors.ts
@@ -2,6 +2,7 @@ import { addEntry, deleteEntry, getEntriesByDate, getEntriesByDateRange, getEntr
 import { getFoodById } from "@/src/features/templates/services/templateDb";
 import { parseDateKey, shiftCalendarDate } from "@/src/utils/date";
 import { VALID_MEAL_TYPES } from "../../constants/toolDefinitions/entryToolDefinitions";
+import { displayQuantity, resolveQuantityToGrams } from "../unitResolution";
 import type { AiToolResult } from "../../types/toolDefinitionTypes";
 
 type ToolExecutor = (args: Record<string, unknown>) => AiToolResult;
@@ -23,16 +24,18 @@ function executeReadLogEntries(args: Record<string, unknown>): AiToolResult {
     if (!isValidDateKey(date)) return { success: false, summary: "Invalid date format. Use YYYY-MM-DD." };
 
     const rows = getEntriesByDate(parseDateKey(date));
-    const result = rows.map((row) => ({
-        entry_id: row.entries.id, food_id: row.entries.food_id,
-        food_name: row.foods?.name ?? "Unknown", quantity_grams: row.entries.quantity_grams,
-        quantity_unit: row.entries.quantity_unit, meal_type: row.entries.meal_type,
-        is_scheduled: row.entries.is_scheduled,
-        calories: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.calories_per_100g).toFixed(1) : 0,
-        protein: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.protein_per_100g).toFixed(1) : 0,
-        carbs: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.carbs_per_100g).toFixed(1) : 0,
-        fat: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.fat_per_100g).toFixed(1) : 0,
-    }));
+    const result = rows.map((row) => {
+        const display = displayQuantity(row.entries.quantity_grams, row.entries.quantity_unit, row.entries.food_id);
+        return {
+            entry_id: row.entries.id, food_id: row.entries.food_id,
+            food_name: row.foods?.name ?? "Unknown", quantity: display.quantity, unit: display.unit,
+            meal_type: row.entries.meal_type, is_scheduled: row.entries.is_scheduled,
+            calories: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.calories_per_100g).toFixed(1) : 0,
+            protein: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.protein_per_100g).toFixed(1) : 0,
+            carbs: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.carbs_per_100g).toFixed(1) : 0,
+            fat: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.fat_per_100g).toFixed(1) : 0,
+        };
+    });
 
     return { success: true, summary: `Found ${result.length} entries for ${date}.`, data: result };
 }
@@ -47,9 +50,10 @@ function executeReadRecentLogEntries(args: Record<string, unknown>): AiToolResul
     for (const row of rows) {
         const date = row.entries.date;
         if (!grouped[date]) grouped[date] = [];
+        const display = displayQuantity(row.entries.quantity_grams, row.entries.quantity_unit, row.entries.food_id);
         grouped[date].push({
             entry_id: row.entries.id, food_id: row.entries.food_id,
-            food_name: row.foods?.name ?? "Unknown", quantity_grams: row.entries.quantity_grams,
+            food_name: row.foods?.name ?? "Unknown", quantity: display.quantity, unit: display.unit,
             meal_type: row.entries.meal_type,
             calories: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.calories_per_100g).toFixed(1) : 0,
             protein: row.foods ? +(row.entries.quantity_grams / 100 * row.foods.protein_per_100g).toFixed(1) : 0,
@@ -91,27 +95,31 @@ function executeReadRecentMacros(args: Record<string, unknown>): AiToolResult {
 
 function executeLogFood(args: Record<string, unknown>): AiToolResult {
     const foodId = Number(args.food_id);
-    const quantityGrams = Number(args.quantity_grams);
+    const quantity = Number(args.quantity);
     const date = String(args.date ?? "");
     const mealType = String(args.meal_type ?? "");
 
     if (!foodId || isNaN(foodId)) return { success: false, summary: "Invalid food_id." };
-    if (!quantityGrams || quantityGrams <= 0) return { success: false, summary: "quantity_grams must be a positive number." };
+    if (!quantity || quantity <= 0) return { success: false, summary: "quantity must be a positive number." };
     if (!isValidDateKey(date)) return { success: false, summary: "Invalid date format. Use YYYY-MM-DD." };
     if (!isValidMealType(mealType)) return { success: false, summary: `Invalid meal_type. Must be one of: ${VALID_MEAL_TYPES.join(", ")}.` };
 
     const food = getFoodById(foodId);
     if (!food) return { success: false, summary: `Food with id ${foodId} not found. Use search_library to find valid food IDs.` };
 
+    const unit = args.unit != null ? String(args.unit).trim() : food.default_unit;
+    const resolved = resolveQuantityToGrams(quantity, unit, foodId);
+    if ("error" in resolved) return { success: false, summary: resolved.error };
+
     const entry = addEntry({
-        food_id: foodId, quantity_grams: quantityGrams, quantity_unit: "g",
+        food_id: foodId, quantity_grams: resolved.grams, quantity_unit: unit,
         timestamp: Date.now(), date, meal_type: mealType,
     });
 
     return {
         success: true,
-        summary: `Added ${quantityGrams}g of "${food.name}" to ${mealType} on ${date}.`,
-        data: { entry_id: entry.id, food_name: food.name, quantity_grams: quantityGrams, date, meal_type: mealType },
+        summary: `Added ${quantity} ${unit} of "${food.name}" to ${mealType} on ${date}.`,
+        data: { entry_id: entry.id, food_name: food.name, quantity, unit, date, meal_type: mealType },
     };
 }
 
@@ -144,18 +152,25 @@ function executeMoveLogEntry(args: Record<string, unknown>): AiToolResult {
 
 function executeUpdateLogEntry(args: Record<string, unknown>): AiToolResult {
     const entryId = Number(args.entry_id);
-    const quantityGrams = Number(args.quantity_grams);
+    const quantity = Number(args.quantity);
     if (!entryId || isNaN(entryId)) return { success: false, summary: "Invalid entry_id." };
-    if (!quantityGrams || quantityGrams <= 0) return { success: false, summary: "quantity_grams must be a positive number." };
+    if (!quantity || quantity <= 0) return { success: false, summary: "quantity must be a positive number." };
 
     const row = getEntryById(entryId);
     if (!row) return { success: false, summary: `Entry with id ${entryId} not found. Use read_log_entries to find valid entry IDs.` };
 
-    updateEntry(entryId, { quantity_grams: quantityGrams });
+    const unit = args.unit != null ? String(args.unit).trim() : row.entries.quantity_unit;
+    const foodId = row.entries.food_id;
+    if (!foodId) return { success: false, summary: "Entry has no associated food." };
+
+    const resolved = resolveQuantityToGrams(quantity, unit, foodId);
+    if ("error" in resolved) return { success: false, summary: resolved.error };
+
+    updateEntry(entryId, { quantity_grams: resolved.grams, quantity_unit: unit });
     return {
         success: true,
-        summary: `Updated entry ${entryId} ("${row.foods?.name ?? "Unknown"}") to ${quantityGrams}g.`,
-        data: { entry_id: entryId, food_name: row.foods?.name, quantity_grams: quantityGrams },
+        summary: `Updated entry ${entryId} ("${row.foods?.name ?? "Unknown"}") to ${quantity} ${unit}.`,
+        data: { entry_id: entryId, food_name: row.foods?.name, quantity, unit },
     };
 }
 

--- a/src/features/ai/services/toolExecutors/templateToolExecutors.ts
+++ b/src/features/ai/services/toolExecutors/templateToolExecutors.ts
@@ -7,6 +7,7 @@ import {
     getRecipeById,
     getRecipeItemById,
     getRecipeItems,
+    getServingUnits,
     searchFoodsByName,
     searchRecipesByName,
     softDeleteFood,
@@ -15,6 +16,7 @@ import {
     updateRecipe,
     type NewFood,
 } from "@/src/features/templates/services/templateDb";
+import { resolveQuantityToGrams } from "../unitResolution";
 import type { AiToolResult } from "../../types/toolDefinitionTypes";
 
 type ToolExecutor = (args: Record<string, unknown>) => AiToolResult;
@@ -25,12 +27,16 @@ function executeSearchLibrary(args: Record<string, unknown>): AiToolResult {
     const query = String(args.query ?? "").trim();
     if (!query) return { success: false, summary: "Search query cannot be empty." };
 
-    const matchedFoods = searchFoodsByName(query).map((f) => ({
-        type: "food" as const, id: f.id, name: f.name,
-        calories_per_100g: f.calories_per_100g, protein_per_100g: f.protein_per_100g,
-        carbs_per_100g: f.carbs_per_100g, fat_per_100g: f.fat_per_100g,
-        default_unit: f.default_unit, serving_size: f.serving_size,
-    }));
+    const matchedFoods = searchFoodsByName(query).map((f) => {
+        const servingUnits = getServingUnits(f.id).map((u) => ({ name: u.name, grams: u.grams }));
+        return {
+            type: "food" as const, id: f.id, name: f.name,
+            calories_per_100g: f.calories_per_100g, protein_per_100g: f.protein_per_100g,
+            carbs_per_100g: f.carbs_per_100g, fat_per_100g: f.fat_per_100g,
+            default_unit: f.default_unit, serving_size: f.serving_size,
+            serving_units: servingUnits,
+        };
+    });
     const matchedRecipes = searchRecipesByName(query).map((r) => ({ type: "recipe" as const, id: r.id, name: r.name }));
     const results = [...matchedFoods, ...matchedRecipes];
 
@@ -211,11 +217,11 @@ function executeReadRecipeTemplate(args: Record<string, unknown>): AiToolResult 
 function executeAddRecipeItem(args: Record<string, unknown>): AiToolResult {
     const recipeId = Number(args.recipe_id);
     const foodId = Number(args.food_id);
-    const quantityGrams = Number(args.quantity_grams);
+    const quantity = Number(args.quantity);
 
     if (!recipeId || isNaN(recipeId)) return { success: false, summary: "Invalid recipe_id." };
     if (!foodId || isNaN(foodId)) return { success: false, summary: "Invalid food_id." };
-    if (!quantityGrams || quantityGrams <= 0) return { success: false, summary: "quantity_grams must be a positive number." };
+    if (!quantity || quantity <= 0) return { success: false, summary: "quantity must be a positive number." };
 
     const recipe = getRecipeById(recipeId);
     if (!recipe) return { success: false, summary: `Recipe with id ${recipeId} not found. Use search_library to find valid recipe IDs.` };
@@ -223,11 +229,15 @@ function executeAddRecipeItem(args: Record<string, unknown>): AiToolResult {
     const food = getFoodById(foodId);
     if (!food) return { success: false, summary: `Food with id ${foodId} not found. Use search_library to find valid food IDs.` };
 
-    const item = addRecipeItem({ recipe_id: recipeId, food_id: foodId, quantity_grams: quantityGrams, quantity_unit: "g" });
+    const unit = args.unit != null ? String(args.unit).trim() : food.default_unit;
+    const resolved = resolveQuantityToGrams(quantity, unit, foodId);
+    if ("error" in resolved) return { success: false, summary: resolved.error };
+
+    const item = addRecipeItem({ recipe_id: recipeId, food_id: foodId, quantity_grams: resolved.grams, quantity_unit: unit });
     return {
         success: true,
-        summary: `Added ${quantityGrams}g of "${food.name}" to recipe "${recipe.name}".`,
-        data: { item_id: item.id, recipe_id: recipeId, food_id: foodId, food_name: food.name, quantity_grams: quantityGrams },
+        summary: `Added ${quantity} ${unit} of "${food.name}" to recipe "${recipe.name}".`,
+        data: { item_id: item.id, recipe_id: recipeId, food_id: foodId, food_name: food.name, quantity, unit },
     };
 }
 

--- a/src/features/ai/services/unitResolution.ts
+++ b/src/features/ai/services/unitResolution.ts
@@ -1,0 +1,59 @@
+import { getServingUnits } from "@/src/features/templates/services/templateDb";
+import { fromGrams, isValidUnit, toGrams } from "@/src/utils/units";
+
+/**
+ * Resolve a user-facing quantity + unit into internal grams.
+ * Supports standard FoodUnits (g, ml, oz, …) and custom serving unit names.
+ */
+export function resolveQuantityToGrams(
+    quantity: number,
+    unit: string,
+    foodId: number,
+): { grams: number } | { error: string } {
+    if (isValidUnit(unit)) {
+        return { grams: toGrams(quantity, unit) };
+    }
+
+    const servingUnits = getServingUnits(foodId);
+    const match = servingUnits.find((u) => u.name.toLowerCase() === unit.toLowerCase());
+    if (match) {
+        return { grams: quantity * match.grams };
+    }
+
+    const available = servingUnits.map((u) => `"${u.name}"`).join(", ");
+    const hint = available
+        ? ` Custom units for this food: ${available}.`
+        : " This food has no custom serving units.";
+    return {
+        error: `Unknown unit "${unit}". Use a standard unit (g, ml, oz, fl_oz, cup, tbsp, tsp, lb) or a custom serving unit for this food.${hint}`,
+    };
+}
+
+/**
+ * Convert a stored entry (quantity_grams + quantity_unit) back to a display quantity + unit.
+ */
+export function displayQuantity(
+    quantityGrams: number,
+    quantityUnit: string,
+    foodId: number | null,
+): { quantity: number; unit: string } {
+    if (isValidUnit(quantityUnit)) {
+        return {
+            quantity: Math.round(fromGrams(quantityGrams, quantityUnit) * 10) / 10,
+            unit: quantityUnit,
+        };
+    }
+
+    if (foodId) {
+        const units = getServingUnits(foodId);
+        const match = units.find((u) => u.name === quantityUnit);
+        if (match && match.grams > 0) {
+            return {
+                quantity: Math.round((quantityGrams / match.grams) * 10) / 10,
+                unit: quantityUnit,
+            };
+        }
+    }
+
+    return { quantity: Math.round(quantityGrams * 10) / 10, unit: "g" };
+}


### PR DESCRIPTION
## Summary

Adds proper unit support to all AI tools, so the AI can work with units the way a human user would — using custom serving units ("1 piece", "1 tablespoon") instead of always guessing grams.

## Changes

### search_library — expose available units
- Now includes `serving_units: [{name, grams}]` for each food in results
- AI can see what custom units are available before logging

### log_food, update_log_entry, add_recipe_item — accept quantity + unit
- Replaced `quantity_grams` parameter with `quantity` + `unit`
- `unit` accepts standard units (g, ml, oz, fl_oz, cup, tbsp, tsp, lb) or custom serving unit names
- Defaults to the food's `default_unit` when omitted
- Entries are stored with the actual unit used (not hardcoded "g")

### read_log_entries, read_recent_log_entries — show display quantities
- Returns `quantity` + `unit` (display values) instead of raw `quantity_grams`
- Custom unit entries display correctly (e.g. "2 piece" instead of "50g")

### System prompt — unit guidance
- Added UNITS section instructing the AI to prefer custom serving units when available
- Encourages natural unit choices (ml for liquids, pieces for countable items)

### New: unitResolution service
- `resolveQuantityToGrams()` — converts any unit to internal grams
- `displayQuantity()` — converts stored grams back to display unit + quantity
- Supports both standard FoodUnits and custom serving units per food

## Example improvement

Before: User says "add a lollipop to snacks" → AI guesses "10g" (wrong)
After: AI searches, sees `serving_units: [{name: "piece", grams: 25}]`, logs `1 piece` → stored as 25g

Closes #158