### PR TITLE
feat: exercise routing and navigation setup

### DIFF
--- a/app/workout/_layout.tsx
+++ b/app/workout/_layout.tsx
@@ -1,0 +1,15 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { Stack } from "expo-router";
+
+export default function WorkoutLayout() {
+    const colors = useThemeColors();
+    return (
+        <Stack
+            screenOptions={{
+                headerStyle: { backgroundColor: colors.surface },
+                headerTintColor: colors.text,
+                headerShadowVisible: false,
+            }}
+        />
+    );
+}

--- a/app/workout/exercise-history.tsx
+++ b/app/workout/exercise-history.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/src/features/exercise/screens/ExerciseHistoryScreen";

--- a/app/workout/index.tsx
+++ b/app/workout/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/src/features/exercise/screens/WorkoutScreen";

--- a/src/features/exercise/screens/ExerciseHistoryScreen.tsx
+++ b/src/features/exercise/screens/ExerciseHistoryScreen.tsx
@@ -1,0 +1,20 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { fontSize, spacing } from "@/src/utils/theme";
+import { StyleSheet, Text, View } from "react-native";
+
+export default function ExerciseHistoryScreen() {
+    const colors = useThemeColors();
+
+    return (
+        <View style={[styles.screen, { backgroundColor: colors.background }]}>
+            <Text style={[styles.placeholder, { color: colors.textSecondary }]}>
+                Exercise History — coming soon
+            </Text>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    screen: { flex: 1, alignItems: "center", justifyContent: "center", padding: spacing.lg },
+    placeholder: { fontSize: fontSize.lg },
+});

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -1,0 +1,20 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { fontSize, spacing } from "@/src/utils/theme";
+import { StyleSheet, Text, View } from "react-native";
+
+export default function WorkoutScreen() {
+    const colors = useThemeColors();
+
+    return (
+        <View style={[styles.screen, { backgroundColor: colors.background }]}>
+            <Text style={[styles.placeholder, { color: colors.textSecondary }]}>
+                Workout — coming soon
+            </Text>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    screen: { flex: 1, alignItems: "center", justifyContent: "center", padding: spacing.lg },
+    placeholder: { fontSize: fontSize.lg },
+});

--- a/src/features/log/hooks/useLogData.ts
+++ b/src/features/log/hooks/useLogData.ts
@@ -8,9 +8,8 @@ import { useFocusEffect } from "@react-navigation/native";
 import { router } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Dimensions, type NativeScrollEvent, type NativeSyntheticEvent, type ScrollView } from "react-native";
-import type { RecipeGroup } from "../services/logDb";
 import { computeWeightTrend, loadGrouped, type EntryWithFood } from "../helpers/logHelpers";
-import { addWeightLog, confirmEntry, confirmRecipeLog, copyEntriesToDate, deleteEntry, deleteRecipeLog, deleteWeightLog, formatDateKey, getEntriesByDate, getWeightLogsForDate, getWeightLogsForRange, moveEntriesToDate, updateRecipeLogPortion, type WeightLog } from "../services/logDb";
+import { addWeightLog, confirmEntry, confirmRecipeLog, copyEntriesToDate, deleteEntry, deleteRecipeLog, deleteWeightLog, formatDateKey, getEntriesByDate, getWeightLogsForDate, getWeightLogsForRange, moveEntriesToDate, updateRecipeLogPortion, type RecipeGroup, type WeightLog } from "../services/logDb";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 
@@ -169,6 +168,10 @@ export function useLogData() {
         router.push({ pathname: "/log/add", params: mealType ? { mealType } : undefined });
     };
 
+    const navigateToWorkout = () => {
+        router.push("/workout");
+    };
+
     function exitSelectionMode() { setSelectionMode(false); setSelectedEntryIds(new Set()); }
 
     function handleToggleEntries(entryIds: number[]) {
@@ -237,7 +240,7 @@ export function useLogData() {
         handleConfirmEntry, handleConfirmRecipeLog,
         handleAddWeight, handleDeleteWeight,
         handleEdit, handleEditRecipeGroup, handleSavePortionMultiplier,
-        navigateToAdd, exitSelectionMode,
+        navigateToAdd, navigateToWorkout, exitSelectionMode,
         handleToggleEntries, handleActivateSelection, handleActivateSelectionMultiple,
         handleMoveCopy, handleDateChange,
         loadAllDays, SCREEN_WIDTH,

--- a/src/features/log/screens/LogScreen.tsx
+++ b/src/features/log/screens/LogScreen.tsx
@@ -138,6 +138,15 @@ export default function LogScreen() {
                 <Ionicons name={d.selectionMode ? "move-outline" : "add"} size={28} color="#fff" />
             </Pressable>
 
+            {!d.selectionMode && (
+                <Pressable
+                    style={({ pressed }) => [styles.fabSecondary, { bottom: d.chatBarVisible ? CHAT_BAR_TOTAL_HEIGHT + 8 : 24 }, pressed && styles.fabPressed]}
+                    onPress={d.navigateToWorkout}
+                >
+                    <Ionicons name="barbell-outline" size={24} color="#fff" />
+                </Pressable>
+            )}
+
             <Modal visible={!!d.editingRecipeGroup} transparent animationType="fade" onRequestClose={() => d.setEditingRecipeGroup(null)}>
                 <Pressable style={styles.overlay} onPress={() => d.setEditingRecipeGroup(null)}>
                     <Pressable style={styles.portionModal} onPress={() => { }}>
@@ -183,6 +192,12 @@ function createStyles(colors: ThemeColors) {
         fab: {
             position: "absolute", right: 24, width: 56, height: 56, borderRadius: 28,
             backgroundColor: colors.primary, alignItems: "center", justifyContent: "center",
+            elevation: 4, shadowColor: "#000", shadowOffset: { width: 0, height: 2 },
+            shadowOpacity: 0.25, shadowRadius: 4,
+        },
+        fabSecondary: {
+            position: "absolute", right: 92, width: 48, height: 48, borderRadius: 24,
+            backgroundColor: colors.weight, alignItems: "center", justifyContent: "center",
             elevation: 4, shadowColor: "#000", shadowOffset: { width: 0, height: 2 },
             shadowOpacity: 0.25, shadowRadius: 4,
         },


### PR DESCRIPTION
## Summary

Closes #193

Sets up the routing infrastructure and navigation entry point for the workout/exercise feature.

### Changes
- Add `app/workout/` stack navigator with `_layout`, `index` (WorkoutScreen), and `exercise-history` routes
- Add placeholder `WorkoutScreen` and `ExerciseHistoryScreen` under `src/features/exercise/screens/`
- Add a workout FAB button on `LogScreen` that navigates to `/workout`
- Fix duplicate `logDb` import in `useLogData` (lint warning)