### PR TITLE
feat(exercise): add types and constants

### DIFF
--- a/src/features/exercise/constants.ts
+++ b/src/features/exercise/constants.ts
@@ -1,0 +1,35 @@
+import type { Equipment, ExerciseType, MuscleGroup, SetType } from "@/src/features/exercise/types";
+
+export const EXERCISE_TYPES: { key: ExerciseType; icon: string }[] = [
+    { key: "weight", icon: "barbell-outline" },
+    { key: "cardio", icon: "bicycle-outline" },
+    { key: "bodyweight", icon: "body-outline" },
+    { key: "other", icon: "ellipsis-horizontal-outline" },
+];
+
+export const MUSCLE_GROUPS: { key: MuscleGroup; icon: string; labelKey: string }[] = [
+    { key: "chest", icon: "body-outline", labelKey: "exercise.muscles.chest" },
+    { key: "back", icon: "body-outline", labelKey: "exercise.muscles.back" },
+    { key: "legs", icon: "body-outline", labelKey: "exercise.muscles.legs" },
+    { key: "shoulders", icon: "body-outline", labelKey: "exercise.muscles.shoulders" },
+    { key: "arms", icon: "body-outline", labelKey: "exercise.muscles.arms" },
+    { key: "core", icon: "body-outline", labelKey: "exercise.muscles.core" },
+    { key: "full_body", icon: "body-outline", labelKey: "exercise.muscles.fullBody" },
+];
+
+export const EQUIPMENT_LIST: { key: Equipment; icon: string }[] = [
+    { key: "barbell", icon: "barbell-outline" },
+    { key: "dumbbell", icon: "barbell-outline" },
+    { key: "machine", icon: "construct-outline" },
+    { key: "cable", icon: "git-branch-outline" },
+    { key: "bodyweight", icon: "body-outline" },
+    { key: "band", icon: "ellipse-outline" },
+    { key: "other", icon: "ellipsis-horizontal-outline" },
+];
+
+export const SET_TYPES: { key: SetType; labelKey: string }[] = [
+    { key: "warmup", labelKey: "exercise.exerciseCard.warmup" },
+    { key: "working", labelKey: "exercise.exerciseCard.working" },
+    { key: "dropset", labelKey: "exercise.exerciseCard.dropset" },
+    { key: "failure", labelKey: "exercise.exerciseCard.failure" },
+];

--- a/src/features/exercise/types.ts
+++ b/src/features/exercise/types.ts
@@ -1,0 +1,8 @@
+// ── Primitive types ──────────────────────────────────────────────────────────
+
+export type ExerciseType = "weight" | "cardio" | "bodyweight" | "other";
+export type MuscleGroup = "chest" | "back" | "legs" | "shoulders" | "arms" | "core" | "full_body";
+export type Equipment = "barbell" | "dumbbell" | "machine" | "cable" | "bodyweight" | "band" | "other";
+export type ResistanceMode = "resistance" | "assistance";
+export type SetType = "warmup" | "working" | "dropset" | "failure";
+export type WeightUnit = "kg" | "lb";


### PR DESCRIPTION
closes #195

## Changes

- **`src/features/exercise/types.ts`** — primitive union types: `ExerciseType`, `MuscleGroup`, `Equipment`, `ResistanceMode`, `SetType`, `WeightUnit`
- **`src/features/exercise/constants.ts`** — picker/dropdown arrays: `EXERCISE_TYPES`, `MUSCLE_GROUPS`, `EQUIPMENT_LIST`, `SET_TYPES` (with `key`, `icon`, and `labelKey` fields matching concept.md §13 i18n keys)

## Architecture note

The issue template placed Drizzle-inferred types (`ExerciseTemplate`, `Workout`, etc.) and composite types (`WorkoutExerciseWithSets`, `WorkoutWithExercises`) in `types.ts`. However, the project's ESLint boundary rules ([eslint.config.js](eslint.config.js)) disallow `feature-types` files from importing `app-service` (`src/services/db/schema`). Following the pattern established by `logDb.ts` and `chatDb.ts`, the Drizzle-inferred and composite types will be exported from `services/exerciseDb.ts` as part of #196.