### PR TITLE
feat(exercise): add exercise history screen with 1RM chart

### DIFF
--- a/src/features/exercise/helpers/workoutSummary.ts
+++ b/src/features/exercise/helpers/workoutSummary.ts
@@ -1,0 +1,85 @@
+import type { ExerciseSet } from "@/src/features/exercise/services/exerciseDb";
+
+export function formatSetSummary(sets: ExerciseSet[]): string {
+    const completed = sets.filter((s) => s.completed_at);
+    if (completed.length === 0) return "—";
+
+    const hasWeight = completed.some((s) => s.weight !== null && s.reps !== null);
+    if (hasWeight) {
+        return formatWeightSets(completed);
+    }
+
+    const hasCardio = completed.some((s) => s.duration_seconds !== null);
+    if (hasCardio) {
+        return formatCardioSets(completed);
+    }
+
+    const hasReps = completed.some((s) => s.reps !== null);
+    if (hasReps) {
+        return formatBodyweightSets(completed);
+    }
+
+    return `${completed.length} sets`;
+}
+
+function formatWeightSets(sets: ExerciseSet[]): string {
+    const groups = new Map<string, number>();
+    for (const s of sets) {
+        if (s.weight === null || s.reps === null) continue;
+        const key = `${s.reps}@${s.weight}${s.weight_unit}`;
+        groups.set(key, (groups.get(key) ?? 0) + 1);
+    }
+
+    return Array.from(groups.entries())
+        .map(([key, count]) => {
+            const match = key.match(/^(\d+)@([\d.]+)(.+)$/);
+            if (!match) return key;
+            return `${count}×${match[1]} @ ${match[2]}${match[3]}`;
+        })
+        .join(", ");
+}
+
+function formatCardioSets(sets: ExerciseSet[]): string {
+    const durations = sets
+        .filter((s) => s.duration_seconds !== null)
+        .map((s) => formatDuration(s.duration_seconds!));
+    return durations.join(", ");
+}
+
+function formatBodyweightSets(sets: ExerciseSet[]): string {
+    const groups = new Map<number, number>();
+    for (const s of sets) {
+        if (s.reps === null) continue;
+        groups.set(s.reps, (groups.get(s.reps) ?? 0) + 1);
+    }
+    return Array.from(groups.entries())
+        .map(([reps, count]) => `${count}×${reps}`)
+        .join(", ");
+}
+
+function formatDuration(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return s > 0 ? `${m}:${String(s).padStart(2, "0")}` : `${m} min`;
+}
+
+export function formatRirRange(sets: ExerciseSet[]): string | null {
+    const rirValues = sets
+        .filter((s) => s.completed_at && s.rir !== null)
+        .map((s) => s.rir!);
+    if (rirValues.length === 0) return null;
+
+    const min = Math.min(...rirValues);
+    const max = Math.max(...rirValues);
+    return min === max ? `RIR ${min}` : `RIR ${min}-${max}`;
+}
+
+export function formatElapsedTime(ms: number): string {
+    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    const mm = String(minutes).padStart(2, "0");
+    const ss = String(seconds).padStart(2, "0");
+    return hours > 0 ? `${hours}:${mm}:${ss}` : `${mm}:${ss}`;
+}

--- a/src/features/exercise/hooks/useExerciseHistory.ts
+++ b/src/features/exercise/hooks/useExerciseHistory.ts
@@ -1,0 +1,45 @@
+import {
+    getEstimated1RMSeries,
+    getExerciseHistory,
+    getExercisePersonalBest,
+    type Estimated1RMPoint,
+    type ExercisePersonalBest,
+    type WorkoutExerciseWithSets,
+} from "@/src/features/exercise/services/exerciseDb";
+import { useCallback, useEffect, useState } from "react";
+
+interface UseExerciseHistoryReturn {
+    history: WorkoutExerciseWithSets[];
+    e1rmSeries: Estimated1RMPoint[];
+    personalBest: ExercisePersonalBest | null;
+    isLoading: boolean;
+    refresh: () => void;
+}
+
+export function useExerciseHistory(templateId: number | undefined): UseExerciseHistoryReturn {
+    const [history, setHistory] = useState<WorkoutExerciseWithSets[]>([]);
+    const [e1rmSeries, setE1rmSeries] = useState<Estimated1RMPoint[]>([]);
+    const [personalBest, setPersonalBest] = useState<ExercisePersonalBest | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const load = useCallback(() => {
+        if (!templateId) {
+            setIsLoading(false);
+            return;
+        }
+        setIsLoading(true);
+        try {
+            setHistory(getExerciseHistory(templateId, 50));
+            setE1rmSeries(getEstimated1RMSeries(templateId));
+            setPersonalBest(getExercisePersonalBest(templateId));
+        } finally {
+            setIsLoading(false);
+        }
+    }, [templateId]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    return { history, e1rmSeries, personalBest, isLoading, refresh: load };
+}

--- a/src/features/exercise/screens/ExerciseHistoryScreen.tsx
+++ b/src/features/exercise/screens/ExerciseHistoryScreen.tsx
@@ -1,20 +1,199 @@
+import { useExerciseHistory } from "@/src/features/exercise/hooks/useExerciseHistory";
+import { getExerciseTemplateById, type ExerciseTemplate } from "@/src/features/exercise/services/exerciseDb";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
-import { fontSize, spacing } from "@/src/utils/theme";
-import { StyleSheet, Text, View } from "react-native";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { Stack, useLocalSearchParams } from "expo-router";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { ActivityIndicator, FlatList, StyleSheet, Text, View } from "react-native";
+import { LineChart } from "react-native-gifted-charts";
+import { formatRirRange, formatSetSummary } from "../helpers/workoutSummary";
 
 export default function ExerciseHistoryScreen() {
     const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const { templateId } = useLocalSearchParams<{ templateId: string }>();
+    const parsedId = templateId ? Number(templateId) : undefined;
+
+    const template: ExerciseTemplate | undefined = useMemo(
+        () => (parsedId ? getExerciseTemplateById(parsedId) : undefined),
+        [parsedId],
+    );
+    const { history, e1rmSeries, personalBest, isLoading } = useExerciseHistory(parsedId);
+
+    const isAssistance = template?.resistance_mode === "assistance";
+
+    const chartData = useMemo(() => {
+        if (e1rmSeries.length === 0) return [];
+        return e1rmSeries.map((point, i) => ({
+            value: Math.round(point.e1rm * 10) / 10,
+            label: i % Math.max(1, Math.floor(e1rmSeries.length / 6)) === 0
+                ? point.date.slice(5)
+                : "",
+            labelTextStyle: { color: colors.textSecondary, fontSize: 9 },
+        }));
+    }, [e1rmSeries, colors.textSecondary]);
+
+    const pbE1rm = personalBest ? Math.round(personalBest.e1rm * 10) / 10 : null;
+    const currentE1rm = e1rmSeries.length > 0
+        ? Math.round(e1rmSeries[e1rmSeries.length - 1].e1rm * 10) / 10
+        : null;
+
+    if (isLoading) {
+        return (
+            <View style={[styles.screen, styles.center]}>
+                <Stack.Screen options={{ title: "" }} />
+                <ActivityIndicator color={colors.primary} />
+            </View>
+        );
+    }
 
     return (
-        <View style={[styles.screen, { backgroundColor: colors.background }]}>
-            <Text style={[styles.placeholder, { color: colors.textSecondary }]}>
-                Exercise History — coming soon
-            </Text>
+        <View style={styles.screen}>
+            <Stack.Screen
+                options={{ title: t("exercise.history.title", { name: template?.name ?? "" }) }}
+            />
+
+            <FlatList
+                data={history}
+                keyExtractor={(item) => String(item.workoutExercise.id)}
+                contentContainerStyle={styles.listContent}
+                ListHeaderComponent={
+                    <>
+                        {chartData.length > 0 && (
+                            <View style={styles.chartCard}>
+                                <Text style={styles.chartTitle}>
+                                    {t("exercise.history.estimated1RM")}
+                                    {isAssistance ? " ↓" : ""}
+                                </Text>
+                                <View style={styles.statsRow}>
+                                    {currentE1rm !== null && (
+                                        <Text style={styles.statText}>
+                                            {t("exercise.history.current")}: {currentE1rm} kg
+                                        </Text>
+                                    )}
+                                    {pbE1rm !== null && (
+                                        <Text style={[styles.statText, { color: colors.success }]}>
+                                            {t("exercise.history.personalBest")}: {pbE1rm} kg
+                                        </Text>
+                                    )}
+                                </View>
+                                <LineChart
+                                    data={chartData}
+                                    color={colors.primary}
+                                    startFillColor={colors.primary}
+                                    endFillColor={colors.background}
+                                    startOpacity={0.3}
+                                    endOpacity={0.01}
+                                    areaChart
+                                    curved
+                                    thickness={2}
+                                    height={160}
+                                    width={280}
+                                    spacing={chartData.length > 1 ? 280 / (chartData.length - 1) : 280}
+                                    hideDataPoints={chartData.length > 12}
+                                    dataPointsColor={colors.primary}
+                                    yAxisTextStyle={{ color: colors.textSecondary, fontSize: 10 }}
+                                    xAxisLabelTextStyle={{ color: colors.textSecondary, fontSize: 9 }}
+                                    yAxisColor={colors.border}
+                                    xAxisColor={colors.border}
+                                    rulesColor={colors.border}
+                                    noOfSections={4}
+                                    animateOnDataChange
+                                    isAnimated
+                                />
+                            </View>
+                        )}
+
+                        {history.length > 0 && (
+                            <Text style={styles.sectionHeader}>
+                                {t("exercise.history.title", { name: "" }).trim()}
+                            </Text>
+                        )}
+                    </>
+                }
+                renderItem={({ item }) => {
+                    const summary = formatSetSummary(item.sets);
+                    const rir = formatRirRange(item.sets);
+                    return (
+                        <View style={styles.historyRow}>
+                            <Text style={styles.historyDate}>
+                                {item.workout.date}
+                            </Text>
+                            <Text style={styles.historySummary} numberOfLines={1}>
+                                {summary}
+                                {rir ? `  ${rir}` : ""}
+                            </Text>
+                        </View>
+                    );
+                }}
+                ListEmptyComponent={
+                    <View style={styles.center}>
+                        <Ionicons name="bar-chart-outline" size={48} color={colors.textTertiary} />
+                        <Text style={styles.emptyText}>
+                            {t("exercise.history.noHistory")}
+                        </Text>
+                    </View>
+                }
+            />
         </View>
     );
 }
 
-const styles = StyleSheet.create({
-    screen: { flex: 1, alignItems: "center", justifyContent: "center", padding: spacing.lg },
-    placeholder: { fontSize: fontSize.lg },
-});
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        screen: { flex: 1, backgroundColor: colors.background },
+        center: { flex: 1, alignItems: "center", justifyContent: "center", padding: spacing.lg },
+        listContent: { padding: spacing.md },
+        chartCard: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.md,
+            marginBottom: spacing.md,
+        },
+        chartTitle: {
+            fontSize: fontSize.md,
+            fontWeight: "600",
+            color: colors.text,
+            marginBottom: spacing.xs,
+        },
+        statsRow: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            marginBottom: spacing.sm,
+        },
+        statText: { fontSize: fontSize.sm, color: colors.textSecondary },
+        sectionHeader: {
+            fontSize: fontSize.xs,
+            fontWeight: "700",
+            color: colors.textSecondary,
+            letterSpacing: 0.5,
+            marginTop: spacing.sm,
+            marginBottom: spacing.sm,
+        },
+        historyRow: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.md,
+            padding: spacing.md,
+            marginBottom: spacing.sm,
+        },
+        historyDate: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.text,
+            marginBottom: 2,
+        },
+        historySummary: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+        },
+        emptyText: {
+            fontSize: fontSize.md,
+            color: colors.textTertiary,
+            marginTop: spacing.sm,
+        },
+    });
+}
+


### PR DESCRIPTION
Closes #204

## Changes

### ExerciseHistoryScreen
- 1RM progression line chart using gifted-charts (Epley formula)
- Personal best + current 1RM stat display
- Chronological history list with set summaries and RIR ranges
- Assistance exercise indicator (inverted chart direction)
- Empty state with icon

### useExerciseHistory hook
- Fetches exercise history, 1RM series, and personal best
- Loads data on mount based on templateId

### workoutSummary helpers
- `formatSetSummary(sets)`: e.g. '4×8 @ 80kg'
- `formatRirRange(sets)`: e.g. 'RIR 2-3'
- `formatElapsedTime(ms)`: e.g. '45:12' or '1:05:30'