### PR TITLE
feat: WorkoutScreen core layout & exercise cards

### DIFF
--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -1,0 +1,341 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import React, { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, Modal, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
+
+type ExerciseType = "weight" | "bodyweight" | "cardio";
+
+interface ExerciseCardProps {
+    item: WorkoutExerciseWithSets;
+    index: number;
+    totalExercises: number;
+    isFinished: boolean;
+    onRemove: (workoutExerciseId: number) => void;
+    onMoveUp: (workoutExerciseId: number) => void;
+    onMoveDown: (workoutExerciseId: number) => void;
+    onNoteChange: (workoutExerciseId: number, note: string) => void;
+}
+
+export default function ExerciseCard({
+    item, index, totalExercises, isFinished,
+    onRemove, onMoveUp, onMoveDown, onNoteChange,
+}: ExerciseCardProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const router = useRouter();
+    const [menuOpen, setMenuOpen] = useState(false);
+    const [noteOpen, setNoteOpen] = useState(false);
+    const [noteDraft, setNoteDraft] = useState(item.workoutExercise.notes ?? "");
+
+    const template = item.exerciseTemplate;
+    const name = template?.name ?? "?";
+    const exerciseType: ExerciseType = template?.type === "cardio" ? "cardio"
+        : template?.type === "bodyweight" ? "bodyweight" : "weight";
+
+    function handleRemove() {
+        Alert.alert(
+            t("exercise.exerciseCard.remove"),
+            t("exercise.exerciseCard.removeConfirm"),
+            [
+                { text: t("common.cancel"), style: "cancel" },
+                { text: t("common.delete"), style: "destructive", onPress: () => onRemove(item.workoutExercise.id) },
+            ],
+        );
+        setMenuOpen(false);
+    }
+
+    function handleHistory() {
+        if (template) {
+            router.push({
+                pathname: "/workout/exercise-history",
+                params: { templateId: String(template.id), name: template.name },
+            });
+        }
+    }
+
+    function handleSaveNote() {
+        onNoteChange(item.workoutExercise.id, noteDraft.trim());
+        setNoteOpen(false);
+    }
+
+    return (
+        <View style={styles.card}>
+            {/* Title row */}
+            <View style={styles.titleRow}>
+                <Text style={styles.orderNum}>{index + 1}.</Text>
+                <Text style={styles.exerciseName} numberOfLines={1}>{name}</Text>
+                <Pressable onPress={handleHistory} hitSlop={8}>
+                    <Ionicons name="bar-chart-outline" size={18} color={colors.textSecondary} />
+                </Pressable>
+                <Pressable onPress={() => setMenuOpen(true)} hitSlop={8}>
+                    <Ionicons name="ellipsis-vertical" size={18} color={colors.textSecondary} />
+                </Pressable>
+            </View>
+
+            {/* Note display */}
+            {item.workoutExercise.notes ? (
+                <Text style={styles.noteText} numberOfLines={2}>
+                    {item.workoutExercise.notes}
+                </Text>
+            ) : null}
+
+            {/* Column headers */}
+            <View style={styles.headerRow}>
+                <Text style={[styles.headerCell, styles.setCol]}>{t("exercise.exerciseCard.set")}</Text>
+                {exerciseType === "weight" && (
+                    <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.weight")}</Text>
+                )}
+                {exerciseType !== "cardio" && (
+                    <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.reps")}</Text>
+                )}
+                {exerciseType === "cardio" && (
+                    <>
+                        <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.duration")}</Text>
+                        <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.distance")}</Text>
+                    </>
+                )}
+                {exerciseType !== "cardio" && (
+                    <Text style={[styles.headerCell, styles.rirCol]}>{t("exercise.exerciseCard.rir")}</Text>
+                )}
+                <Text style={[styles.headerCell, styles.checkCol]}>✓</Text>
+            </View>
+
+            {/* Set rows */}
+            {item.sets.map((set, si) => (
+                <SetRow key={set.id} set={set} index={si} exerciseType={exerciseType} colors={colors} styles={styles} />
+            ))}
+
+            {/* Empty state */}
+            {item.sets.length === 0 && (
+                <Text style={styles.emptyText}>{t("exercise.workout.emptyState")}</Text>
+            )}
+
+            {/* Overflow menu modal */}
+            <Modal visible={menuOpen} transparent animationType="fade" onRequestClose={() => setMenuOpen(false)}>
+                <Pressable style={styles.overlay} onPress={() => setMenuOpen(false)}>
+                    <View style={styles.menu}>
+                        {index > 0 && (
+                            <MenuItem label={t("exercise.exerciseCard.moveUp")} icon="arrow-up"
+                                onPress={() => { onMoveUp(item.workoutExercise.id); setMenuOpen(false); }} colors={colors} />
+                        )}
+                        {index < totalExercises - 1 && (
+                            <MenuItem label={t("exercise.exerciseCard.moveDown")} icon="arrow-down"
+                                onPress={() => { onMoveDown(item.workoutExercise.id); setMenuOpen(false); }} colors={colors} />
+                        )}
+                        <MenuItem
+                            label={item.workoutExercise.notes ? t("exercise.exerciseCard.editNote") : t("exercise.exerciseCard.addNote")}
+                            icon="create-outline"
+                            onPress={() => { setMenuOpen(false); setNoteDraft(item.workoutExercise.notes ?? ""); setNoteOpen(true); }} colors={colors} />
+                        {!isFinished && (
+                            <MenuItem label={t("exercise.exerciseCard.remove")} icon="trash-outline"
+                                onPress={handleRemove} colors={colors} destructive />
+                        )}
+                    </View>
+                </Pressable>
+            </Modal>
+
+            {/* Note edit modal */}
+            <Modal visible={noteOpen} transparent animationType="fade" onRequestClose={() => setNoteOpen(false)}>
+                <Pressable style={styles.overlay} onPress={() => setNoteOpen(false)}>
+                    <Pressable style={styles.noteModal} onPress={() => { }}>
+                        <Text style={styles.noteTitle}>{t("exercise.exerciseCard.note")}</Text>
+                        <TextInput
+                            style={styles.noteInput}
+                            value={noteDraft}
+                            onChangeText={setNoteDraft}
+                            placeholder={t("exercise.exerciseCard.notePlaceholder")}
+                            placeholderTextColor={colors.textTertiary}
+                            multiline
+                            autoFocus
+                        />
+                        <Pressable style={styles.noteSaveBtn} onPress={handleSaveNote}>
+                            <Text style={styles.noteSaveText}>{t("common.save")}</Text>
+                        </Pressable>
+                    </Pressable>
+                </Pressable>
+            </Modal>
+        </View>
+    );
+}
+
+function SetRow({ set, index, exerciseType, colors, styles }: {
+    set: ExerciseSet; index: number; exerciseType: ExerciseType;
+    colors: ReturnType<typeof useThemeColors>; styles: ReturnType<typeof createStyles>;
+}) {
+    const isCompleted = !!set.completed_at;
+    const isScheduled = !!set.is_scheduled && !isCompleted;
+    const textColor = isScheduled ? colors.textTertiary : colors.text;
+
+    function formatWeight(w: number | null): string {
+        if (w === null) return "—";
+        return `${w}`;
+    }
+
+    return (
+        <View style={[styles.setRow, isScheduled && styles.setRowScheduled]}>
+            <Text style={[styles.setCell, styles.setCol, { color: textColor }]}>{index + 1}</Text>
+            {exerciseType === "weight" && (
+                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{formatWeight(set.weight)}</Text>
+            )}
+            {exerciseType !== "cardio" && (
+                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{set.reps ?? "—"}</Text>
+            )}
+            {exerciseType === "cardio" && (
+                <>
+                    <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{set.duration_seconds ? `${set.duration_seconds}s` : "—"}</Text>
+                    <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{set.distance_meters ? `${set.distance_meters}m` : "—"}</Text>
+                </>
+            )}
+            {exerciseType !== "cardio" && (
+                <Text style={[styles.setCell, styles.rirCol, { color: textColor }]}>{set.rir ?? "—"}</Text>
+            )}
+            <View style={styles.checkCol}>
+                <Ionicons
+                    name={isCompleted ? "checkmark-circle" : "ellipse-outline"}
+                    size={20}
+                    color={isCompleted ? colors.primary : isScheduled ? colors.textTertiary : colors.border}
+                />
+            </View>
+        </View>
+    );
+}
+
+function MenuItem({ label, icon, onPress, colors, destructive }: {
+    label: string; icon: string; onPress: () => void;
+    colors: ReturnType<typeof useThemeColors>; destructive?: boolean;
+}) {
+    return (
+        <Pressable style={menuItemStyles.item} onPress={onPress}>
+            <Ionicons name={icon as never} size={20} color={destructive ? "#ef4444" : colors.text} />
+            <Text style={[menuItemStyles.label, { color: destructive ? "#ef4444" : colors.text }]}>{label}</Text>
+        </Pressable>
+    );
+}
+
+const menuItemStyles = StyleSheet.create({
+    item: { flexDirection: "row", alignItems: "center", gap: spacing.sm, paddingVertical: spacing.sm },
+    label: { fontSize: fontSize.sm },
+});
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        card: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.md,
+            marginBottom: spacing.md,
+        },
+        titleRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            marginBottom: spacing.sm,
+        },
+        orderNum: {
+            fontSize: fontSize.sm,
+            fontWeight: "700",
+            color: colors.textSecondary,
+        },
+        exerciseName: {
+            flex: 1,
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.text,
+        },
+        noteText: {
+            fontSize: fontSize.xs,
+            color: colors.textSecondary,
+            fontStyle: "italic",
+            marginBottom: spacing.sm,
+        },
+        headerRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            paddingBottom: spacing.xs,
+            borderBottomWidth: 1,
+            borderBottomColor: colors.border,
+            marginBottom: spacing.xs,
+        },
+        headerCell: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            textTransform: "uppercase",
+        },
+        setRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            paddingVertical: 4,
+        },
+        setRowScheduled: {
+            opacity: 0.6,
+        },
+        setCell: {
+            fontSize: fontSize.sm,
+        },
+        setCol: { width: 32 },
+        valueCol: { flex: 1, textAlign: "center" },
+        rirCol: { width: 36, textAlign: "center" },
+        checkCol: { width: 28, alignItems: "center" },
+        emptyText: {
+            fontSize: fontSize.sm,
+            color: colors.textTertiary,
+            textAlign: "center",
+            paddingVertical: spacing.md,
+        },
+        overlay: {
+            flex: 1,
+            backgroundColor: "rgba(0,0,0,0.5)",
+            justifyContent: "center",
+            alignItems: "center",
+            padding: spacing.lg,
+        },
+        menu: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.md,
+            width: "100%",
+            maxWidth: 300,
+        },
+        noteModal: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.lg,
+            width: "100%",
+            maxWidth: 340,
+        },
+        noteTitle: {
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+            color: colors.text,
+            marginBottom: spacing.md,
+        },
+        noteInput: {
+            fontSize: fontSize.sm,
+            color: colors.text,
+            borderWidth: 1,
+            borderColor: colors.border,
+            borderRadius: borderRadius.md,
+            padding: spacing.sm,
+            minHeight: 80,
+            textAlignVertical: "top",
+            marginBottom: spacing.md,
+        },
+        noteSaveBtn: {
+            backgroundColor: colors.primary,
+            borderRadius: borderRadius.md,
+            paddingVertical: spacing.sm,
+            alignItems: "center",
+        },
+        noteSaveText: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: "#fff",
+        },
+    });
+}

--- a/src/features/exercise/components/WorkoutHeader.tsx
+++ b/src/features/exercise/components/WorkoutHeader.tsx
@@ -1,0 +1,148 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+interface WorkoutHeaderProps {
+    title: string;
+    elapsedMs: number;
+    isFinished: boolean;
+    hasUnfinishedSets: boolean;
+    onTitleChange: (title: string) => void;
+    onFinish: () => void;
+    onBack: () => void;
+}
+
+export default function WorkoutHeader({
+    title, elapsedMs, isFinished, hasUnfinishedSets,
+    onTitleChange, onFinish, onBack,
+}: WorkoutHeaderProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
+    const [editing, setEditing] = useState(false);
+    const [draft, setDraft] = useState(title);
+
+    function formatElapsed(ms: number): string {
+        const totalSec = Math.floor(ms / 1000);
+        const h = Math.floor(totalSec / 3600);
+        const m = Math.floor((totalSec % 3600) / 60);
+        const s = totalSec % 60;
+        const pad = (n: number) => String(n).padStart(2, "0");
+        return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+    }
+
+    function handleFinish() {
+        if (hasUnfinishedSets) {
+            Alert.alert(
+                t("exercise.workout.finish"),
+                t("exercise.workout.finishConfirm"),
+                [
+                    { text: t("common.cancel"), style: "cancel" },
+                    { text: t("exercise.workout.finish"), style: "destructive", onPress: onFinish },
+                ],
+            );
+        } else {
+            onFinish();
+        }
+    }
+
+    function commitTitle() {
+        setEditing(false);
+        if (draft.trim() && draft.trim() !== title) {
+            onTitleChange(draft.trim());
+        } else {
+            setDraft(title);
+        }
+    }
+
+    return (
+        <View style={[styles.container, { paddingTop: insets.top + spacing.xs }]}>
+            <Pressable onPress={onBack} hitSlop={12} style={styles.backBtn}>
+                <Ionicons name="arrow-back" size={24} color={colors.text} />
+            </Pressable>
+
+            {editing ? (
+                <TextInput
+                    style={styles.titleInput}
+                    value={draft}
+                    onChangeText={setDraft}
+                    onBlur={commitTitle}
+                    onSubmitEditing={commitTitle}
+                    autoFocus
+                    selectTextOnFocus
+                    returnKeyType="done"
+                />
+            ) : (
+                <Pressable onPress={() => { setDraft(title); setEditing(true); }} style={styles.titleWrap}>
+                    <Text style={styles.title} numberOfLines={1}>{title}</Text>
+                </Pressable>
+            )}
+
+            <View style={styles.timerWrap}>
+                <Ionicons name="time-outline" size={16} color={colors.textSecondary} />
+                <Text style={styles.timer}>{formatElapsed(elapsedMs)}</Text>
+            </View>
+
+            {!isFinished && (
+                <Pressable onPress={handleFinish} style={styles.finishBtn} hitSlop={8}>
+                    <Ionicons name="checkmark-circle" size={28} color={colors.primary} />
+                </Pressable>
+            )}
+        </View>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        container: {
+            flexDirection: "row",
+            alignItems: "center",
+            backgroundColor: colors.surface,
+            paddingHorizontal: spacing.md,
+            paddingBottom: spacing.sm,
+            gap: spacing.sm,
+            borderBottomWidth: 1,
+            borderBottomColor: colors.border,
+        },
+        backBtn: {
+            padding: spacing.xs,
+        },
+        titleWrap: {
+            flex: 1,
+            minWidth: 0,
+        },
+        title: {
+            fontSize: fontSize.md,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        titleInput: {
+            flex: 1,
+            fontSize: fontSize.md,
+            fontWeight: "700",
+            color: colors.text,
+            borderBottomWidth: 1,
+            borderBottomColor: colors.primary,
+            paddingVertical: 2,
+        },
+        timerWrap: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 4,
+        },
+        timer: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            fontVariant: ["tabular-nums"],
+        },
+        finishBtn: {
+            padding: spacing.xs,
+        },
+    });
+}

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -1,29 +1,123 @@
 import Button from "@/src/shared/atoms/Button";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { spacing, type ThemeColors } from "@/src/utils/theme";
 import { Ionicons } from "@expo/vector-icons";
-import React, { useState } from "react";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { StyleSheet, View } from "react-native";
+import { FlatList, StyleSheet, Text, View } from "react-native";
 import AddExerciseModal from "../components/AddExerciseModal";
-import type { ExerciseTemplate } from "../services/exerciseDb";
+import ExerciseCard from "../components/ExerciseCard";
+import WorkoutHeader from "../components/WorkoutHeader";
+import { useWorkout } from "../hooks/useWorkout";
+import { updateWorkoutExercise, type ExerciseTemplate, type WorkoutExerciseWithSets } from "../services/exerciseDb";
 
 export default function WorkoutScreen() {
     const colors = useThemeColors();
     const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const router = useRouter();
+    const params = useLocalSearchParams<{ workoutId?: string }>();
+    const workoutId = params.workoutId ? Number(params.workoutId) : undefined;
+
+    const workout = useWorkout({ workoutId });
     const [showAddExercise, setShowAddExercise] = useState(false);
 
-    function handleExerciseSelected(_template: ExerciseTemplate) {
+    // Auto-start workout if none loaded
+    if (!workout.data && !workoutId) {
+        workout.startWorkout();
+    }
+
+    const isFinished = !!workout.data?.workout.ended_at;
+
+    function handleExerciseSelected(template: ExerciseTemplate) {
+        workout.addExercise(template.id);
         setShowAddExercise(false);
     }
 
-    return (
-        <View style={[styles.screen, { backgroundColor: colors.background }]}>
-            <Button
-                title={t("exercise.workout.addExercise")}
-                variant="outline"
-                icon={<Ionicons name="add" size={18} color={colors.text} />}
-                onPress={() => setShowAddExercise(true)}
+    function handleFinish() {
+        workout.finishCurrentWorkout();
+        router.back();
+    }
+
+    function handleBack() {
+        router.back();
+    }
+
+    function handleNoteChange(workoutExerciseId: number, note: string) {
+        updateWorkoutExercise(workoutExerciseId, { notes: note || null });
+        workout.reload();
+    }
+
+    function handleMoveUp(workoutExerciseId: number) {
+        const exercises = workout.data?.exercises ?? [];
+        const idx = exercises.findIndex((e) => e.workoutExercise.id === workoutExerciseId);
+        if (idx > 0) {
+            workout.moveExercise(workoutExerciseId, idx);
+        }
+    }
+
+    function handleMoveDown(workoutExerciseId: number) {
+        const exercises = workout.data?.exercises ?? [];
+        const idx = exercises.findIndex((e) => e.workoutExercise.id === workoutExerciseId);
+        if (idx < exercises.length - 1) {
+            workout.moveExercise(workoutExerciseId, idx + 2);
+        }
+    }
+
+    function renderExercise({ item, index }: { item: WorkoutExerciseWithSets; index: number }) {
+        return (
+            <ExerciseCard
+                item={item}
+                index={index}
+                totalExercises={workout.data?.exercises.length ?? 0}
+                isFinished={isFinished}
+                onRemove={workout.removeExercise}
+                onMoveUp={handleMoveUp}
+                onMoveDown={handleMoveDown}
+                onNoteChange={handleNoteChange}
             />
+        );
+    }
+
+    return (
+        <View style={styles.screen}>
+            <Stack.Screen options={{ headerShown: false }} />
+
+            <WorkoutHeader
+                title={workout.data?.workout.title || t("exercise.workout.defaultTitle")}
+                elapsedMs={workout.elapsedMs}
+                isFinished={isFinished}
+                hasUnfinishedSets={workout.hasUnfinishedSets}
+                onTitleChange={workout.updateTitle}
+                onFinish={handleFinish}
+                onBack={handleBack}
+            />
+
+            <FlatList
+                data={workout.data?.exercises ?? []}
+                keyExtractor={(item) => String(item.workoutExercise.id)}
+                renderItem={renderExercise}
+                contentContainerStyle={styles.list}
+                ListEmptyComponent={
+                    <View style={styles.emptyWrap}>
+                        <Ionicons name="barbell-outline" size={48} color={colors.textTertiary} />
+                        <Text style={styles.emptyText}>{t("exercise.workout.emptyState")}</Text>
+                    </View>
+                }
+                ListFooterComponent={
+                    !isFinished ? (
+                        <Button
+                            title={t("exercise.workout.addExercise")}
+                            variant="outline"
+                            icon={<Ionicons name="add" size={18} color={colors.text} />}
+                            onPress={() => setShowAddExercise(true)}
+                            style={styles.addBtn}
+                        />
+                    ) : null
+                }
+            />
+
             <AddExerciseModal
                 visible={showAddExercise}
                 onClose={() => setShowAddExercise(false)}
@@ -33,6 +127,29 @@ export default function WorkoutScreen() {
     );
 }
 
-const styles = StyleSheet.create({
-    screen: { flex: 1, alignItems: "center", justifyContent: "center" },
-});
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        screen: {
+            flex: 1,
+            backgroundColor: colors.background,
+        },
+        list: {
+            padding: spacing.md,
+            paddingBottom: 100,
+        },
+        emptyWrap: {
+            alignItems: "center",
+            justifyContent: "center",
+            paddingVertical: spacing.xl * 2,
+            gap: spacing.md,
+        },
+        emptyText: {
+            fontSize: 14,
+            color: colors.textTertiary,
+            textAlign: "center",
+        },
+        addBtn: {
+            marginTop: spacing.sm,
+        },
+    });
+}

--- a/src/features/exercise/services/exerciseDb.ts
+++ b/src/features/exercise/services/exerciseDb.ts
@@ -290,6 +290,11 @@ export function removeExerciseFromWorkout(id: number) {
     exerciseDbSupport.normalizeExerciseSortOrder(workoutExercise.workout_id);
 }
 
+export function updateWorkoutExercise(id: number, data: Partial<NewWorkoutExercise>) {
+    exerciseDbSupport.getWorkoutExerciseOrThrow(id);
+    db.update(workoutExercises).set(data).where(eq(workoutExercises.id, id)).run();
+}
+
 export function getExercisesForWorkout(workoutId: number): WorkoutExerciseWithSets[] {
     exerciseDbSupport.getWorkoutOrThrow(workoutId);
     return listWorkoutExercisesForWorkout(workoutId);


### PR DESCRIPTION
Closes #199

## Summary
- Complete rewrite of `WorkoutScreen` from placeholder to full implementation
- **WorkoutHeader**: editable inline title, elapsed timer, back button (preserves workout), finish with confirmation dialog when unfinished scheduled sets exist
- **ExerciseCard**: adaptive set table columns per exercise type (weight/bodyweight/cardio), overflow menu (⋮) with reorder, remove, add/edit note actions, chart icon → ExerciseHistoryScreen
- **WorkoutScreen**: FlatList of exercise cards, empty state with barbell icon, '+ Add Exercise' button, auto-start new workout, accept `workoutId` param for resuming
- Added `updateWorkoutExercise()` to `exerciseDb.ts` for note persistence
- Uses `Stack.Screen options={{ headerShown: false }}` to render custom header