### PR TITLE
feat: Copy historical workout as scheduled

### DIFF
--- a/src/features/exercise/components/CopyWorkoutSheet.tsx
+++ b/src/features/exercise/components/CopyWorkoutSheet.tsx
@@ -1,0 +1,157 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { FlatList, Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import {
+    copyWorkoutAsScheduled,
+    getExercisesForWorkout,
+    getRecentWorkouts,
+    type Workout,
+} from "../services/exerciseDb";
+
+interface CopyWorkoutSheetProps {
+    visible: boolean;
+    targetWorkoutId: number;
+    onClose: () => void;
+    onCopied: () => void;
+}
+
+interface WorkoutRow {
+    workout: Workout;
+    exerciseCount: number;
+}
+
+export default function CopyWorkoutSheet({ visible, targetWorkoutId, onClose, onCopied }: CopyWorkoutSheetProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const [rows, setRows] = useState<WorkoutRow[]>([]);
+
+    useEffect(() => {
+        if (!visible) return;
+        const recents = getRecentWorkouts(20);
+        const filtered = recents.filter((w) => w.id !== targetWorkoutId && w.ended_at !== null);
+        setRows(filtered.map((w) => ({
+            workout: w,
+            exerciseCount: getExercisesForWorkout(w.id).length,
+        })));
+    }, [visible, targetWorkoutId]);
+
+    function handleCopy(sourceId: number) {
+        copyWorkoutAsScheduled(sourceId, targetWorkoutId);
+        onCopied();
+        onClose();
+    }
+
+    function formatDate(dateStr: string): string {
+        const [y, m, d] = dateStr.split("-");
+        const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+        return `${months[Number(m) - 1]} ${Number(d)}`;
+    }
+
+    return (
+        <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+            <Pressable style={styles.overlay} onPress={onClose}>
+                <Pressable style={styles.sheet} onPress={() => { }}>
+                    <View style={styles.header}>
+                        <Text style={styles.title}>{t("exercise.copyWorkout.title")}</Text>
+                        <Pressable onPress={onClose} hitSlop={8}>
+                            <Ionicons name="close" size={24} color={colors.textSecondary} />
+                        </Pressable>
+                    </View>
+
+                    {rows.length === 0 ? (
+                        <Text style={styles.emptyText}>{t("exercise.copyWorkout.noWorkouts")}</Text>
+                    ) : (
+                        <>
+                            <Text style={styles.subtitle}>{t("exercise.copyWorkout.subtitle")}</Text>
+                            <FlatList
+                                data={rows}
+                                keyExtractor={(item) => String(item.workout.id)}
+                                renderItem={({ item }) => (
+                                    <Pressable style={styles.row} onPress={() => handleCopy(item.workout.id)}>
+                                        <Text style={styles.rowDate}>{formatDate(item.workout.date)}</Text>
+                                        <Text style={styles.rowTitle} numberOfLines={1}>
+                                            {item.workout.title || t("exercise.workout.defaultTitle")}
+                                        </Text>
+                                        <Text style={styles.rowCount}>
+                                            {t("exercise.copyWorkout.exercises", { count: item.exerciseCount })}
+                                        </Text>
+                                    </Pressable>
+                                )}
+                                style={styles.list}
+                            />
+                        </>
+                    )}
+                </Pressable>
+            </Pressable>
+        </Modal>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        overlay: {
+            flex: 1,
+            backgroundColor: "rgba(0,0,0,0.5)",
+            justifyContent: "flex-end",
+        },
+        sheet: {
+            backgroundColor: colors.surface,
+            borderTopLeftRadius: borderRadius.lg,
+            borderTopRightRadius: borderRadius.lg,
+            padding: spacing.lg,
+            maxHeight: "60%",
+        },
+        header: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: spacing.sm,
+        },
+        title: {
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        subtitle: {
+            fontSize: fontSize.xs,
+            color: colors.textSecondary,
+            marginBottom: spacing.md,
+        },
+        list: {
+            flexGrow: 0,
+        },
+        row: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            paddingVertical: spacing.sm,
+            borderBottomWidth: 1,
+            borderBottomColor: colors.border,
+        },
+        rowDate: {
+            fontSize: fontSize.xs,
+            color: colors.textSecondary,
+            width: 50,
+        },
+        rowTitle: {
+            flex: 1,
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.text,
+        },
+        rowCount: {
+            fontSize: fontSize.xs,
+            color: colors.textTertiary,
+        },
+        emptyText: {
+            fontSize: fontSize.sm,
+            color: colors.textTertiary,
+            textAlign: "center",
+            paddingVertical: spacing.lg,
+        },
+    });
+}

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -7,6 +7,7 @@ import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FlatList, StyleSheet, Text, View } from "react-native";
 import AddExerciseModal from "../components/AddExerciseModal";
+import CopyWorkoutSheet from "../components/CopyWorkoutSheet";
 import ExerciseCard from "../components/ExerciseCard";
 import WorkoutHeader from "../components/WorkoutHeader";
 import { useWorkout } from "../hooks/useWorkout";
@@ -22,6 +23,7 @@ export default function WorkoutScreen() {
 
     const workout = useWorkout({ workoutId });
     const [showAddExercise, setShowAddExercise] = useState(false);
+    const [showCopySheet, setShowCopySheet] = useState(false);
 
     // Auto-start workout if none loaded
     if (!workout.data && !workoutId) {
@@ -29,6 +31,7 @@ export default function WorkoutScreen() {
     }
 
     const isFinished = !!workout.data?.workout.ended_at;
+    const isEmpty = (workout.data?.exercises.length ?? 0) === 0;
 
     function handleExerciseSelected(template: ExerciseTemplate) {
         workout.addExercise(template.id);
@@ -103,10 +106,18 @@ export default function WorkoutScreen() {
                     <View style={styles.emptyWrap}>
                         <Ionicons name="barbell-outline" size={48} color={colors.textTertiary} />
                         <Text style={styles.emptyText}>{t("exercise.workout.emptyState")}</Text>
+                        {!isFinished && (
+                            <Button
+                                title={t("exercise.workout.copyFromHistory")}
+                                variant="ghost"
+                                icon={<Ionicons name="copy-outline" size={18} color={colors.primary} />}
+                                onPress={() => setShowCopySheet(true)}
+                            />
+                        )}
                     </View>
                 }
                 ListFooterComponent={
-                    !isFinished ? (
+                    !isFinished && !isEmpty ? (
                         <Button
                             title={t("exercise.workout.addExercise")}
                             variant="outline"
@@ -123,6 +134,15 @@ export default function WorkoutScreen() {
                 onClose={() => setShowAddExercise(false)}
                 onSelect={handleExerciseSelected}
             />
+
+            {workout.data?.workout.id && (
+                <CopyWorkoutSheet
+                    visible={showCopySheet}
+                    targetWorkoutId={workout.data.workout.id}
+                    onClose={() => setShowCopySheet(false)}
+                    onCopied={workout.reload}
+                />
+            )}
         </View>
     );
 }

--- a/src/features/exercise/services/exerciseDb.ts
+++ b/src/features/exercise/services/exerciseDb.ts
@@ -334,6 +334,47 @@ export function getSetsForExercise(workoutExerciseId: number): ExerciseSet[] {
     return exerciseDbSupport.listSetsForExercise(workoutExerciseId);
 }
 
+export function copyWorkoutAsScheduled(sourceWorkoutId: number, targetWorkoutId: number): void {
+    const sourceExercises = listWorkoutExercisesForWorkout(sourceWorkoutId);
+    const sourceWorkout = exerciseDbSupport.getWorkoutOrThrow(sourceWorkoutId);
+    const targetWorkout = exerciseDbSupport.getWorkoutOrThrow(targetWorkoutId);
+
+    if (sourceWorkout.title) {
+        db.update(workouts).set({ title: sourceWorkout.title }).where(eq(workouts.id, targetWorkoutId)).run();
+    }
+
+    for (const ex of sourceExercises) {
+        const newWe = db
+            .insert(workoutExercises)
+            .values({
+                workout_id: targetWorkoutId,
+                exercise_template_id: ex.workoutExercise.exercise_template_id,
+                sort_order: ex.workoutExercise.sort_order,
+                notes: ex.workoutExercise.notes,
+            })
+            .returning()
+            .get();
+
+        for (const set of ex.sets) {
+            db.insert(exerciseSets)
+                .values({
+                    workout_exercise_id: newWe.id,
+                    set_order: set.set_order,
+                    type: set.type,
+                    weight: set.weight,
+                    weight_unit: set.weight_unit,
+                    reps: set.reps,
+                    duration_seconds: set.duration_seconds,
+                    distance_meters: set.distance_meters,
+                    rir: set.rir,
+                    rest_seconds: set.rest_seconds,
+                    is_scheduled: 1,
+                })
+                .run();
+        }
+    }
+}
+
 export function getExerciseHistory(templateId: number, limit = DEFAULT_RECENT_LIMIT): WorkoutExerciseWithSets[] {
     exerciseDbSupport.getExerciseTemplateOrThrow(templateId);
     return listWorkoutExerciseHistory(templateId, limit);


### PR DESCRIPTION
Closes #202

## Summary
- **CopyWorkoutSheet**: Bottom sheet listing recent finished workouts (last 20) with date, title, and exercise count
- **copyWorkoutAsScheduled()**: DB function that copies all exercises + sets from a source workout into a target workout with `is_scheduled = 1`
- Integrated into WorkoutScreen empty state — 'Start from History' button opens the sheet
- Copied workout title is applied to the target workout
- Scheduled sets display with ghost/dim styling (reduced opacity) in ExerciseCard