### PR TITLE
feat: Set logging — input row, confirm, pre-fill

### DIFF
--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -2,10 +2,11 @@ import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Modal, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
+import SetInputRow, { type SetValues } from "./SetInputRow";
 
 type ExerciseType = "weight" | "bodyweight" | "cardio";
 
@@ -14,15 +15,21 @@ interface ExerciseCardProps {
     index: number;
     totalExercises: number;
     isFinished: boolean;
+    lastWorkoutSets: ExerciseSet[];
     onRemove: (workoutExerciseId: number) => void;
     onMoveUp: (workoutExerciseId: number) => void;
     onMoveDown: (workoutExerciseId: number) => void;
     onNoteChange: (workoutExerciseId: number, note: string) => void;
+    onConfirmSet: (setId: number, values: SetValues) => void;
+    onDeleteSet: (setId: number) => void;
+    onSetTypeChange: (setId: number, type: string) => void;
+    onAddSet: (workoutExerciseId: number) => void;
 }
 
 export default function ExerciseCard({
-    item, index, totalExercises, isFinished,
+    item, index, totalExercises, isFinished, lastWorkoutSets,
     onRemove, onMoveUp, onMoveDown, onNoteChange,
+    onConfirmSet, onDeleteSet, onSetTypeChange, onAddSet,
 }: ExerciseCardProps) {
     const colors = useThemeColors();
     const { t } = useTranslation();
@@ -106,13 +113,38 @@ export default function ExerciseCard({
             </View>
 
             {/* Set rows */}
-            {item.sets.map((set, si) => (
-                <SetRow key={set.id} set={set} index={si} exerciseType={exerciseType} colors={colors} styles={styles} />
-            ))}
+            {item.sets.map((set, si) => {
+                const prefill = getPrefillForSet(si, item.sets, lastWorkoutSets);
+                return (
+                    <SetInputRow
+                        key={set.id}
+                        set={set}
+                        index={si}
+                        exerciseType={exerciseType}
+                        isActive={isActiveSet(set, si, item.sets)}
+                        isFinished={isFinished}
+                        prefillWeight={prefill.weight}
+                        prefillReps={prefill.reps}
+                        prefillRir={prefill.rir}
+                        prefillDuration={prefill.duration}
+                        prefillDistance={prefill.distance}
+                        onConfirm={onConfirmSet}
+                        onDelete={onDeleteSet}
+                        onTypeChange={onSetTypeChange}
+                    />
+                );
+            })}
 
             {/* Empty state */}
             {item.sets.length === 0 && (
                 <Text style={styles.emptyText}>{t("exercise.workout.emptyState")}</Text>
+            )}
+
+            {/* + Add Set button */}
+            {!isFinished && (
+                <Pressable style={styles.addSetBtn} onPress={() => onAddSet(item.workoutExercise.id)}>
+                    <Text style={styles.addSetText}>{t("exercise.exerciseCard.addSet")}</Text>
+                </Pressable>
             )}
 
             {/* Overflow menu modal */}
@@ -163,46 +195,36 @@ export default function ExerciseCard({
     );
 }
 
-function SetRow({ set, index, exerciseType, colors, styles }: {
-    set: ExerciseSet; index: number; exerciseType: ExerciseType;
-    colors: ReturnType<typeof useThemeColors>; styles: ReturnType<typeof createStyles>;
-}) {
-    const isCompleted = !!set.completed_at;
-    const isScheduled = !!set.is_scheduled && !isCompleted;
-    const textColor = isScheduled ? colors.textTertiary : colors.text;
+/** Determine if a set is the "active" (first non-completed) set. */
+function isActiveSet(set: ExerciseSet, index: number, sets: ExerciseSet[]): boolean {
+    if (!!set.completed_at) return false;
+    const firstUncompletedIdx = sets.findIndex((s) => !s.completed_at);
+    return firstUncompletedIdx === index;
+}
 
-    function formatWeight(w: number | null): string {
-        if (w === null) return "—";
-        return `${w}`;
+interface Prefill { weight: number | null; reps: number | null; rir: number | null; duration: number | null; distance: number | null; }
+
+/** Pre-fill logic: previous completed set in this exercise > last workout's matching set. */
+function getPrefillForSet(index: number, sets: ExerciseSet[], lastWorkoutSets: ExerciseSet[]): Prefill {
+    // 1. Previous completed set in same exercise
+    for (let i = index - 1; i >= 0; i--) {
+        if (sets[i].completed_at) {
+            return {
+                weight: sets[i].weight, reps: sets[i].reps, rir: sets[i].rir,
+                duration: sets[i].duration_seconds, distance: sets[i].distance_meters,
+            };
+        }
     }
-
-    return (
-        <View style={[styles.setRow, isScheduled && styles.setRowScheduled]}>
-            <Text style={[styles.setCell, styles.setCol, { color: textColor }]}>{index + 1}</Text>
-            {exerciseType === "weight" && (
-                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{formatWeight(set.weight)}</Text>
-            )}
-            {exerciseType !== "cardio" && (
-                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{set.reps ?? "—"}</Text>
-            )}
-            {exerciseType === "cardio" && (
-                <>
-                    <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{set.duration_seconds ? `${set.duration_seconds}s` : "—"}</Text>
-                    <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{set.distance_meters ? `${set.distance_meters}m` : "—"}</Text>
-                </>
-            )}
-            {exerciseType !== "cardio" && (
-                <Text style={[styles.setCell, styles.rirCol, { color: textColor }]}>{set.rir ?? "—"}</Text>
-            )}
-            <View style={styles.checkCol}>
-                <Ionicons
-                    name={isCompleted ? "checkmark-circle" : "ellipse-outline"}
-                    size={20}
-                    color={isCompleted ? colors.primary : isScheduled ? colors.textTertiary : colors.border}
-                />
-            </View>
-        </View>
-    );
+    // 2. Matching set from last workout
+    if (lastWorkoutSets.length > index) {
+        const lw = lastWorkoutSets[index];
+        return { weight: lw.weight, reps: lw.reps, rir: lw.rir, duration: lw.duration_seconds, distance: lw.distance_meters };
+    }
+    if (lastWorkoutSets.length > 0) {
+        const lw = lastWorkoutSets[lastWorkoutSets.length - 1];
+        return { weight: lw.weight, reps: lw.reps, rir: lw.rir, duration: lw.duration_seconds, distance: lw.distance_meters };
+    }
+    return { weight: null, reps: null, rir: null, duration: null, distance: null };
 }
 
 function MenuItem({ label, icon, onPress, colors, destructive }: {
@@ -267,26 +289,24 @@ function createStyles(colors: ThemeColors) {
             color: colors.textSecondary,
             textTransform: "uppercase",
         },
-        setRow: {
-            flexDirection: "row",
-            alignItems: "center",
-            paddingVertical: 4,
-        },
-        setRowScheduled: {
-            opacity: 0.6,
-        },
-        setCell: {
-            fontSize: fontSize.sm,
-        },
         setCol: { width: 32 },
-        valueCol: { flex: 1, textAlign: "center" },
-        rirCol: { width: 36, textAlign: "center" },
-        checkCol: { width: 28, alignItems: "center" },
+        valueCol: { flex: 1, textAlign: "center" as const },
+        rirCol: { width: 36, textAlign: "center" as const },
+        checkCol: { width: 28, alignItems: "center" as const },
         emptyText: {
             fontSize: fontSize.sm,
             color: colors.textTertiary,
             textAlign: "center",
             paddingVertical: spacing.md,
+        },
+        addSetBtn: {
+            paddingVertical: spacing.sm,
+            alignItems: "center",
+        },
+        addSetText: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.primary,
         },
         overlay: {
             flex: 1,

--- a/src/features/exercise/components/SetInputRow.tsx
+++ b/src/features/exercise/components/SetInputRow.tsx
@@ -1,0 +1,263 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import type { ExerciseSet } from "../services/exerciseDb";
+
+type ExerciseType = "weight" | "bodyweight" | "cardio";
+
+const SET_TYPES = ["warmup", "working", "dropset", "failure"] as const;
+type SetType = (typeof SET_TYPES)[number];
+
+const SET_TYPE_LABELS: Record<SetType, string> = {
+    warmup: "W", working: "", dropset: "D", failure: "F",
+};
+
+interface SetInputRowProps {
+    set: ExerciseSet;
+    index: number;
+    exerciseType: ExerciseType;
+    isActive: boolean;
+    isFinished: boolean;
+    prefillWeight: number | null;
+    prefillReps: number | null;
+    prefillRir: number | null;
+    prefillDuration: number | null;
+    prefillDistance: number | null;
+    onConfirm: (id: number, values: SetValues) => void;
+    onDelete: (id: number) => void;
+    onTypeChange: (id: number, type: string) => void;
+}
+
+export interface SetValues {
+    weight: number | null;
+    weight_unit: string;
+    reps: number | null;
+    rir: number | null;
+    duration_seconds: number | null;
+    distance_meters: number | null;
+    type: string;
+}
+
+export default function SetInputRow({
+    set, index, exerciseType, isActive, isFinished,
+    prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance,
+    onConfirm, onDelete, onTypeChange,
+}: SetInputRowProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+
+    const isCompleted = !!set.completed_at;
+    const isScheduled = !!set.is_scheduled && !isCompleted;
+
+    // Input state — initialise from set data, placeholders from prefill
+    const [weight, setWeight] = useState(set.weight != null ? String(set.weight) : "");
+    const [reps, setReps] = useState(set.reps != null ? String(set.reps) : "");
+    const [rir, setRir] = useState(set.rir != null ? String(set.rir) : "");
+    const [duration, setDuration] = useState(set.duration_seconds != null ? String(set.duration_seconds) : "");
+    const [distance, setDistance] = useState(set.distance_meters != null ? String(set.distance_meters) : "");
+    const [unit] = useState(set.weight_unit ?? "kg");
+
+    const typeLabel = SET_TYPE_LABELS[set.type as SetType] ?? "";
+
+    const handleConfirm = useCallback(() => {
+        const vals: SetValues = {
+            weight: weight ? parseFloat(weight) : prefillWeight,
+            weight_unit: unit,
+            reps: reps ? parseInt(reps, 10) : prefillReps,
+            rir: rir ? parseInt(rir, 10) : prefillRir,
+            duration_seconds: duration ? parseInt(duration, 10) : prefillDuration,
+            distance_meters: distance ? parseFloat(distance) : prefillDistance,
+            type: set.type,
+        };
+        onConfirm(set.id, vals);
+    }, [weight, reps, rir, duration, distance, unit, set.id, set.type,
+        prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance, onConfirm]);
+
+    const handleLongPressSetNum = useCallback(() => {
+        if (isCompleted || isFinished) return;
+        const currentIdx = SET_TYPES.indexOf(set.type as SetType);
+        const nextIdx = (currentIdx + 1) % SET_TYPES.length;
+        onTypeChange(set.id, SET_TYPES[nextIdx]);
+    }, [set.id, set.type, isCompleted, isFinished, onTypeChange]);
+
+    const handleDelete = useCallback(() => {
+        if (isFinished) return;
+        Alert.alert(
+            t("common.delete"),
+            t("exercise.exerciseCard.removeConfirm"),
+            [
+                { text: t("common.cancel"), style: "cancel" },
+                { text: t("common.delete"), style: "destructive", onPress: () => onDelete(set.id) },
+            ],
+        );
+    }, [set.id, isFinished, onDelete, t]);
+
+    // Completed / read-only display
+    if (isCompleted && !isActive) {
+        return (
+            <Pressable style={styles.setRow} onLongPress={handleDelete} delayLongPress={600}>
+                <Text style={[styles.setCell, styles.setCol, { color: colors.textSecondary }]}>
+                    {typeLabel}{index + 1}
+                </Text>
+                <ReadOnlyCells set={set} exerciseType={exerciseType} textColor={colors.textSecondary} styles={styles} />
+                <View style={styles.checkCol}>
+                    <Ionicons name="checkmark-circle" size={20} color={colors.primary} />
+                </View>
+            </Pressable>
+        );
+    }
+
+    // Active / editable input row
+    if (isActive && !isFinished) {
+        const textColor = isScheduled ? colors.textTertiary : colors.text;
+        return (
+            <View style={[styles.setRow, styles.activeRow]}>
+                <Pressable onLongPress={handleLongPressSetNum} style={styles.setCol}>
+                    <Text style={[styles.setCell, { color: colors.primary, fontWeight: "700" }]}>
+                        {typeLabel}{index + 1}
+                    </Text>
+                </Pressable>
+                {exerciseType === "weight" && (
+                    <TextInput
+                        style={[styles.input, styles.valueCol, { color: textColor }]}
+                        value={weight}
+                        onChangeText={setWeight}
+                        placeholder={prefillWeight != null ? String(prefillWeight) : "—"}
+                        placeholderTextColor={colors.textTertiary}
+                        keyboardType="decimal-pad"
+                        selectTextOnFocus
+                    />
+                )}
+                {exerciseType !== "cardio" && (
+                    <TextInput
+                        style={[styles.input, styles.valueCol, { color: textColor }]}
+                        value={reps}
+                        onChangeText={setReps}
+                        placeholder={prefillReps != null ? String(prefillReps) : "—"}
+                        placeholderTextColor={colors.textTertiary}
+                        keyboardType="number-pad"
+                        selectTextOnFocus
+                    />
+                )}
+                {exerciseType === "cardio" && (
+                    <>
+                        <TextInput
+                            style={[styles.input, styles.valueCol, { color: textColor }]}
+                            value={duration}
+                            onChangeText={setDuration}
+                            placeholder={prefillDuration != null ? String(prefillDuration) : "—"}
+                            placeholderTextColor={colors.textTertiary}
+                            keyboardType="number-pad"
+                            selectTextOnFocus
+                        />
+                        <TextInput
+                            style={[styles.input, styles.valueCol, { color: textColor }]}
+                            value={distance}
+                            onChangeText={setDistance}
+                            placeholder={prefillDistance != null ? String(prefillDistance) : "—"}
+                            placeholderTextColor={colors.textTertiary}
+                            keyboardType="decimal-pad"
+                            selectTextOnFocus
+                        />
+                    </>
+                )}
+                {exerciseType !== "cardio" && (
+                    <TextInput
+                        style={[styles.input, styles.rirCol, { color: textColor }]}
+                        value={rir}
+                        onChangeText={setRir}
+                        placeholder={prefillRir != null ? String(prefillRir) : "—"}
+                        placeholderTextColor={colors.textTertiary}
+                        keyboardType="number-pad"
+                        selectTextOnFocus
+                    />
+                )}
+                <Pressable style={styles.checkCol} onPress={handleConfirm}>
+                    <Ionicons name="checkmark-circle-outline" size={22} color={colors.primary} />
+                </Pressable>
+            </View>
+        );
+    }
+
+    // Scheduled / pending (not active) — display-only dim row
+    const textColor = isScheduled ? colors.textTertiary : colors.text;
+    return (
+        <Pressable
+            style={[styles.setRow, isScheduled && styles.setRowScheduled]}
+            onLongPress={handleLongPressSetNum}
+        >
+            <Text style={[styles.setCell, styles.setCol, { color: textColor }]}>{typeLabel}{index + 1}</Text>
+            <ReadOnlyCells set={set} exerciseType={exerciseType} textColor={textColor} styles={styles} />
+            <View style={styles.checkCol}>
+                <Ionicons name="ellipse-outline" size={20} color={colors.border} />
+            </View>
+        </Pressable>
+    );
+}
+
+function ReadOnlyCells({ set, exerciseType, textColor, styles }: {
+    set: ExerciseSet; exerciseType: ExerciseType; textColor: string;
+    styles: ReturnType<typeof createStyles>;
+}) {
+    return (
+        <>
+            {exerciseType === "weight" && (
+                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{set.weight ?? "—"}</Text>
+            )}
+            {exerciseType !== "cardio" && (
+                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{set.reps ?? "—"}</Text>
+            )}
+            {exerciseType === "cardio" && (
+                <>
+                    <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>
+                        {set.duration_seconds ? `${set.duration_seconds}s` : "—"}
+                    </Text>
+                    <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>
+                        {set.distance_meters ? `${set.distance_meters}m` : "—"}
+                    </Text>
+                </>
+            )}
+            {exerciseType !== "cardio" && (
+                <Text style={[styles.setCell, styles.rirCol, { color: textColor }]}>{set.rir ?? "—"}</Text>
+            )}
+        </>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        setRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            paddingVertical: 4,
+        },
+        activeRow: {
+            backgroundColor: colors.surfaceVariant ?? colors.background,
+            borderRadius: borderRadius.sm,
+            marginHorizontal: -spacing.xs,
+            paddingHorizontal: spacing.xs,
+        },
+        setRowScheduled: {
+            opacity: 0.6,
+        },
+        setCell: {
+            fontSize: fontSize.sm,
+        },
+        setCol: { width: 32, justifyContent: "center" },
+        valueCol: { flex: 1, textAlign: "center" },
+        rirCol: { width: 36, textAlign: "center" },
+        checkCol: { width: 28, alignItems: "center" },
+        input: {
+            fontSize: fontSize.sm,
+            textAlign: "center",
+            borderBottomWidth: 1,
+            borderBottomColor: colors.border,
+            paddingVertical: 2,
+            marginHorizontal: 2,
+        },
+    });
+}

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -3,15 +3,19 @@ import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { spacing, type ThemeColors } from "@/src/utils/theme";
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FlatList, StyleSheet, Text, View } from "react-native";
 import AddExerciseModal from "../components/AddExerciseModal";
 import CopyWorkoutSheet from "../components/CopyWorkoutSheet";
 import ExerciseCard from "../components/ExerciseCard";
+import type { SetValues } from "../components/SetInputRow";
 import WorkoutHeader from "../components/WorkoutHeader";
 import { useWorkout } from "../hooks/useWorkout";
-import { updateWorkoutExercise, type ExerciseTemplate, type WorkoutExerciseWithSets } from "../services/exerciseDb";
+import {
+    addSet, completeSet, deleteSet, getLastCompletedSetsForTemplate, updateSet,
+    updateWorkoutExercise, type ExerciseSet, type ExerciseTemplate, type WorkoutExerciseWithSets,
+} from "../services/exerciseDb";
 
 export default function WorkoutScreen() {
     const colors = useThemeColors();
@@ -68,17 +72,64 @@ export default function WorkoutScreen() {
         }
     }
 
+    const handleConfirmSet = useCallback((setId: number, values: SetValues) => {
+        updateSet(setId, {
+            weight: values.weight,
+            weight_unit: values.weight_unit,
+            reps: values.reps,
+            rir: values.rir,
+            duration_seconds: values.duration_seconds,
+            distance_meters: values.distance_meters,
+            type: values.type,
+        });
+        completeSet(setId);
+        workout.reload();
+    }, [workout]);
+
+    const handleDeleteSet = useCallback((setId: number) => {
+        deleteSet(setId);
+        workout.reload();
+    }, [workout]);
+
+    const handleSetTypeChange = useCallback((setId: number, type: string) => {
+        updateSet(setId, { type });
+        workout.reload();
+    }, [workout]);
+
+    const handleAddSet = useCallback((workoutExerciseId: number) => {
+        addSet({ workout_exercise_id: workoutExerciseId });
+        workout.reload();
+    }, [workout]);
+
+    /** Cache of last-workout sets per template. */
+    const lastSetsCache = useMemo(() => {
+        const cache = new Map<number, ExerciseSet[]>();
+        for (const ex of workout.data?.exercises ?? []) {
+            const tid = ex.workoutExercise.exercise_template_id;
+            if (tid && !cache.has(tid)) {
+                cache.set(tid, getLastCompletedSetsForTemplate(tid));
+            }
+        }
+        return cache;
+    }, [workout.data?.exercises]);
+
     function renderExercise({ item, index }: { item: WorkoutExerciseWithSets; index: number }) {
+        const tid = item.workoutExercise.exercise_template_id;
         return (
             <ExerciseCard
                 item={item}
                 index={index}
                 totalExercises={workout.data?.exercises.length ?? 0}
                 isFinished={isFinished}
+                lastWorkoutSets={tid ? (lastSetsCache.get(tid) ?? []) : []}
                 onRemove={workout.removeExercise}
                 onMoveUp={handleMoveUp}
                 onMoveDown={handleMoveDown}
                 onNoteChange={handleNoteChange}
+                onConfirmSet={handleConfirmSet}
+                onDeleteSet={handleDeleteSet}
+                onSetTypeChange={handleSetTypeChange}
+                onAddSet={handleAddSet}
             />
         );
     }

--- a/src/features/exercise/services/exerciseDb.ts
+++ b/src/features/exercise/services/exerciseDb.ts
@@ -334,6 +334,21 @@ export function getSetsForExercise(workoutExerciseId: number): ExerciseSet[] {
     return exerciseDbSupport.listSetsForExercise(workoutExerciseId);
 }
 
+/** Returns completed sets from the most recent finished workout that used this template. */
+export function getLastCompletedSetsForTemplate(templateId: number): ExerciseSet[] {
+    const rows = db
+        .select({ weId: workoutExercises.id })
+        .from(workoutExercises)
+        .innerJoin(workouts, eq(workoutExercises.workout_id, workouts.id))
+        .where(and(eq(workoutExercises.exercise_template_id, templateId), isNotNull(workouts.ended_at)))
+        .orderBy(desc(workouts.date), desc(workoutExercises.id))
+        .limit(1)
+        .all();
+
+    if (rows.length === 0) return [];
+    return exerciseDbSupport.listSetsForExercise(rows[0].weId).filter((s) => !!s.completed_at);
+}
+
 export function copyWorkoutAsScheduled(sourceWorkoutId: number, targetWorkoutId: number): void {
     const sourceExercises = listWorkoutExercisesForWorkout(sourceWorkoutId);
     const sourceWorkout = exerciseDbSupport.getWorkoutOrThrow(sourceWorkoutId);


### PR DESCRIPTION
Closes #200

## Summary
- **SetInputRow** component: 3-mode set display (completed → read-only, active → editable inputs, pending → dimmed)
- Active row: editable weight/reps/RIR fields (weight type), duration/distance (cardio), bodyweight (reps only)
- Confirm ✓ button writes to DB immediately via `completeSet()`
- Pre-fill: previous completed set in exercise → last workout's matching set via `getLastCompletedSetsForTemplate()`
- Set type cycling via long-press on set number (warmup ↔ working ↔ dropset ↔ failure)
- `+ Add Set` button per exercise card
- Long-press delete on completed set rows
- All set callbacks wired through WorkoutScreen → ExerciseCard → SetInputRow