### PR TITLE
feat: RIR input & display enhancements

### DIFF
--- a/src/features/exercise/components/SetInputRow.tsx
+++ b/src/features/exercise/components/SetInputRow.tsx
@@ -239,7 +239,13 @@ function ReadOnlyCells({ set, exerciseType, textColor, styles }: {
                 </>
             )}
             {exerciseType !== "cardio" && (
-                <Text style={[styles.setCell, styles.rirCol, { color: textColor }]}>{set.rir ?? "—"}</Text>
+                <Text style={[
+                    styles.setCell, styles.rirCol,
+                    { color: set.rir != null && set.rir <= 1 ? "#ef4444" : textColor },
+                    set.rir != null && set.rir <= 1 && { fontWeight: "700" },
+                ]}>
+                    {set.rir ?? "—"}
+                </Text>
             )}
         </>
     );

--- a/src/features/exercise/helpers/workoutSummary.ts
+++ b/src/features/exercise/helpers/workoutSummary.ts
@@ -30,13 +30,16 @@ function formatWeightSets(sets: ExerciseSet[]): string {
         groups.set(key, (groups.get(key) ?? 0) + 1);
     }
 
-    return Array.from(groups.entries())
+    const base = Array.from(groups.entries())
         .map(([key, count]) => {
             const match = key.match(/^(\d+)@([\d.]+)(.+)$/);
             if (!match) return key;
             return `${count}×${match[1]} @ ${match[2]}${match[3]}`;
         })
         .join(", ");
+
+    const rir = formatRirRange(sets);
+    return rir ? `${base} ${rir}` : base;
 }
 
 function formatCardioSets(sets: ExerciseSet[]): string {
@@ -52,9 +55,12 @@ function formatBodyweightSets(sets: ExerciseSet[]): string {
         if (s.reps === null) continue;
         groups.set(s.reps, (groups.get(s.reps) ?? 0) + 1);
     }
-    return Array.from(groups.entries())
+    const base = Array.from(groups.entries())
         .map(([reps, count]) => `${count}×${reps}`)
         .join(", ");
+
+    const rir = formatRirRange(sets);
+    return rir ? `${base} ${rir}` : base;
 }
 
 function formatDuration(seconds: number): string {


### PR DESCRIPTION
Closes #208

## Summary
- **RIR range in summaries**: Weight and bodyweight set summaries now include RIR range (e.g. `3×8 @ 80kg RIR 2-3`) — visible in WorkoutSummarySection and ExerciseHistoryScreen
- **Close-to-failure indicator**: Completed sets with RIR ≤ 1 show the value in red bold for immediate visual feedback
- RIR input/storage was already implemented in #200; this PR adds display polish and summary integration