### PR TITLE
feat: Rest timer with background persistence

### DIFF
--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -2,10 +2,11 @@ import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Modal, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
+import RestTimer from "./RestTimer";
 import SetInputRow, { type SetValues } from "./SetInputRow";
 
 type ExerciseType = "weight" | "bodyweight" | "cardio";
@@ -24,12 +25,18 @@ interface ExerciseCardProps {
     onDeleteSet: (setId: number) => void;
     onSetTypeChange: (setId: number, type: string) => void;
     onAddSet: (workoutExerciseId: number) => void;
+    restTimerActive: boolean;
+    restTimerElapsed: number;
+    restTimerTarget: number;
+    restTimerReached: boolean;
+    onRestTimerSkip: () => void;
 }
 
 export default function ExerciseCard({
     item, index, totalExercises, isFinished, lastWorkoutSets,
     onRemove, onMoveUp, onMoveDown, onNoteChange,
     onConfirmSet, onDeleteSet, onSetTypeChange, onAddSet,
+    restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExerciseCardProps) {
     const colors = useThemeColors();
     const { t } = useTranslation();
@@ -115,23 +122,34 @@ export default function ExerciseCard({
             {/* Set rows */}
             {item.sets.map((set, si) => {
                 const prefill = getPrefillForSet(si, item.sets, lastWorkoutSets);
+                const isActive = isActiveSet(set, si, item.sets);
                 return (
-                    <SetInputRow
-                        key={set.id}
-                        set={set}
-                        index={si}
-                        exerciseType={exerciseType}
-                        isActive={isActiveSet(set, si, item.sets)}
-                        isFinished={isFinished}
-                        prefillWeight={prefill.weight}
-                        prefillReps={prefill.reps}
-                        prefillRir={prefill.rir}
-                        prefillDuration={prefill.duration}
-                        prefillDistance={prefill.distance}
-                        onConfirm={onConfirmSet}
-                        onDelete={onDeleteSet}
-                        onTypeChange={onSetTypeChange}
-                    />
+                    <React.Fragment key={set.id}>
+                        {/* Rest timer between last completed set and active input */}
+                        {isActive && restTimerActive && (
+                            <RestTimer
+                                elapsedSeconds={restTimerElapsed}
+                                targetSeconds={restTimerTarget}
+                                isTargetReached={restTimerReached}
+                                onSkip={onRestTimerSkip}
+                            />
+                        )}
+                        <SetInputRow
+                            set={set}
+                            index={si}
+                            exerciseType={exerciseType}
+                            isActive={isActive}
+                            isFinished={isFinished}
+                            prefillWeight={prefill.weight}
+                            prefillReps={prefill.reps}
+                            prefillRir={prefill.rir}
+                            prefillDuration={prefill.duration}
+                            prefillDistance={prefill.distance}
+                            onConfirm={onConfirmSet}
+                            onDelete={onDeleteSet}
+                            onTypeChange={onSetTypeChange}
+                        />
+                    </React.Fragment>
                 );
             })}
 

--- a/src/features/exercise/components/RestTimer.tsx
+++ b/src/features/exercise/components/RestTimer.tsx
@@ -1,0 +1,82 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+interface RestTimerProps {
+    elapsedSeconds: number;
+    targetSeconds: number;
+    isTargetReached: boolean;
+    onSkip: () => void;
+}
+
+export default function RestTimer({ elapsedSeconds, targetSeconds, isTargetReached, onSkip }: RestTimerProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+
+    const progress = Math.min(elapsedSeconds / targetSeconds, 1);
+    const accentColor = isTargetReached ? "#f59e0b" : colors.primary;
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.progressBg}>
+                <View style={[styles.progressFill, { width: `${progress * 100}%`, backgroundColor: accentColor }]} />
+            </View>
+            <View style={styles.row}>
+                <Ionicons name="timer-outline" size={16} color={accentColor} />
+                <Text style={[styles.timeText, { color: accentColor }]}>
+                    {t("exercise.restTimer.label")}: {formatTime(elapsedSeconds)} / {formatTime(targetSeconds)}
+                </Text>
+                <Pressable onPress={onSkip} style={styles.skipBtn} hitSlop={8}>
+                    <Text style={[styles.skipText, { color: colors.primary }]}>{t("exercise.restTimer.skip")}</Text>
+                </Pressable>
+            </View>
+        </View>
+    );
+}
+
+function formatTime(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        container: {
+            marginVertical: spacing.xs,
+        },
+        progressBg: {
+            height: 3,
+            backgroundColor: colors.border,
+            borderRadius: borderRadius.sm,
+            overflow: "hidden",
+            marginBottom: spacing.xs,
+        },
+        progressFill: {
+            height: "100%",
+            borderRadius: borderRadius.sm,
+        },
+        row: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.xs,
+        },
+        timeText: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            flex: 1,
+        },
+        skipBtn: {
+            paddingVertical: 2,
+            paddingHorizontal: spacing.sm,
+        },
+        skipText: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+        },
+    });
+}

--- a/src/features/exercise/hooks/useRestTimer.ts
+++ b/src/features/exercise/hooks/useRestTimer.ts
@@ -1,0 +1,103 @@
+import { create } from "zustand";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const REST_DEFAULTS: Record<string, number> = {
+    warmup: 60,
+    working: 120,
+    dropset: 30,
+    failure: 120,
+};
+
+interface TimerState {
+    isRunning: boolean;
+    startedAtEpoch: number;
+    targetDurationSeconds: number;
+    workoutExerciseId: number | null;
+}
+
+interface TimerStore extends TimerState {
+    start: (workoutExerciseId: number, setType: string) => void;
+    stop: () => void;
+}
+
+const useTimerStore = create<TimerStore>((set) => ({
+    isRunning: false,
+    startedAtEpoch: 0,
+    targetDurationSeconds: 120,
+    workoutExerciseId: null,
+    start: (workoutExerciseId, setType) =>
+        set({
+            isRunning: true,
+            startedAtEpoch: Date.now(),
+            targetDurationSeconds: REST_DEFAULTS[setType] ?? 120,
+            workoutExerciseId,
+        }),
+    stop: () =>
+        set({ isRunning: false, startedAtEpoch: 0, workoutExerciseId: null }),
+}));
+
+export interface UseRestTimerReturn {
+    isRunning: boolean;
+    elapsedSeconds: number;
+    targetSeconds: number;
+    workoutExerciseId: number | null;
+    start: (workoutExerciseId: number, setType: string) => void;
+    skip: () => void;
+    isTargetReached: boolean;
+}
+
+export function useRestTimer(): UseRestTimerReturn {
+    const store = useTimerStore();
+    const [elapsedSeconds, setElapsedSeconds] = useState(0);
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const hapticFiredRef = useRef(false);
+
+    useEffect(() => {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+
+        if (store.isRunning && store.startedAtEpoch > 0) {
+            const tick = () => {
+                const elapsed = Math.floor((Date.now() - store.startedAtEpoch) / 1000);
+                setElapsedSeconds(elapsed);
+
+                // Haptic feedback when target reached (fire once)
+                if (elapsed >= store.targetDurationSeconds && !hapticFiredRef.current) {
+                    hapticFiredRef.current = true;
+                    triggerHaptic();
+                }
+            };
+            tick();
+            intervalRef.current = setInterval(tick, 1000);
+        } else {
+            setElapsedSeconds(0);
+            hapticFiredRef.current = false;
+        }
+
+        return () => {
+            if (intervalRef.current) clearInterval(intervalRef.current);
+        };
+    }, [store.isRunning, store.startedAtEpoch, store.targetDurationSeconds]);
+
+    const skip = useCallback(() => {
+        store.stop();
+    }, [store]);
+
+    return {
+        isRunning: store.isRunning,
+        elapsedSeconds,
+        targetSeconds: store.targetDurationSeconds,
+        workoutExerciseId: store.workoutExerciseId,
+        start: store.start,
+        skip,
+        isTargetReached: elapsedSeconds >= store.targetDurationSeconds,
+    };
+}
+
+async function triggerHaptic() {
+    try {
+        const Haptics = await import("expo-haptics");
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    } catch {
+        // Haptics not available (e.g. web)
+    }
+}

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -11,6 +11,7 @@ import CopyWorkoutSheet from "../components/CopyWorkoutSheet";
 import ExerciseCard from "../components/ExerciseCard";
 import type { SetValues } from "../components/SetInputRow";
 import WorkoutHeader from "../components/WorkoutHeader";
+import { useRestTimer } from "../hooks/useRestTimer";
 import { useWorkout } from "../hooks/useWorkout";
 import {
     addSet, completeSet, deleteSet, getLastCompletedSetsForTemplate, updateSet,
@@ -26,6 +27,7 @@ export default function WorkoutScreen() {
     const workoutId = params.workoutId ? Number(params.workoutId) : undefined;
 
     const workout = useWorkout({ workoutId });
+    const restTimer = useRestTimer();
     const [showAddExercise, setShowAddExercise] = useState(false);
     const [showCopySheet, setShowCopySheet] = useState(false);
 
@@ -83,8 +85,17 @@ export default function WorkoutScreen() {
             type: values.type,
         });
         completeSet(setId);
+
+        // Find which workout exercise this set belongs to & start rest timer
+        for (const ex of workout.data?.exercises ?? []) {
+            if (ex.sets.some((s) => s.id === setId)) {
+                restTimer.start(ex.workoutExercise.id, values.type);
+                break;
+            }
+        }
+
         workout.reload();
-    }, [workout]);
+    }, [workout, restTimer]);
 
     const handleDeleteSet = useCallback((setId: number) => {
         deleteSet(setId);
@@ -117,6 +128,7 @@ export default function WorkoutScreen() {
 
     function renderExercise({ item, index }: { item: WorkoutExerciseWithSets; index: number }) {
         const tid = item.workoutExercise.exercise_template_id;
+        const timerActive = restTimer.isRunning && restTimer.workoutExerciseId === item.workoutExercise.id;
         return (
             <ExerciseCard
                 item={item}
@@ -132,6 +144,11 @@ export default function WorkoutScreen() {
                 onDeleteSet={handleDeleteSet}
                 onSetTypeChange={handleSetTypeChange}
                 onAddSet={handleAddSet}
+                restTimerActive={timerActive}
+                restTimerElapsed={timerActive ? restTimer.elapsedSeconds : 0}
+                restTimerTarget={timerActive ? restTimer.targetSeconds : 0}
+                restTimerReached={timerActive ? restTimer.isTargetReached : false}
+                onRestTimerSkip={restTimer.skip}
             />
         );
     }


### PR DESCRIPTION
Closes #201

## Summary
- **useRestTimer** hook: Zustand-based timer state with `startedAtEpoch` pattern for background survival
- **RestTimer** component: progress bar + elapsed/target display + Skip button
- Timer **auto-starts** when a set is confirmed (`handleConfirmSet`)
- Displayed between last completed set and active input row on the exercise card
- **Haptic feedback** (`expo-haptics`) when target rest time is reached
- Color transitions: primary → amber when target exceeded
- Default rest durations per set type: working=120s, warmup=60s, dropset=30s
- Skip button dismisses timer immediately