### PR TITLE
feat: Copy historical exercise sets into current workout

### DIFF
--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -25,6 +25,7 @@ interface ExerciseCardProps {
     onDeleteSet: (setId: number) => void;
     onSetTypeChange: (setId: number, type: string) => void;
     onAddSet: (workoutExerciseId: number) => void;
+    onCopyFromLast: (workoutExerciseId: number, templateId: number) => void;
     restTimerActive: boolean;
     restTimerElapsed: number;
     restTimerTarget: number;
@@ -35,7 +36,7 @@ interface ExerciseCardProps {
 export default function ExerciseCard({
     item, index, totalExercises, isFinished, lastWorkoutSets,
     onRemove, onMoveUp, onMoveDown, onNoteChange,
-    onConfirmSet, onDeleteSet, onSetTypeChange, onAddSet,
+    onConfirmSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExerciseCardProps) {
     const colors = useThemeColors();
@@ -181,6 +182,10 @@ export default function ExerciseCard({
                             label={item.workoutExercise.notes ? t("exercise.exerciseCard.editNote") : t("exercise.exerciseCard.addNote")}
                             icon="create-outline"
                             onPress={() => { setMenuOpen(false); setNoteDraft(item.workoutExercise.notes ?? ""); setNoteOpen(true); }} colors={colors} />
+                        {!isFinished && template && (
+                            <MenuItem label={t("exercise.exerciseCard.copyFromLast")} icon="copy-outline"
+                                onPress={() => { onCopyFromLast(item.workoutExercise.id, template.id); setMenuOpen(false); }} colors={colors} />
+                        )}
                         {!isFinished && (
                             <MenuItem label={t("exercise.exerciseCard.remove")} icon="trash-outline"
                                 onPress={handleRemove} colors={colors} destructive />

--- a/src/features/exercise/hooks/useWorkout.ts
+++ b/src/features/exercise/hooks/useWorkout.ts
@@ -28,7 +28,7 @@ export interface UseWorkoutReturn {
     updateTitle: (title: string) => void;
     updateStartTime: (epoch: number) => void;
     updateEndTime: (epoch: number) => void;
-    addExercise: (templateId: number) => void;
+    addExercise: (templateId: number) => number | undefined;
     removeExercise: (workoutExerciseId: number) => void;
     moveExercise: (workoutExerciseId: number, newOrder: number) => void;
     reload: () => void;
@@ -139,14 +139,15 @@ export function useWorkout({ workoutId, date }: UseWorkoutOptions = {}): UseWork
 
     const addExercise = useCallback(
         (templateId: number) => {
-            if (!data?.workout) return;
-            addExerciseToWorkout({
+            if (!data?.workout) return undefined;
+            const we = addExerciseToWorkout({
                 workout_id: data.workout.id,
                 exercise_template_id: templateId,
                 sort_order: data.exercises.length + 1,
             });
             const exercises = getExercisesForWorkout(data.workout.id);
             setData((prev) => (prev ? { ...prev, exercises } : null));
+            return we.id;
         },
         [data?.workout, data?.exercises.length],
     );

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -5,7 +5,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FlatList, StyleSheet, Text, View } from "react-native";
+import { FlatList, Alert, StyleSheet, Text, View } from "react-native";
 import AddExerciseModal from "../components/AddExerciseModal";
 import CopyWorkoutSheet from "../components/CopyWorkoutSheet";
 import ExerciseCard from "../components/ExerciseCard";
@@ -14,7 +14,7 @@ import WorkoutHeader from "../components/WorkoutHeader";
 import { useRestTimer } from "../hooks/useRestTimer";
 import { useWorkout } from "../hooks/useWorkout";
 import {
-    addSet, completeSet, deleteSet, getLastCompletedSetsForTemplate, updateSet,
+    addSet, completeSet, copySetsFromLastSession, deleteSet, getLastCompletedSetsForTemplate, updateSet,
     updateWorkoutExercise, type ExerciseSet, type ExerciseTemplate, type WorkoutExerciseWithSets,
 } from "../services/exerciseDb";
 
@@ -40,7 +40,9 @@ export default function WorkoutScreen() {
     const isEmpty = (workout.data?.exercises.length ?? 0) === 0;
 
     function handleExerciseSelected(template: ExerciseTemplate) {
-        workout.addExercise(template.id);
+        const weId = workout.addExercise(template.id);
+        if (weId) copySetsFromLastSession(template.id, weId);
+        workout.reload();
         setShowAddExercise(false);
     }
 
@@ -114,6 +116,14 @@ export default function WorkoutScreen() {
         workout.reload();
     }, [workout]);
 
+    const handleCopyFromLast = useCallback((workoutExerciseId: number, templateId: number) => {
+        const count = copySetsFromLastSession(templateId, workoutExerciseId);
+        if (count === 0) {
+            Alert.alert(t("exercise.exerciseCard.noHistory"));
+        }
+        workout.reload();
+    }, [workout, t]);
+
     /** Cache of last-workout sets per template. */
     const lastSetsCache = useMemo(() => {
         const cache = new Map<number, ExerciseSet[]>();
@@ -144,6 +154,7 @@ export default function WorkoutScreen() {
                 onDeleteSet={handleDeleteSet}
                 onSetTypeChange={handleSetTypeChange}
                 onAddSet={handleAddSet}
+                onCopyFromLast={handleCopyFromLast}
                 restTimerActive={timerActive}
                 restTimerElapsed={timerActive ? restTimer.elapsedSeconds : 0}
                 restTimerTarget={timerActive ? restTimer.targetSeconds : 0}

--- a/src/features/exercise/services/exerciseDb.ts
+++ b/src/features/exercise/services/exerciseDb.ts
@@ -349,6 +349,34 @@ export function getLastCompletedSetsForTemplate(templateId: number): ExerciseSet
     return exerciseDbSupport.listSetsForExercise(rows[0].weId).filter((s) => !!s.completed_at);
 }
 
+/** Copies sets from a historical template instance into a target workout_exercise as scheduled. */
+export function copySetsFromLastSession(templateId: number, targetWorkoutExerciseId: number): number {
+    const sourceSets = getLastCompletedSetsForTemplate(templateId);
+    if (sourceSets.length === 0) return 0;
+
+    const existing = exerciseDbSupport.listSetsForExercise(targetWorkoutExerciseId);
+    let order = existing.length + 1;
+
+    for (const s of sourceSets) {
+        db.insert(exerciseSets)
+            .values({
+                workout_exercise_id: targetWorkoutExerciseId,
+                set_order: order++,
+                type: s.type,
+                weight: s.weight,
+                weight_unit: s.weight_unit,
+                reps: s.reps,
+                duration_seconds: s.duration_seconds,
+                distance_meters: s.distance_meters,
+                rir: s.rir,
+                rest_seconds: s.rest_seconds,
+                is_scheduled: 1,
+            })
+            .run();
+    }
+    return sourceSets.length;
+}
+
 export function copyWorkoutAsScheduled(sourceWorkoutId: number, targetWorkoutId: number): void {
     const sourceExercises = listWorkoutExercisesForWorkout(sourceWorkoutId);
     const sourceWorkout = exerciseDbSupport.getWorkoutOrThrow(sourceWorkoutId);


### PR DESCRIPTION
Closes #203

## Summary
- **copySetsFromLastSession()** DB function: finds the most recent completed instance of an exercise template and copies its sets to a target workout_exercise with `is_scheduled = 1`
- **'Copy from last session'** overflow menu item on ExerciseCard (only shown for active workouts with a known template)
- **Auto-prefill on add**: When adding an exercise via AddExerciseModal, sets from the last session are automatically copied as scheduled
- **No-history feedback**: Alert shown when no previous session exists for the template
- **useWorkout.addExercise** now returns the created workout_exercise id for downstream use