### PR TITLE
fix: replace hardcoded English strings with i18n in exercise components

### DIFF
--- a/src/features/exercise/components/CopyWorkoutSheet.tsx
+++ b/src/features/exercise/components/CopyWorkoutSheet.tsx
@@ -47,8 +47,8 @@ export default function CopyWorkoutSheet({ visible, targetWorkoutId, onClose, on
 
     function formatDate(dateStr: string): string {
         const [y, m, d] = dateStr.split("-");
-        const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-        return `${months[Number(m) - 1]} ${Number(d)}`;
+        const dateObj = new Date(Number(y), Number(m) - 1, Number(d));
+        return dateObj.toLocaleDateString(undefined, { month: "short", day: "numeric" });
     }
 
     return (

--- a/src/features/exercise/components/WorkoutSummarySection.tsx
+++ b/src/features/exercise/components/WorkoutSummarySection.tsx
@@ -62,7 +62,7 @@ function WorkoutSummaryCard({ workout, exercises, onDelete }: WorkoutSummaryProp
             ))}
             {exercises.length > 5 && (
                 <Text style={styles.moreText}>
-                    +{exercises.length - 5} more
+                    {t("exercise.workoutSummary.moreExercises", { count: exercises.length - 5 })}
                 </Text>
             )}
         </Pressable>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -358,6 +358,7 @@ const de = {
             exercises: "{{count}} Übungen",
             deleteConfirm:
                 "Dieses Training und alle Daten löschen?",
+            moreExercises: "+{{count}} weitere",
         },
         workout: {
             title: "Training",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -356,6 +356,7 @@ const en = {
             duration: "{{minutes}} min",
             exercises: "{{count}} exercises",
             deleteConfirm: "Delete this workout and all its data?",
+            moreExercises: "+{{count}} more",
         },
         workout: {
             title: "Workout",


### PR DESCRIPTION
- `CopyWorkoutSheet`: use `Intl.DateTimeFormat` for locale-aware date formatting
- `WorkoutSummarySection`: wrap "+N more" text with `t()` translation key
- Add `moreExercises` key to both `en.ts` and `de.ts` locale files

Closes #231