### PR TITLE
feat: add back-navigation guard for in-progress workouts

### DIFF
--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -52,7 +52,28 @@ export default function WorkoutScreen() {
     }
 
     function handleBack() {
-        router.back();
+        const isInProgress = workout.data?.workout && !workout.data.workout.ended_at;
+        if (!isInProgress) {
+            router.back();
+            return;
+        }
+
+        Alert.alert(
+            t("exercise.workout.leaveTitle"),
+            t("exercise.workout.leaveMessage"),
+            [
+                { text: t("exercise.workout.leaveContinue"), style: "cancel" },
+                {
+                    text: t("exercise.workout.leaveFinish"),
+                    onPress: () => { workout.finishCurrentWorkout(); router.back(); },
+                },
+                {
+                    text: t("exercise.workout.leaveWithout"),
+                    style: "destructive",
+                    onPress: () => router.back(),
+                },
+            ],
+        );
     }
 
     function handleNoteChange(workoutExerciseId: number, note: string) {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -371,6 +371,11 @@ const de = {
             copyFromHistory: "Aus Verlauf starten",
             startedAt: "Gestartet um",
             endedAt: "Beendet um",
+            leaveTitle: "Training läuft",
+            leaveMessage: "Du hast ein aktives Training. Was möchtest du tun?",
+            leaveContinue: "Training fortsetzen",
+            leaveFinish: "Speichern & Beenden",
+            leaveWithout: "Ohne Beenden verlassen",
         },
         restTimer: {
             rest: "Pause",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -369,6 +369,11 @@ const en = {
             copyFromHistory: "Start from History",
             startedAt: "Started at",
             endedAt: "Ended at",
+            leaveTitle: "Workout in Progress",
+            leaveMessage: "You have an active workout. What would you like to do?",
+            leaveContinue: "Continue Workout",
+            leaveFinish: "Save & Finish",
+            leaveWithout: "Leave without Finishing",
         },
         restTimer: {
             rest: "Rest",


### PR DESCRIPTION
Shows a 3-option Alert when pressing back during an active workout:
- **Continue workout** — dismisses the alert
- **Save & finish** — finishes the workout and navigates back
- **Leave without finishing** — navigates back without saving

Adds i18n keys for both en and de locales.

Closes #233