### PR TITLE
feat: handle 'other' exercise type in UI components

### DIFF
--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -6,10 +6,9 @@ import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Modal, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
+import type { ExerciseType } from "../types";
 import RestTimer from "./RestTimer";
 import SetInputRow, { type SetValues } from "./SetInputRow";
-
-type ExerciseType = "weight" | "bodyweight" | "cardio";
 
 interface ExerciseCardProps {
     item: WorkoutExerciseWithSets;
@@ -49,8 +48,7 @@ export default function ExerciseCard({
 
     const template = item.exerciseTemplate;
     const name = template?.name ?? "?";
-    const exerciseType: ExerciseType = template?.type === "cardio" ? "cardio"
-        : template?.type === "bodyweight" ? "bodyweight" : "weight";
+    const exerciseType: ExerciseType = (template?.type as ExerciseType) ?? "weight";
 
     function handleRemove() {
         Alert.alert(

--- a/src/features/exercise/components/SetInputRow.tsx
+++ b/src/features/exercise/components/SetInputRow.tsx
@@ -6,8 +6,7 @@ import { useTranslation } from "react-i18next";
 import { Alert, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import { convertWeight } from "../helpers/exerciseUnits";
 import type { ExerciseSet } from "../services/exerciseDb";
-
-type ExerciseType = "weight" | "bodyweight" | "cardio";
+import type { ExerciseType } from "../types";
 
 const SET_TYPES = ["warmup", "working", "dropset", "failure"] as const;
 type SetType = (typeof SET_TYPES)[number];


### PR DESCRIPTION
Imports the canonical `ExerciseType` from `types.ts` instead of using local duplicate type definitions in `ExerciseCard` and `SetInputRow`. Removes the ternary mapping that coerced `"other"` → `"weight"`, so `"other"` exercises now render like bodyweight (reps + RIR, no weight column).

Closes #236