### PR TITLE
fix: use selected date when creating workout from Logs screen

### DIFF
--- a/src/features/exercise/components/WorkoutSummarySection.tsx
+++ b/src/features/exercise/components/WorkoutSummarySection.tsx
@@ -115,7 +115,7 @@ export default function WorkoutSummarySection({ date, refreshKey, onQuickAdd }: 
     }
 
     function handleStartWorkout() {
-        router.push("/workout");
+        router.push({ pathname: "/workout", params: { date } });
     }
 
     return (

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -1,5 +1,6 @@
 import Button from "@/src/shared/atoms/Button";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { parseDateKey } from "@/src/utils/date";
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -23,10 +24,11 @@ export default function WorkoutScreen() {
     const { t } = useTranslation();
     const styles = useMemo(() => createWorkoutScreenStyles(colors), [colors]);
     const router = useRouter();
-    const params = useLocalSearchParams<{ workoutId?: string }>();
+    const params = useLocalSearchParams<{ workoutId?: string; date?: string }>();
     const workoutId = params.workoutId ? Number(params.workoutId) : undefined;
+    const workoutDate = params.date ? parseDateKey(params.date) : undefined;
 
-    const workout = useWorkout({ workoutId });
+    const workout = useWorkout({ workoutId, date: workoutDate });
     const restTimer = useRestTimer();
     const [showAddExercise, setShowAddExercise] = useState(false);
     const [showCopySheet, setShowCopySheet] = useState(false);
@@ -34,9 +36,9 @@ export default function WorkoutScreen() {
     // Auto-start workout if none loaded (must run in effect, not during render)
     useEffect(() => {
         if (!workout.data && !workoutId && !workout.isResumed) {
-            workout.startWorkout();
+            workout.startWorkout(workoutDate);
         }
-    }, [workout.data, workoutId, workout.isResumed, workout.startWorkout]);
+    }, [workout.data, workoutId, workout.isResumed, workout.startWorkout, workoutDate]);
 
     const isFinished = !!workout.data?.workout.ended_at;
     const isEmpty = (workout.data?.exercises.length ?? 0) === 0;

--- a/src/features/log/hooks/useLogData.ts
+++ b/src/features/log/hooks/useLogData.ts
@@ -169,7 +169,7 @@ export function useLogData() {
     };
 
     const navigateToWorkout = () => {
-        router.push("/workout");
+        router.push({ pathname: "/workout", params: { date: formatDateKey(selectedDate) } });
     };
 
     function exitSelectionMode() { setSelectionMode(false); setSelectedEntryIds(new Set()); }


### PR DESCRIPTION
## Summary
Pass the currently selected date as a route param when navigating to WorkoutScreen from the Logs screen (FAB and WorkoutSummarySection header button). WorkoutScreen reads the param and passes it to `useWorkout` and `startWorkout` so the new workout is recorded against the correct date instead of always defaulting to today.

### Changes
- `useLogData.ts`: `navigateToWorkout` passes `date` param
- `WorkoutSummarySection.tsx`: `handleStartWorkout` passes `date` prop as param
- `WorkoutScreen.tsx`: parses `date` param via `parseDateKey`, passes to `useWorkout` and `startWorkout`

Resolves #248