### PR TITLE
fix: refresh WorkoutSummarySection when returning to Logs screen

### DIFF
--- a/src/features/log/hooks/useLogData.ts
+++ b/src/features/log/hooks/useLogData.ts
@@ -50,6 +50,7 @@ export function useLogData() {
     const [dayWeightLogs, setDayWeightLogs] = useState<WeightLog[]>([]);
     const [meanWeightKg, setMeanWeightKg] = useState<number | null>(null);
     const [weightDaysAgo, setWeightDaysAgo] = useState<number | null>(null);
+    const [workoutRefreshKey, setWorkoutRefreshKey] = useState(0);
 
     function loadAllDays(center: Date) {
         setGrouped(loadGrouped(center));
@@ -88,6 +89,7 @@ export function useLogData() {
     useFocusEffect(
         useCallback(() => {
             loadAllDays(selectedDate);
+            setWorkoutRefreshKey((k) => k + 1);
             return () => { setSelectionMode(false); setSelectedEntryIds(new Set()); };
         }, [selectedDate]),
     );
@@ -235,7 +237,7 @@ export function useLogData() {
         editingEntry, setEditingEntry, editingRecipeGroup, setEditingRecipeGroup,
         portionInput, setPortionInput,
         selectionMode, selectedEntryIds, moveModalVisible, setMoveModalVisible,
-        weightTrend, dayWeightLogs, meanWeightKg, weightDaysAgo,
+        weightTrend, dayWeightLogs, meanWeightKg, weightDaysAgo, workoutRefreshKey,
         handleScrollEnd, handleDelete, handleDeleteRecipeLog,
         handleConfirmEntry, handleConfirmRecipeLog,
         handleAddWeight, handleDeleteWeight,

--- a/src/features/log/screens/LogScreen.tsx
+++ b/src/features/log/screens/LogScreen.tsx
@@ -39,7 +39,7 @@ function DayPage({
     onConfirmEntry, onConfirmRecipeLog,
     selectionMode, selectedEntryIds, onToggleEntries, onActivateSelection, onActivateSelectionMultiple,
     meanWeightKg, weightTrend, weightDaysAgo, weightLogs, onAddWeight, onDeleteWeight,
-    dateKey, onQuickAdd,
+    dateKey, onQuickAdd, workoutRefreshKey,
 }: {
     grouped: Record<MealType, EntryWithFood[]>;
     goals: Goals;
@@ -63,6 +63,7 @@ function DayPage({
     onDeleteWeight?: (id: number) => void;
     dateKey?: string;
     onQuickAdd?: () => void;
+    workoutRefreshKey?: number;
 }) {
     const totals = computeTotals(grouped);
     return (
@@ -81,7 +82,7 @@ function DayPage({
                     />
                 ))}
                 <WeightSection weights={weightLogs ?? []} onAdd={onAddWeight ?? (() => { })} onDelete={onDeleteWeight ?? (() => { })} />
-                {dateKey && <WorkoutSummarySection date={dateKey} onQuickAdd={onQuickAdd} />}
+                {dateKey && <WorkoutSummarySection date={dateKey} onQuickAdd={onQuickAdd} refreshKey={workoutRefreshKey} />}
             </ScrollView>
         </View>
     );
@@ -121,7 +122,8 @@ export default function LogScreen() {
                     onDeleteRecipeLog={d.handleDeleteRecipeLog} onConfirmEntry={d.handleConfirmEntry}
                     onConfirmRecipeLog={d.handleConfirmRecipeLog}
                     meanWeightKg={d.meanWeightKg} weightTrend={d.weightTrend} weightDaysAgo={d.weightDaysAgo}
-                    dateKey={formatDateKey(shiftCalendarDate(d.selectedDate, -1))} />
+                    dateKey={formatDateKey(shiftCalendarDate(d.selectedDate, -1))}
+                    workoutRefreshKey={d.workoutRefreshKey} />
                 <DayPage grouped={d.grouped} goals={d.dailyGoals} onAdd={d.navigateToAdd}
                     onDelete={d.handleDelete} onEdit={d.handleEdit} onEditRecipeGroup={d.handleEditRecipeGroup}
                     onDeleteRecipeLog={d.handleDeleteRecipeLog} onConfirmEntry={d.handleConfirmEntry}
@@ -132,13 +134,15 @@ export default function LogScreen() {
                     meanWeightKg={d.meanWeightKg} weightTrend={d.weightTrend} weightDaysAgo={d.weightDaysAgo}
                     weightLogs={d.dayWeightLogs} onAddWeight={d.handleAddWeight} onDeleteWeight={d.handleDeleteWeight}
                     dateKey={formatDateKey(d.selectedDate)}
-                    onQuickAdd={() => setShowQuickExercise(true)} />
+                    onQuickAdd={() => setShowQuickExercise(true)}
+                    workoutRefreshKey={d.workoutRefreshKey} />
                 <DayPage grouped={d.nextGrouped} goals={d.dailyGoals} onAdd={d.navigateToAdd}
                     onDelete={d.handleDelete} onEdit={d.handleEdit} onEditRecipeGroup={d.handleEditRecipeGroup}
                     onDeleteRecipeLog={d.handleDeleteRecipeLog} onConfirmEntry={d.handleConfirmEntry}
                     onConfirmRecipeLog={d.handleConfirmRecipeLog}
                     meanWeightKg={d.meanWeightKg} weightTrend={d.weightTrend} weightDaysAgo={d.weightDaysAgo}
-                    dateKey={formatDateKey(shiftCalendarDate(d.selectedDate, +1))} />
+                    dateKey={formatDateKey(shiftCalendarDate(d.selectedDate, +1))}
+                    workoutRefreshKey={d.workoutRefreshKey} />
             </ScrollView>
 
             <EntryModal food={d.editingEntry?.foods ?? null} entry={d.editingEntry?.entries ?? null}


### PR DESCRIPTION
## Summary
Increment a `workoutRefreshKey` counter in the `useFocusEffect` inside `useLogData` so that every time the Logs screen regains focus (e.g. after finishing a workout) the `WorkoutSummarySection` re-fetches its data and shows the newly created workout immediately.

### Changes
- `useLogData.ts`: adds `workoutRefreshKey` state, incremented on focus; exposed in return value
- `LogScreen.tsx`: passes `workoutRefreshKey` through `DayPage` → `WorkoutSummarySection`

Resolves #249