### PR TITLE
enhance: show minute-accurate time in Workout header timer

### DIFF
--- a/src/features/exercise/components/WorkoutHeader.tsx
+++ b/src/features/exercise/components/WorkoutHeader.tsx
@@ -28,12 +28,13 @@ export default function WorkoutHeader({
     const [draft, setDraft] = useState(title);
 
     function formatElapsed(ms: number): string {
-        const totalSec = Math.floor(ms / 1000);
-        const h = Math.floor(totalSec / 3600);
-        const m = Math.floor((totalSec % 3600) / 60);
-        const s = totalSec % 60;
-        const pad = (n: number) => String(n).padStart(2, "0");
-        return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+        const totalMin = Math.floor(ms / 60000);
+        const h = Math.floor(totalMin / 60);
+        const m = totalMin % 60;
+        if (h > 0) {
+            return `${h}:${String(m).padStart(2, "0")}`;
+        }
+        return `${m} min`;
     }
 
     function handleFinish() {

--- a/src/features/exercise/hooks/useWorkout.ts
+++ b/src/features/exercise/hooks/useWorkout.ts
@@ -74,7 +74,7 @@ export function useWorkout({ workoutId, date }: UseWorkoutOptions = {}): UseWork
         if (data?.workout && !data.workout.ended_at) {
             const tick = () => setElapsedMs(Date.now() - data.workout.started_at);
             tick();
-            timerRef.current = setInterval(tick, 1000);
+            timerRef.current = setInterval(tick, 60000);
         } else {
             setElapsedMs(
                 data?.workout.ended_at && data?.workout.started_at


### PR DESCRIPTION
## Summary

Closes #254

The Workout screen header timer was showing seconds (e.g. `12:34`), which updated every second and caused unnecessary visual noise.

## Changes

### `WorkoutHeader.tsx` — `formatElapsed`
| Duration | Before | After |
|---|---|---|
| < 1 hour | `05:42` | `5 min` |
| ≥ 1 hour | `01:23:45` | `1:23` |

### `useWorkout.ts`
- Timer interval changed from **1 000 ms → 60 000 ms**: the display only needs to refresh once per minute, eliminating 59 unnecessary re-renders per minute.