### PR TITLE
feat: Focus-mode workout screen — expand one exercise at a time

### DIFF
--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -1,21 +1,21 @@
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { Ionicons } from "@expo/vector-icons";
-import { useRouter } from "expo-router";
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Alert, Pressable, Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
 import type { ExerciseType } from "../types";
-import { createExerciseCardStyles, getPrefillForSet, isActiveSet } from "./ExerciseCardHelpers";
-import { ExerciseCardMenu, ExerciseNoteModal } from "./ExerciseCardModals";
-import RestTimer from "./RestTimer";
-import SetInputRow, { type SetValues } from "./SetInputRow";
+import { bestSetSummary, createCollapsedCardStyles } from "./ExerciseCardHelpers";
+import { ExpandedExerciseCard } from "./ExpandedExerciseCard";
+import type { SetValues } from "./SetInputRow";
 
 interface ExerciseCardProps {
     item: WorkoutExerciseWithSets;
     index: number;
     totalExercises: number;
     isFinished: boolean;
+    isExpanded: boolean;
+    onExpand: () => void;
     lastWorkoutSets: ExerciseSet[];
     onRemove: (workoutExerciseId: number) => void;
     onMoveUp: (workoutExerciseId: number) => void;
@@ -34,172 +34,114 @@ interface ExerciseCardProps {
 }
 
 export default function ExerciseCard({
-    item, index, totalExercises, isFinished, lastWorkoutSets,
+    item, index, totalExercises, isFinished, isExpanded, onExpand, lastWorkoutSets,
     onRemove, onMoveUp, onMoveDown, onNoteChange,
     onConfirmSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExerciseCardProps) {
-    const colors = useThemeColors();
-    const { t } = useTranslation();
-    const styles = useMemo(() => createExerciseCardStyles(colors), [colors]);
-    const router = useRouter();
-    const [menuOpen, setMenuOpen] = useState(false);
-    const [noteOpen, setNoteOpen] = useState(false);
-    const [noteDraft, setNoteDraft] = useState(item.workoutExercise.notes ?? "");
-
     const template = item.exerciseTemplate;
     const name = template?.name ?? "?";
     const exerciseType: ExerciseType = (template?.type as ExerciseType) ?? "weight";
 
-    function handleRemove() {
-        Alert.alert(
-            t("exercise.exerciseCard.remove"),
-            t("exercise.exerciseCard.removeConfirm"),
-            [
-                { text: t("common.cancel"), style: "cancel" },
-                { text: t("common.delete"), style: "destructive", onPress: () => onRemove(item.workoutExercise.id) },
-            ],
+    const [menuOpen, setMenuOpen] = useState(false);
+    const [noteOpen, setNoteOpen] = useState(false);
+    const [noteDraft, setNoteDraft] = useState(item.workoutExercise.notes ?? "");
+
+    // Show collapsed card for non-expanded, non-finished exercises
+    if (!isExpanded && !isFinished) {
+        return (
+            <CollapsedExerciseCard
+                item={item}
+                index={index}
+                name={name}
+                onExpand={onExpand}
+            />
         );
-        setMenuOpen(false);
-    }
-
-    function handleHistory() {
-        if (template) {
-            router.push({
-                pathname: "/workout/exercise-history",
-                params: { templateId: String(template.id), name: template.name },
-            });
-        }
-    }
-
-    function handleSaveNote() {
-        onNoteChange(item.workoutExercise.id, noteDraft.trim());
-        setNoteOpen(false);
     }
 
     return (
-        <View style={styles.card}>
-            {/* Title row */}
-            <View style={styles.titleRow}>
-                <Text style={styles.orderNum}>{index + 1}.</Text>
-                <Text style={styles.exerciseName} numberOfLines={1}>{name}</Text>
-                <Pressable onPress={handleHistory} hitSlop={8}>
-                    <Ionicons name="bar-chart-outline" size={18} color={colors.textSecondary} />
-                </Pressable>
-                <Pressable onPress={() => setMenuOpen(true)} hitSlop={8}>
-                    <Ionicons name="ellipsis-vertical" size={18} color={colors.textSecondary} />
-                </Pressable>
-            </View>
+        <ExpandedExerciseCard
+            item={item}
+            index={index}
+            totalExercises={totalExercises}
+            isFinished={isFinished}
+            name={name}
+            exerciseType={exerciseType}
+            template={template}
+            lastWorkoutSets={lastWorkoutSets}
+            menuOpen={menuOpen}
+            setMenuOpen={setMenuOpen}
+            noteOpen={noteOpen}
+            setNoteOpen={setNoteOpen}
+            noteDraft={noteDraft}
+            setNoteDraft={setNoteDraft}
+            onRemove={onRemove}
+            onMoveUp={onMoveUp}
+            onMoveDown={onMoveDown}
+            onNoteChange={onNoteChange}
+            onConfirmSet={onConfirmSet}
+            onDeleteSet={onDeleteSet}
+            onSetTypeChange={onSetTypeChange}
+            onAddSet={onAddSet}
+            onCopyFromLast={onCopyFromLast}
+            restTimerActive={restTimerActive}
+            restTimerElapsed={restTimerElapsed}
+            restTimerTarget={restTimerTarget}
+            restTimerReached={restTimerReached}
+            onRestTimerSkip={onRestTimerSkip}
+        />
+    );
+}
 
-            {/* Note display */}
-            {item.workoutExercise.notes ? (
-                <Text style={styles.noteText} numberOfLines={2}>
-                    {item.workoutExercise.notes}
-                </Text>
+// ── Collapsed card ──────────────────────────────────────────────────────────
+
+interface CollapsedProps {
+    item: WorkoutExerciseWithSets;
+    index: number;
+    name: string;
+    onExpand: () => void;
+}
+
+function CollapsedExerciseCard({ item, index, name, onExpand }: CollapsedProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createCollapsedCardStyles(colors), [colors]);
+
+    const totalSets = item.sets.length;
+    const completedSets = item.sets.filter((s) => !!s.completed_at).length;
+    const isAllDone = totalSets > 0 && completedSets === totalSets;
+    const summary = bestSetSummary(item.sets);
+
+    function getProgressLabel(): string {
+        if (totalSets === 0) return t("exercise.exerciseCard.noSetsYet");
+        if (isAllDone) return t("exercise.exerciseCard.allSetsComplete", { total: totalSets });
+        return t("exercise.exerciseCard.setsProgress", { completed: completedSets, total: totalSets });
+    }
+
+    return (
+        <Pressable style={styles.card} onPress={onExpand}>
+            <Text style={styles.orderNum}>{index + 1}.</Text>
+            <Text style={styles.name} numberOfLines={1}>{name}</Text>
+
+            {summary ? (
+                <Text style={styles.bestSetText}>{summary}</Text>
             ) : null}
 
-            {/* Column headers */}
-            <View style={styles.headerRow}>
-                <Text style={[styles.headerCell, styles.setCol]}>{t("exercise.exerciseCard.set")}</Text>
-                {exerciseType === "weight" && (
-                    <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.weight")}</Text>
+            <View style={[styles.progressBadge, isAllDone && styles.progressBadgeComplete]}>
+                {isAllDone && (
+                    <Ionicons name="checkmark-circle" size={12} color={colors.success} />
                 )}
-                {exerciseType !== "cardio" && (
-                    <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.reps")}</Text>
-                )}
-                {exerciseType === "cardio" && (
-                    <>
-                        <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.duration")}</Text>
-                        <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.distance")}</Text>
-                    </>
-                )}
-                {exerciseType !== "cardio" && (
-                    <Text style={[styles.headerCell, styles.rirCol]}>{t("exercise.exerciseCard.rir")}</Text>
-                )}
-                <Text style={[styles.headerCell, styles.checkCol]}>✓</Text>
+                <Text style={[styles.progressText, isAllDone && styles.progressTextComplete]}>
+                    {getProgressLabel()}
+                </Text>
             </View>
 
-            {/* Set rows */}
-            {item.sets.map((set, si) => {
-                const prefill = getPrefillForSet(si, item.sets, lastWorkoutSets);
-                const isActive = isActiveSet(set, si, item.sets);
-                return (
-                    <React.Fragment key={set.id}>
-                        {/* Rest timer between last completed set and active input */}
-                        {isActive && restTimerActive && (
-                            <RestTimer
-                                elapsedSeconds={restTimerElapsed}
-                                targetSeconds={restTimerTarget}
-                                isTargetReached={restTimerReached}
-                                onSkip={onRestTimerSkip}
-                            />
-                        )}
-                        <SetInputRow
-                            set={set}
-                            index={si}
-                            exerciseType={exerciseType}
-                            isActive={isActive}
-                            isFinished={isFinished}
-                            prefillWeight={prefill.weight}
-                            prefillReps={prefill.reps}
-                            prefillRir={prefill.rir}
-                            prefillDuration={prefill.duration}
-                            prefillDistance={prefill.distance}
-                            onConfirm={onConfirmSet}
-                            onDelete={onDeleteSet}
-                            onTypeChange={onSetTypeChange}
-                        />
-                    </React.Fragment>
-                );
-            })}
-
-            {/* Empty state */}
-            {item.sets.length === 0 && (
-                <Text style={styles.emptyText}>{t("exercise.workout.emptyState")}</Text>
-            )}
-
-            {/* + Add Set button */}
-            {!isFinished && (
-                <Pressable style={styles.addSetBtn} onPress={() => onAddSet(item.workoutExercise.id)}>
-                    <Text style={styles.addSetText}>{t("exercise.exerciseCard.addSet")}</Text>
-                </Pressable>
-            )}
-
-            <ExerciseCardMenu
-                visible={menuOpen}
-                onClose={() => setMenuOpen(false)}
-                index={index}
-                totalExercises={totalExercises}
-                isFinished={isFinished}
-                hasNote={!!item.workoutExercise.notes}
-                hasTemplate={!!template}
-                onMoveUp={() => { onMoveUp(item.workoutExercise.id); setMenuOpen(false); }}
-                onMoveDown={() => { onMoveDown(item.workoutExercise.id); setMenuOpen(false); }}
-                onEditNote={() => { setMenuOpen(false); setNoteDraft(item.workoutExercise.notes ?? ""); setNoteOpen(true); }}
-                onCopyFromLast={() => { onCopyFromLast(item.workoutExercise.id, template!.id); setMenuOpen(false); }}
-                onRemove={handleRemove}
-                labels={{
-                    moveUp: t("exercise.exerciseCard.moveUp"),
-                    moveDown: t("exercise.exerciseCard.moveDown"),
-                    editNote: t("exercise.exerciseCard.editNote"),
-                    addNote: t("exercise.exerciseCard.addNote"),
-                    copyFromLast: t("exercise.exerciseCard.copyFromLast"),
-                    remove: t("exercise.exerciseCard.remove"),
-                }}
+            <Ionicons
+                name="chevron-forward"
+                size={16}
+                color={colors.textTertiary}
+                style={styles.chevron}
             />
-
-            <ExerciseNoteModal
-                visible={noteOpen}
-                onClose={() => setNoteOpen(false)}
-                value={noteDraft}
-                onChangeText={setNoteDraft}
-                onSave={handleSaveNote}
-                labels={{
-                    title: t("exercise.exerciseCard.note"),
-                    placeholder: t("exercise.exerciseCard.notePlaceholder"),
-                    save: t("common.save"),
-                }}
-            />
-        </View>
+        </Pressable>
     );
 }

--- a/src/features/exercise/components/ExerciseCardHelpers.ts
+++ b/src/features/exercise/components/ExerciseCardHelpers.ts
@@ -40,6 +40,26 @@ export function getPrefillForSet(index: number, sets: ExerciseSet[], lastWorkout
     return { weight: null, reps: null, rir: null, duration: null, distance: null };
 }
 
+/** Build a compact summary string for a set list, e.g. "80kg × 8" for the best completed set. */
+export function bestSetSummary(sets: ExerciseSet[]): string {
+    const completed = sets.filter((s) => !!s.completed_at);
+    if (completed.length === 0) return "";
+    // Pick the set with the highest weight (or most reps for bodyweight)
+    const best = completed.reduce((a, b) => {
+        const aScore = (a.weight ?? 0) * 1000 + (a.reps ?? 0);
+        const bScore = (b.weight ?? 0) * 1000 + (b.reps ?? 0);
+        return bScore > aScore ? b : a;
+    });
+    if (best.weight != null && best.reps != null) {
+        return `${best.weight}${best.weight_unit ?? "kg"} × ${best.reps}`;
+    }
+    if (best.reps != null) return `× ${best.reps}`;
+    if (best.duration_seconds != null) return `${best.duration_seconds}s`;
+    return "";
+}
+
+// ── Expanded card styles ────────────────────────────────────────────────────
+
 export function createExerciseCardStyles(colors: ThemeColors) {
     return StyleSheet.create({
         card: {
@@ -47,6 +67,8 @@ export function createExerciseCardStyles(colors: ThemeColors) {
             borderRadius: borderRadius.lg,
             padding: spacing.md,
             marginBottom: spacing.md,
+            borderWidth: 2,
+            borderColor: colors.primary,
         },
         titleRow: {
             flexDirection: "row",
@@ -55,13 +77,13 @@ export function createExerciseCardStyles(colors: ThemeColors) {
             marginBottom: spacing.sm,
         },
         orderNum: {
-            fontSize: fontSize.sm,
-            fontWeight: "700",
-            color: colors.textSecondary,
+            fontSize: fontSize.md,
+            fontWeight: "800",
+            color: colors.primary,
         },
         exerciseName: {
             flex: 1,
-            fontSize: fontSize.sm,
+            fontSize: fontSize.md,
             fontWeight: "600",
             color: colors.text,
         },
@@ -103,6 +125,63 @@ export function createExerciseCardStyles(colors: ThemeColors) {
             fontSize: fontSize.sm,
             fontWeight: "600",
             color: colors.primary,
+        },
+    });
+}
+
+// ── Collapsed card styles ───────────────────────────────────────────────────
+
+export function createCollapsedCardStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        card: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            paddingVertical: spacing.sm + 2,
+            paddingHorizontal: spacing.md,
+            marginBottom: spacing.sm,
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+        },
+        orderNum: {
+            fontSize: fontSize.sm,
+            fontWeight: "700",
+            color: colors.textTertiary,
+            width: 22,
+        },
+        name: {
+            flex: 1,
+            fontSize: fontSize.sm,
+            fontWeight: "500",
+            color: colors.text,
+        },
+        progressBadge: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 4,
+            backgroundColor: colors.primaryLight,
+            paddingHorizontal: spacing.sm,
+            paddingVertical: 3,
+            borderRadius: borderRadius.sm,
+        },
+        progressBadgeComplete: {
+            backgroundColor: colors.success + "22",
+        },
+        progressText: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: colors.primary,
+        },
+        progressTextComplete: {
+            color: colors.success,
+        },
+        bestSetText: {
+            fontSize: fontSize.xs,
+            color: colors.textSecondary,
+            fontWeight: "500",
+        },
+        chevron: {
+            marginLeft: 2,
         },
     });
 }

--- a/src/features/exercise/components/ExpandedExerciseCard.tsx
+++ b/src/features/exercise/components/ExpandedExerciseCard.tsx
@@ -1,0 +1,208 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, Pressable, Text, View } from "react-native";
+import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
+import type { ExerciseType } from "../types";
+import { createExerciseCardStyles, getPrefillForSet, isActiveSet } from "./ExerciseCardHelpers";
+import { ExerciseCardMenu, ExerciseNoteModal } from "./ExerciseCardModals";
+import RestTimer from "./RestTimer";
+import SetInputRow, { type SetValues } from "./SetInputRow";
+
+interface ExpandedExerciseCardProps {
+    item: WorkoutExerciseWithSets;
+    index: number;
+    totalExercises: number;
+    isFinished: boolean;
+    name: string;
+    exerciseType: ExerciseType;
+    template: WorkoutExerciseWithSets["exerciseTemplate"];
+    lastWorkoutSets: ExerciseSet[];
+    menuOpen: boolean;
+    setMenuOpen: (v: boolean) => void;
+    noteOpen: boolean;
+    setNoteOpen: (v: boolean) => void;
+    noteDraft: string;
+    setNoteDraft: (v: string) => void;
+    onRemove: (workoutExerciseId: number) => void;
+    onMoveUp: (workoutExerciseId: number) => void;
+    onMoveDown: (workoutExerciseId: number) => void;
+    onNoteChange: (workoutExerciseId: number, note: string) => void;
+    onConfirmSet: (setId: number, values: SetValues) => void;
+    onDeleteSet: (setId: number) => void;
+    onSetTypeChange: (setId: number, type: string) => void;
+    onAddSet: (workoutExerciseId: number) => void;
+    onCopyFromLast: (workoutExerciseId: number, templateId: number) => void;
+    restTimerActive: boolean;
+    restTimerElapsed: number;
+    restTimerTarget: number;
+    restTimerReached: boolean;
+    onRestTimerSkip: () => void;
+}
+
+export function ExpandedExerciseCard({
+    item, index, totalExercises, isFinished, name, exerciseType, template,
+    lastWorkoutSets,
+    menuOpen, setMenuOpen, noteOpen, setNoteOpen, noteDraft, setNoteDraft,
+    onRemove, onMoveUp, onMoveDown, onNoteChange,
+    onConfirmSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
+    restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
+}: ExpandedExerciseCardProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createExerciseCardStyles(colors), [colors]);
+    const router = useRouter();
+
+    function handleRemove() {
+        Alert.alert(
+            t("exercise.exerciseCard.remove"),
+            t("exercise.exerciseCard.removeConfirm"),
+            [
+                { text: t("common.cancel"), style: "cancel" },
+                { text: t("common.delete"), style: "destructive", onPress: () => onRemove(item.workoutExercise.id) },
+            ],
+        );
+        setMenuOpen(false);
+    }
+
+    function handleHistory() {
+        if (template) {
+            router.push({
+                pathname: "/workout/exercise-history",
+                params: { templateId: String(template.id), name: template.name },
+            });
+        }
+    }
+
+    function handleSaveNote() {
+        onNoteChange(item.workoutExercise.id, noteDraft.trim());
+        setNoteOpen(false);
+    }
+
+    return (
+        <View style={styles.card}>
+            {/* Title row */}
+            <View style={styles.titleRow}>
+                <Text style={styles.orderNum}>{index + 1}.</Text>
+                <Text style={styles.exerciseName} numberOfLines={1}>{name}</Text>
+                <Pressable onPress={handleHistory} hitSlop={8}>
+                    <Ionicons name="bar-chart-outline" size={18} color={colors.textSecondary} />
+                </Pressable>
+                <Pressable onPress={() => setMenuOpen(true)} hitSlop={8}>
+                    <Ionicons name="ellipsis-vertical" size={18} color={colors.textSecondary} />
+                </Pressable>
+            </View>
+
+            {/* Note display */}
+            {item.workoutExercise.notes ? (
+                <Text style={styles.noteText} numberOfLines={2}>
+                    {item.workoutExercise.notes}
+                </Text>
+            ) : null}
+
+            {/* Column headers */}
+            <View style={styles.headerRow}>
+                <Text style={[styles.headerCell, styles.setCol]}>{t("exercise.exerciseCard.set")}</Text>
+                {exerciseType === "weight" && (
+                    <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.weight")}</Text>
+                )}
+                {exerciseType !== "cardio" && (
+                    <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.reps")}</Text>
+                )}
+                {exerciseType === "cardio" && (
+                    <>
+                        <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.duration")}</Text>
+                        <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.distance")}</Text>
+                    </>
+                )}
+                {exerciseType !== "cardio" && (
+                    <Text style={[styles.headerCell, styles.rirCol]}>{t("exercise.exerciseCard.rir")}</Text>
+                )}
+                <Text style={[styles.headerCell, styles.checkCol]}>✓</Text>
+            </View>
+
+            {/* Set rows */}
+            {item.sets.map((set, si) => {
+                const prefill = getPrefillForSet(si, item.sets, lastWorkoutSets);
+                const isActive = isActiveSet(set, si, item.sets);
+                return (
+                    <React.Fragment key={set.id}>
+                        {isActive && restTimerActive && (
+                            <RestTimer
+                                elapsedSeconds={restTimerElapsed}
+                                targetSeconds={restTimerTarget}
+                                isTargetReached={restTimerReached}
+                                onSkip={onRestTimerSkip}
+                            />
+                        )}
+                        <SetInputRow
+                            set={set}
+                            index={si}
+                            exerciseType={exerciseType}
+                            isActive={isActive}
+                            isFinished={isFinished}
+                            prefillWeight={prefill.weight}
+                            prefillReps={prefill.reps}
+                            prefillRir={prefill.rir}
+                            prefillDuration={prefill.duration}
+                            prefillDistance={prefill.distance}
+                            onConfirm={onConfirmSet}
+                            onDelete={onDeleteSet}
+                            onTypeChange={onSetTypeChange}
+                        />
+                    </React.Fragment>
+                );
+            })}
+
+            {/* Empty state */}
+            {item.sets.length === 0 && (
+                <Text style={styles.emptyText}>{t("exercise.workout.emptyState")}</Text>
+            )}
+
+            {/* + Add Set button */}
+            {!isFinished && (
+                <Pressable style={styles.addSetBtn} onPress={() => onAddSet(item.workoutExercise.id)}>
+                    <Text style={styles.addSetText}>{t("exercise.exerciseCard.addSet")}</Text>
+                </Pressable>
+            )}
+
+            <ExerciseCardMenu
+                visible={menuOpen}
+                onClose={() => setMenuOpen(false)}
+                index={index}
+                totalExercises={totalExercises}
+                isFinished={isFinished}
+                hasNote={!!item.workoutExercise.notes}
+                hasTemplate={!!template}
+                onMoveUp={() => { onMoveUp(item.workoutExercise.id); setMenuOpen(false); }}
+                onMoveDown={() => { onMoveDown(item.workoutExercise.id); setMenuOpen(false); }}
+                onEditNote={() => { setMenuOpen(false); setNoteDraft(item.workoutExercise.notes ?? ""); setNoteOpen(true); }}
+                onCopyFromLast={() => { onCopyFromLast(item.workoutExercise.id, template!.id); setMenuOpen(false); }}
+                onRemove={handleRemove}
+                labels={{
+                    moveUp: t("exercise.exerciseCard.moveUp"),
+                    moveDown: t("exercise.exerciseCard.moveDown"),
+                    editNote: t("exercise.exerciseCard.editNote"),
+                    addNote: t("exercise.exerciseCard.addNote"),
+                    copyFromLast: t("exercise.exerciseCard.copyFromLast"),
+                    remove: t("exercise.exerciseCard.remove"),
+                }}
+            />
+
+            <ExerciseNoteModal
+                visible={noteOpen}
+                onClose={() => setNoteOpen(false)}
+                value={noteDraft}
+                onChangeText={setNoteDraft}
+                onSave={handleSaveNote}
+                labels={{
+                    title: t("exercise.exerciseCard.note"),
+                    placeholder: t("exercise.exerciseCard.notePlaceholder"),
+                    save: t("common.save"),
+                }}
+            />
+        </View>
+    );
+}

--- a/src/features/exercise/components/SetInputHelpers.tsx
+++ b/src/features/exercise/components/SetInputHelpers.tsx
@@ -52,7 +52,7 @@ export function createSetInputStyles(colors: ThemeColors) {
         activeRow: {
             backgroundColor: colors.surfaceVariant ?? colors.background,
             borderRadius: borderRadius.sm,
-            marginHorizontal: -spacing.xs,
+            marginHorizontal: -(spacing.xs - 2),
             paddingHorizontal: spacing.xs,
         },
         setRowScheduled: {

--- a/src/features/exercise/components/SetInputRow.tsx
+++ b/src/features/exercise/components/SetInputRow.tsx
@@ -31,15 +31,7 @@ interface SetInputRowProps {
     onTypeChange: (id: number, type: string) => void;
 }
 
-export interface SetValues {
-    weight: number | null;
-    weight_unit: string;
-    reps: number | null;
-    rir: number | null;
-    duration_seconds: number | null;
-    distance_meters: number | null;
-    type: string;
-}
+export type { SetValues } from "../types";
 
 export default function SetInputRow({
     set, index, exerciseType, isActive, isFinished,

--- a/src/features/exercise/hooks/useWorkoutActions.ts
+++ b/src/features/exercise/hooks/useWorkoutActions.ts
@@ -1,0 +1,99 @@
+import { useCallback, useMemo } from "react";
+import { Alert } from "react-native";
+import { useTranslation } from "react-i18next";
+import type { SetValues } from "../types";
+import type { UseRestTimerReturn } from "./useRestTimer";
+import type { UseWorkoutReturn } from "./useWorkout";
+import {
+    addSet, completeSet, copySetsFromLastSession, deleteSet,
+    getLastCompletedSetsForTemplate, updateSet,
+    updateWorkoutExercise, type ExerciseSet,
+} from "../services/exerciseDb";
+
+export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestTimerReturn) {
+    const { t } = useTranslation();
+
+    const handleNoteChange = useCallback((workoutExerciseId: number, note: string) => {
+        updateWorkoutExercise(workoutExerciseId, { notes: note || null });
+        workout.reload();
+    }, [workout]);
+
+    const handleMoveUp = useCallback((workoutExerciseId: number) => {
+        const exercises = workout.data?.exercises ?? [];
+        const idx = exercises.findIndex((e) => e.workoutExercise.id === workoutExerciseId);
+        if (idx > 0) workout.moveExercise(workoutExerciseId, idx);
+    }, [workout]);
+
+    const handleMoveDown = useCallback((workoutExerciseId: number) => {
+        const exercises = workout.data?.exercises ?? [];
+        const idx = exercises.findIndex((e) => e.workoutExercise.id === workoutExerciseId);
+        if (idx < exercises.length - 1) workout.moveExercise(workoutExerciseId, idx + 2);
+    }, [workout]);
+
+    const handleConfirmSet = useCallback((setId: number, values: SetValues) => {
+        updateSet(setId, {
+            weight: values.weight,
+            weight_unit: values.weight_unit,
+            reps: values.reps,
+            rir: values.rir,
+            duration_seconds: values.duration_seconds,
+            distance_meters: values.distance_meters,
+            type: values.type,
+        });
+        completeSet(setId);
+
+        for (const ex of workout.data?.exercises ?? []) {
+            if (ex.sets.some((s) => s.id === setId)) {
+                restTimer.start(ex.workoutExercise.id, values.type);
+                break;
+            }
+        }
+        workout.reload();
+    }, [workout, restTimer]);
+
+    const handleDeleteSet = useCallback((setId: number) => {
+        deleteSet(setId);
+        workout.reload();
+    }, [workout]);
+
+    const handleSetTypeChange = useCallback((setId: number, type: string) => {
+        updateSet(setId, { type });
+        workout.reload();
+    }, [workout]);
+
+    const handleAddSet = useCallback((workoutExerciseId: number) => {
+        const ex = workout.data?.exercises.find((e) => e.workoutExercise.id === workoutExerciseId);
+        const defaultUnit = ex?.exerciseTemplate?.default_weight_unit ?? "kg";
+        addSet({ workout_exercise_id: workoutExerciseId, weight_unit: defaultUnit });
+        workout.reload();
+    }, [workout]);
+
+    const handleCopyFromLast = useCallback((workoutExerciseId: number, templateId: number) => {
+        const count = copySetsFromLastSession(templateId, workoutExerciseId);
+        if (count === 0) Alert.alert(t("exercise.exerciseCard.noHistory"));
+        workout.reload();
+    }, [workout, t]);
+
+    const lastSetsCache = useMemo(() => {
+        const cache = new Map<number, ExerciseSet[]>();
+        for (const ex of workout.data?.exercises ?? []) {
+            const tid = ex.workoutExercise.exercise_template_id;
+            if (tid && !cache.has(tid)) {
+                cache.set(tid, getLastCompletedSetsForTemplate(tid));
+            }
+        }
+        return cache;
+    }, [workout.data?.exercises]);
+
+    return {
+        handleNoteChange,
+        handleMoveUp,
+        handleMoveDown,
+        handleConfirmSet,
+        handleDeleteSet,
+        handleSetTypeChange,
+        handleAddSet,
+        handleCopyFromLast,
+        lastSetsCache,
+    };
+}

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -3,21 +3,24 @@ import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { parseDateKey } from "@/src/utils/date";
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FlatList, Alert, Text, View } from "react-native";
+import { FlatList, Alert, LayoutAnimation, Platform, Text, UIManager, View } from "react-native";
 import AddExerciseModal from "../components/AddExerciseModal";
 import CopyWorkoutSheet from "../components/CopyWorkoutSheet";
 import ExerciseCard from "../components/ExerciseCard";
-import type { SetValues } from "../components/SetInputRow";
 import WorkoutHeader from "../components/WorkoutHeader";
 import { useRestTimer } from "../hooks/useRestTimer";
 import { useWorkout } from "../hooks/useWorkout";
+import { useWorkoutActions } from "../hooks/useWorkoutActions";
 import { createWorkoutScreenStyles } from "./WorkoutScreenStyles";
 import {
-    addSet, completeSet, copySetsFromLastSession, deleteSet, getLastCompletedSetsForTemplate, updateSet,
-    updateWorkoutExercise, type ExerciseSet, type ExerciseTemplate, type WorkoutExerciseWithSets,
+    copySetsFromLastSession, type ExerciseTemplate, type WorkoutExerciseWithSets,
 } from "../services/exerciseDb";
+
+if (Platform.OS === "android" && UIManager.setLayoutAnimationEnabledExperimental) {
+    UIManager.setLayoutAnimationEnabledExperimental(true);
+}
 
 export default function WorkoutScreen() {
     const colors = useThemeColors();
@@ -30,22 +33,46 @@ export default function WorkoutScreen() {
 
     const workout = useWorkout({ workoutId, date: workoutDate });
     const restTimer = useRestTimer();
+    const actions = useWorkoutActions(workout, restTimer);
     const [showAddExercise, setShowAddExercise] = useState(false);
     const [showCopySheet, setShowCopySheet] = useState(false);
 
-    // Auto-start workout if none loaded (must run in effect, not during render)
+    // Focus state: which exercise is expanded (null = none)
+    const [expandedId, setExpandedId] = useState<number | null>(null);
+    const flatListRef = useRef<FlatList>(null);
+
     useEffect(() => {
         if (!workout.data && !workoutId && !workout.isResumed) {
             workout.startWorkout(workoutDate);
         }
     }, [workout.data, workoutId, workout.isResumed, workout.startWorkout, workoutDate]);
 
+    // Auto-expand the first exercise when data loads
+    useEffect(() => {
+        const exercises = workout.data?.exercises ?? [];
+        if (exercises.length > 0 && expandedId === null) {
+            setExpandedId(exercises[0].workoutExercise.id);
+        }
+    }, [workout.data?.exercises, expandedId]);
+
     const isFinished = !!workout.data?.workout.ended_at;
     const isEmpty = (workout.data?.exercises.length ?? 0) === 0;
 
+    const handleExpand = useCallback((weId: number, index: number) => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        setExpandedId(weId);
+        setTimeout(() => {
+            flatListRef.current?.scrollToIndex({ index, animated: true, viewOffset: 8 });
+        }, 100);
+    }, []);
+
     function handleExerciseSelected(template: ExerciseTemplate) {
         const weId = workout.addExercise(template.id);
-        if (weId) copySetsFromLastSession(template.id, weId);
+        if (weId) {
+            copySetsFromLastSession(template.id, weId);
+            LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+            setExpandedId(weId);
+        }
         workout.reload();
         setShowAddExercise(false);
     }
@@ -57,129 +84,41 @@ export default function WorkoutScreen() {
 
     function handleBack() {
         const isInProgress = workout.data?.workout && !workout.data.workout.ended_at;
-        if (!isInProgress) {
-            router.back();
-            return;
-        }
+        if (!isInProgress) { router.back(); return; }
 
         Alert.alert(
             t("exercise.workout.leaveTitle"),
             t("exercise.workout.leaveMessage"),
             [
                 { text: t("exercise.workout.leaveContinue"), style: "cancel" },
-                {
-                    text: t("exercise.workout.leaveFinish"),
-                    onPress: () => { workout.finishCurrentWorkout(); router.back(); },
-                },
-                {
-                    text: t("exercise.workout.leaveWithout"),
-                    style: "destructive",
-                    onPress: () => router.back(),
-                },
+                { text: t("exercise.workout.leaveFinish"), onPress: () => { workout.finishCurrentWorkout(); router.back(); } },
+                { text: t("exercise.workout.leaveWithout"), style: "destructive", onPress: () => router.back() },
             ],
         );
     }
 
-    function handleNoteChange(workoutExerciseId: number, note: string) {
-        updateWorkoutExercise(workoutExerciseId, { notes: note || null });
-        workout.reload();
-    }
-
-    function handleMoveUp(workoutExerciseId: number) {
-        const exercises = workout.data?.exercises ?? [];
-        const idx = exercises.findIndex((e) => e.workoutExercise.id === workoutExerciseId);
-        if (idx > 0) {
-            workout.moveExercise(workoutExerciseId, idx);
-        }
-    }
-
-    function handleMoveDown(workoutExerciseId: number) {
-        const exercises = workout.data?.exercises ?? [];
-        const idx = exercises.findIndex((e) => e.workoutExercise.id === workoutExerciseId);
-        if (idx < exercises.length - 1) {
-            workout.moveExercise(workoutExerciseId, idx + 2);
-        }
-    }
-
-    const handleConfirmSet = useCallback((setId: number, values: SetValues) => {
-        updateSet(setId, {
-            weight: values.weight,
-            weight_unit: values.weight_unit,
-            reps: values.reps,
-            rir: values.rir,
-            duration_seconds: values.duration_seconds,
-            distance_meters: values.distance_meters,
-            type: values.type,
-        });
-        completeSet(setId);
-
-        // Find which workout exercise this set belongs to & start rest timer
-        for (const ex of workout.data?.exercises ?? []) {
-            if (ex.sets.some((s) => s.id === setId)) {
-                restTimer.start(ex.workoutExercise.id, values.type);
-                break;
-            }
-        }
-
-        workout.reload();
-    }, [workout, restTimer]);
-
-    const handleDeleteSet = useCallback((setId: number) => {
-        deleteSet(setId);
-        workout.reload();
-    }, [workout]);
-
-    const handleSetTypeChange = useCallback((setId: number, type: string) => {
-        updateSet(setId, { type });
-        workout.reload();
-    }, [workout]);
-
-    const handleAddSet = useCallback((workoutExerciseId: number) => {
-        const ex = workout.data?.exercises.find((e) => e.workoutExercise.id === workoutExerciseId);
-        const defaultUnit = ex?.exerciseTemplate?.default_weight_unit ?? "kg";
-        addSet({ workout_exercise_id: workoutExerciseId, weight_unit: defaultUnit });
-        workout.reload();
-    }, [workout]);
-
-    const handleCopyFromLast = useCallback((workoutExerciseId: number, templateId: number) => {
-        const count = copySetsFromLastSession(templateId, workoutExerciseId);
-        if (count === 0) {
-            Alert.alert(t("exercise.exerciseCard.noHistory"));
-        }
-        workout.reload();
-    }, [workout, t]);
-
-    /** Cache of last-workout sets per template. */
-    const lastSetsCache = useMemo(() => {
-        const cache = new Map<number, ExerciseSet[]>();
-        for (const ex of workout.data?.exercises ?? []) {
-            const tid = ex.workoutExercise.exercise_template_id;
-            if (tid && !cache.has(tid)) {
-                cache.set(tid, getLastCompletedSetsForTemplate(tid));
-            }
-        }
-        return cache;
-    }, [workout.data?.exercises]);
-
     function renderExercise({ item, index }: { item: WorkoutExerciseWithSets; index: number }) {
         const tid = item.workoutExercise.exercise_template_id;
         const timerActive = restTimer.isRunning && restTimer.workoutExerciseId === item.workoutExercise.id;
+        const isExpanded = isFinished || expandedId === item.workoutExercise.id;
         return (
             <ExerciseCard
                 item={item}
                 index={index}
                 totalExercises={workout.data?.exercises.length ?? 0}
                 isFinished={isFinished}
-                lastWorkoutSets={tid ? (lastSetsCache.get(tid) ?? []) : []}
+                isExpanded={isExpanded}
+                onExpand={() => handleExpand(item.workoutExercise.id, index)}
+                lastWorkoutSets={tid ? (actions.lastSetsCache.get(tid) ?? []) : []}
                 onRemove={workout.removeExercise}
-                onMoveUp={handleMoveUp}
-                onMoveDown={handleMoveDown}
-                onNoteChange={handleNoteChange}
-                onConfirmSet={handleConfirmSet}
-                onDeleteSet={handleDeleteSet}
-                onSetTypeChange={handleSetTypeChange}
-                onAddSet={handleAddSet}
-                onCopyFromLast={handleCopyFromLast}
+                onMoveUp={actions.handleMoveUp}
+                onMoveDown={actions.handleMoveDown}
+                onNoteChange={actions.handleNoteChange}
+                onConfirmSet={actions.handleConfirmSet}
+                onDeleteSet={actions.handleDeleteSet}
+                onSetTypeChange={actions.handleSetTypeChange}
+                onAddSet={actions.handleAddSet}
+                onCopyFromLast={actions.handleCopyFromLast}
                 restTimerActive={timerActive}
                 restTimerElapsed={timerActive ? restTimer.elapsedSeconds : 0}
                 restTimerTarget={timerActive ? restTimer.targetSeconds : 0}
@@ -204,6 +143,7 @@ export default function WorkoutScreen() {
             />
 
             <FlatList
+                ref={flatListRef}
                 data={workout.data?.exercises ?? []}
                 keyExtractor={(item) => String(item.workoutExercise.id)}
                 renderItem={renderExercise}

--- a/src/features/exercise/types.ts
+++ b/src/features/exercise/types.ts
@@ -6,3 +6,15 @@ export type Equipment = "barbell" | "dumbbell" | "machine" | "cable" | "bodyweig
 export type ResistanceMode = "resistance" | "assistance";
 export type SetType = "warmup" | "working" | "dropset" | "failure";
 export type WeightUnit = "kg" | "lb";
+
+// ── Set input values (shared between components and hooks) ──────────────────
+
+export interface SetValues {
+    weight: number | null;
+    weight_unit: string;
+    reps: number | null;
+    rir: number | null;
+    duration_seconds: number | null;
+    distance_meters: number | null;
+    type: string;
+}

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -328,6 +328,9 @@ const de = {
             notePlaceholder: "Übungsnotizen…",
             deleteSet: "Satz löschen",
             deleteSetConfirm: "Diesen Satz löschen?",
+            setsProgress: "{{completed}}/{{total}} Sätze",
+            allSetsComplete: "Alle {{total}} Sätze fertig",
+            noSetsYet: "Noch keine Sätze",
         },
         addExercise: {
             title: "Übung hinzufügen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -327,6 +327,9 @@ const en = {
             notePlaceholder: "Exercise notes…",
             deleteSet: "Delete Set",
             deleteSetConfirm: "Delete this set?",
+            setsProgress: "{{completed}}/{{total}} sets",
+            allSetsComplete: "All {{total}} sets done",
+            noSetsYet: "No sets yet",
         },
         addExercise: {
             title: "Add Exercise",


### PR DESCRIPTION
## Summary

Redesign the Workout screen so only the active exercise is expanded while others collapse into compact single-row summaries.

### Changes
- **Focus mode**: Tap an exercise to expand it; others collapse into a compact row showing name, set progress (e.g. "2/4 sets"), and best set summary
- **ExpandedExerciseCard**: Extracted from ExerciseCard for file-size compliance
- **useWorkoutActions hook**: Extracted set/exercise action handlers from WorkoutScreen
- **LayoutAnimation**: Smooth expand/collapse transitions
- **Auto-expand**: First exercise on load, newly added exercises
- **Finished workouts**: All exercises shown expanded (read-only)
- **SetValues type**: Moved to feature `types.ts` for boundary compliance
- **i18n**: Added keys for collapsed card labels (en + de)

Closes #257