### PR TITLE
feat: remove input mode toggle for exercise sets

### DIFF
--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -22,6 +22,7 @@ interface ExerciseCardProps {
     onMoveDown: (workoutExerciseId: number) => void;
     onNoteChange: (workoutExerciseId: number, note: string) => void;
     onConfirmSet: (setId: number, values: SetValues) => void;
+    onUpdateSet: (setId: number, values: SetValues) => void;
     onDeleteSet: (setId: number) => void;
     onSetTypeChange: (setId: number, type: string) => void;
     onAddSet: (workoutExerciseId: number) => void;
@@ -36,7 +37,7 @@ interface ExerciseCardProps {
 export default function ExerciseCard({
     item, index, totalExercises, isFinished, isExpanded, onExpand, lastWorkoutSets,
     onRemove, onMoveUp, onMoveDown, onNoteChange,
-    onConfirmSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
+    onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExerciseCardProps) {
     const template = item.exerciseTemplate;
@@ -80,6 +81,7 @@ export default function ExerciseCard({
             onMoveDown={onMoveDown}
             onNoteChange={onNoteChange}
             onConfirmSet={onConfirmSet}
+            onUpdateSet={onUpdateSet}
             onDeleteSet={onDeleteSet}
             onSetTypeChange={onSetTypeChange}
             onAddSet={onAddSet}

--- a/src/features/exercise/components/ExerciseCardHelpers.ts
+++ b/src/features/exercise/components/ExerciseCardHelpers.ts
@@ -77,13 +77,13 @@ export function createExerciseCardStyles(colors: ThemeColors) {
             marginBottom: spacing.sm,
         },
         orderNum: {
-            fontSize: fontSize.md,
+            fontSize: fontSize.lg,
             fontWeight: "800",
             color: colors.primary,
         },
         exerciseName: {
             flex: 1,
-            fontSize: fontSize.md,
+            fontSize: fontSize.lg,
             fontWeight: "600",
             color: colors.text,
         },
@@ -110,7 +110,7 @@ export function createExerciseCardStyles(colors: ThemeColors) {
         setCol: { width: 32 },
         valueCol: { flex: 1, textAlign: "center" as const },
         rirCol: { width: 36, textAlign: "center" as const },
-        checkCol: { width: 28, alignItems: "center" as const },
+        emptyCol: { width: 28, alignItems: "center" as const },
         emptyText: {
             fontSize: fontSize.sm,
             color: colors.textTertiary,

--- a/src/features/exercise/components/ExpandedExerciseCard.tsx
+++ b/src/features/exercise/components/ExpandedExerciseCard.tsx
@@ -31,6 +31,7 @@ interface ExpandedExerciseCardProps {
     onMoveDown: (workoutExerciseId: number) => void;
     onNoteChange: (workoutExerciseId: number, note: string) => void;
     onConfirmSet: (setId: number, values: SetValues) => void;
+    onUpdateSet: (setId: number, values: SetValues) => void;
     onDeleteSet: (setId: number) => void;
     onSetTypeChange: (setId: number, type: string) => void;
     onAddSet: (workoutExerciseId: number) => void;
@@ -47,7 +48,7 @@ export function ExpandedExerciseCard({
     lastWorkoutSets,
     menuOpen, setMenuOpen, noteOpen, setNoteOpen, noteDraft, setNoteDraft,
     onRemove, onMoveUp, onMoveDown, onNoteChange,
-    onConfirmSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
+    onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExpandedExerciseCardProps) {
     const colors = useThemeColors();
@@ -120,7 +121,7 @@ export function ExpandedExerciseCard({
                 {exerciseType !== "cardio" && (
                     <Text style={[styles.headerCell, styles.rirCol]}>{t("exercise.exerciseCard.rir")}</Text>
                 )}
-                <Text style={[styles.headerCell, styles.checkCol]}>✓</Text>
+                <Text style={[styles.headerCell, styles.emptyCol]}></Text>
             </View>
 
             {/* Set rows */}
@@ -149,6 +150,7 @@ export function ExpandedExerciseCard({
                             prefillDuration={prefill.duration}
                             prefillDistance={prefill.distance}
                             onConfirm={onConfirmSet}
+                            onUpdate={onUpdateSet}
                             onDelete={onDeleteSet}
                             onTypeChange={onSetTypeChange}
                         />

--- a/src/features/exercise/components/SetInputHelpers.tsx
+++ b/src/features/exercise/components/SetInputHelpers.tsx
@@ -5,7 +5,7 @@ import type { ExerciseSet } from "../services/exerciseDb";
 
 type ExerciseType = "weight" | "bodyweight" | "cardio";
 
-export function ReadOnlyCells({ set, exerciseType, textColor, styles }: {
+export function ScheduledCells({ set, exerciseType, textColor, styles }: {
     set: ExerciseSet; exerciseType: ExerciseType; textColor: string;
     styles: ReturnType<typeof createSetInputStyles>;
 }) {
@@ -17,7 +17,9 @@ export function ReadOnlyCells({ set, exerciseType, textColor, styles }: {
                 </Text>
             )}
             {exerciseType !== "cardio" && (
-                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>{set.reps ?? "—"}</Text>
+                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>
+                    {set.reps ?? "—"}
+                </Text>
             )}
             {exerciseType === "cardio" && (
                 <>
@@ -30,11 +32,7 @@ export function ReadOnlyCells({ set, exerciseType, textColor, styles }: {
                 </>
             )}
             {exerciseType !== "cardio" && (
-                <Text style={[
-                    styles.setCell, styles.rirCol,
-                    { color: set.rir != null && set.rir <= 1 ? "#ef4444" : textColor },
-                    set.rir != null && set.rir <= 1 && { fontWeight: "700" },
-                ]}>
+                <Text style={[styles.setCell, styles.rirCol, { color: textColor }]}>
                     {set.rir ?? "—"}
                 </Text>
             )}
@@ -47,7 +45,7 @@ export function createSetInputStyles(colors: ThemeColors) {
         setRow: {
             flexDirection: "row",
             alignItems: "center",
-            paddingVertical: 4,
+            paddingVertical: spacing.sm,
         },
         activeRow: {
             backgroundColor: colors.surfaceVariant ?? colors.background,
@@ -73,14 +71,27 @@ export function createSetInputStyles(colors: ThemeColors) {
             paddingVertical: 2,
             marginHorizontal: 2,
         },
+        inlineInput: {
+            fontSize: fontSize.sm,
+            textAlign: "center",
+            paddingVertical: 2,
+            marginHorizontal: 2,
+        },
         weightInputGroup: {
             flex: 1,
             flexDirection: "row",
             alignItems: "center",
+            justifyContent: "center",
+        },
+        weightInput: {
+            textAlign: "right",
+            minWidth: 48,
         },
         unitToggle: {
-            paddingHorizontal: 4,
+            paddingLeft: 2,
+            paddingRight: spacing.xs,
             paddingVertical: 2,
+            minWidth: 28,
         },
         unitText: {
             fontSize: fontSize.xs,

--- a/src/features/exercise/components/SetInputRow.tsx
+++ b/src/features/exercise/components/SetInputRow.tsx
@@ -6,7 +6,7 @@ import { Alert, Pressable, Text, TextInput, View } from "react-native";
 import { convertWeight } from "../helpers/exerciseUnits";
 import type { ExerciseSet } from "../services/exerciseDb";
 import type { ExerciseType } from "../types";
-import { ReadOnlyCells, createSetInputStyles } from "./SetInputHelpers";
+import { ScheduledCells, createSetInputStyles } from "./SetInputHelpers";
 
 const SET_TYPES = ["warmup", "working", "dropset", "failure"] as const;
 type SetType = (typeof SET_TYPES)[number];
@@ -16,17 +16,12 @@ const SET_TYPE_LABELS: Record<SetType, string> = {
 };
 
 interface SetInputRowProps {
-    set: ExerciseSet;
-    index: number;
-    exerciseType: ExerciseType;
-    isActive: boolean;
-    isFinished: boolean;
-    prefillWeight: number | null;
-    prefillReps: number | null;
-    prefillRir: number | null;
-    prefillDuration: number | null;
-    prefillDistance: number | null;
+    set: ExerciseSet; index: number; exerciseType: ExerciseType;
+    isActive: boolean; isFinished: boolean;
+    prefillWeight: number | null; prefillReps: number | null; prefillRir: number | null;
+    prefillDuration: number | null; prefillDistance: number | null;
     onConfirm: (id: number, values: SetValues) => void;
+    onUpdate: (id: number, values: SetValues) => void;
     onDelete: (id: number) => void;
     onTypeChange: (id: number, type: string) => void;
 }
@@ -36,7 +31,7 @@ export type { SetValues } from "../types";
 export default function SetInputRow({
     set, index, exerciseType, isActive, isFinished,
     prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance,
-    onConfirm, onDelete, onTypeChange,
+    onConfirm, onUpdate, onDelete, onTypeChange,
 }: SetInputRowProps) {
     const colors = useThemeColors();
     const { t } = useTranslation();
@@ -44,16 +39,16 @@ export default function SetInputRow({
 
     const isCompleted = !!set.completed_at;
     const isScheduled = !!set.is_scheduled && !isCompleted;
+    const isActiveSet = isActive && !isFinished;
 
-    // Input state — initialise from set data, placeholders from prefill
     const [weight, setWeight] = useState(set.weight != null ? String(set.weight) : "");
     const [reps, setReps] = useState(set.reps != null ? String(set.reps) : "");
     const [rir, setRir] = useState(set.rir != null ? String(set.rir) : "");
     const [duration, setDuration] = useState(set.duration_seconds != null ? String(set.duration_seconds) : "");
     const [distance, setDistance] = useState(set.distance_meters != null ? String(set.distance_meters) : "");
     const [unit, setUnit] = useState<"kg" | "lb">((set.weight_unit as "kg" | "lb") ?? "kg");
+    const [focusedField, setFocusedField] = useState<string | null>(null);
 
-    // Sync local state when set prop changes externally (e.g. copy from last, type change)
     useEffect(() => {
         setWeight(set.weight != null ? String(set.weight) : "");
         setReps(set.reps != null ? String(set.reps) : "");
@@ -65,28 +60,39 @@ export default function SetInputRow({
 
     const typeLabel = SET_TYPE_LABELS[set.type as SetType] ?? "";
 
+    const buildValues = useCallback((): SetValues => ({
+        weight: weight ? parseFloat(weight) : prefillWeight,
+        weight_unit: unit,
+        reps: reps ? parseInt(reps, 10) : prefillReps,
+        rir: rir ? parseInt(rir, 10) : prefillRir,
+        duration_seconds: duration ? parseInt(duration, 10) : prefillDuration,
+        distance_meters: distance ? parseFloat(distance) : prefillDistance,
+        type: set.type,
+    }), [weight, reps, rir, duration, distance, unit, set.type,
+        prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance]);
+
     const handleToggleUnit = useCallback(() => {
         const newUnit = unit === "kg" ? "lb" : "kg";
-        if (weight) {
-            const converted = convertWeight(parseFloat(weight), unit, newUnit);
-            setWeight(String(converted));
-        }
+        const newWeight = weight ? String(convertWeight(parseFloat(weight), unit, newUnit)) : weight;
+        setWeight(newWeight);
         setUnit(newUnit);
-    }, [unit, weight]);
+        if (isCompleted) {
+            onUpdate(set.id, {
+                ...buildValues(),
+                weight: newWeight ? parseFloat(newWeight) : prefillWeight,
+                weight_unit: newUnit,
+            });
+        }
+    }, [unit, weight, isCompleted, set.id, buildValues, prefillWeight, onUpdate]);
 
     const handleConfirm = useCallback(() => {
-        const vals: SetValues = {
-            weight: weight ? parseFloat(weight) : prefillWeight,
-            weight_unit: unit,
-            reps: reps ? parseInt(reps, 10) : prefillReps,
-            rir: rir ? parseInt(rir, 10) : prefillRir,
-            duration_seconds: duration ? parseInt(duration, 10) : prefillDuration,
-            distance_meters: distance ? parseFloat(distance) : prefillDistance,
-            type: set.type,
-        };
-        onConfirm(set.id, vals);
-    }, [weight, reps, rir, duration, distance, unit, set.id, set.type,
-        prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance, onConfirm]);
+        onConfirm(set.id, buildValues());
+    }, [set.id, buildValues, onConfirm]);
+
+    const handleBlurSave = useCallback((field: string) => {
+        setFocusedField((prev) => (prev === field ? null : prev));
+        if (isCompleted) onUpdate(set.id, buildValues());
+    }, [isCompleted, set.id, buildValues, onUpdate]);
 
     const handleLongPressSetNum = useCallback(() => {
         if (isCompleted || isFinished) return;
@@ -107,127 +113,133 @@ export default function SetInputRow({
         );
     }, [set.id, isFinished, onDelete, t]);
 
-    const [reEditing, setReEditing] = useState(false);
-
-    // Completed / read-only display
-    if (isCompleted && !isActive && !reEditing) {
+    // Scheduled / pending — display-only dim row
+    if (isScheduled && !isActive) {
         return (
-            <Pressable
-                style={styles.setRow}
-                onLongPress={handleDelete}
-                delayLongPress={600}
-                onPress={() => { if (!isFinished) setReEditing(true); }}
-            >
-                <Text style={[styles.setCell, styles.setCol, { color: colors.textSecondary }]}>
+            <Pressable style={[styles.setRow, styles.setRowScheduled]} onLongPress={handleLongPressSetNum}>
+                <Text style={[styles.setCell, styles.setCol, { color: colors.textTertiary }]}>
                     {typeLabel}{index + 1}
                 </Text>
-                <ReadOnlyCells set={set} exerciseType={exerciseType} textColor={colors.textSecondary} styles={styles} />
-                <View style={styles.checkCol}>
-                    <Ionicons
-                        name={isFinished ? "checkmark-circle" : "create-outline"}
-                        size={20}
-                        color={isFinished ? colors.primary : colors.textSecondary}
-                    />
-                </View>
+                <ScheduledCells set={set} exerciseType={exerciseType} textColor={colors.textTertiary} styles={styles} />
+                {isFinished ? (
+                    <View style={styles.checkCol}>
+                        <Ionicons name="ellipse-outline" size={20} color={colors.border} />
+                    </View>
+                ) : (
+                    <Pressable style={styles.checkCol} onPress={handleDelete}>
+                        <Ionicons name="trash-outline" size={18} color={colors.textTertiary} />
+                    </Pressable>
+                )}
             </Pressable>
         );
     }
 
-    // Active / editable input row (also used for re-editing a completed set)
-    if ((isActive && !isFinished) || reEditing) {
-        const textColor = isScheduled ? colors.textTertiary : colors.text;
-        return (
-            <View style={[styles.setRow, styles.activeRow]}>
-                <Pressable onLongPress={handleLongPressSetNum} style={styles.setCol}>
-                    <Text style={[styles.setCell, { color: colors.primary, fontWeight: "700" }]}>
-                        {typeLabel}{index + 1}
-                    </Text>
-                </Pressable>
-                {exerciseType === "weight" && (
-                    <View style={styles.weightInputGroup}>
-                        <TextInput
-                            style={[styles.input, { flex: 1, color: textColor }]}
-                            value={weight}
-                            onChangeText={setWeight}
-                            placeholder={prefillWeight != null ? String(prefillWeight) : "—"}
-                            placeholderTextColor={colors.textTertiary}
-                            keyboardType="decimal-pad"
-                            selectTextOnFocus
-                        />
-                        <Pressable onPress={handleToggleUnit} style={styles.unitToggle}>
-                            <Text style={[styles.unitText, { color: colors.primary }]}>{unit}</Text>
-                        </Pressable>
-                    </View>
-                )}
-                {exerciseType !== "cardio" && (
-                    <TextInput
-                        style={[styles.input, styles.valueCol, { color: textColor }]}
-                        value={reps}
-                        onChangeText={setReps}
-                        placeholder={prefillReps != null ? String(prefillReps) : "—"}
-                        placeholderTextColor={colors.textTertiary}
-                        keyboardType="number-pad"
-                        selectTextOnFocus
-                    />
-                )}
-                {exerciseType === "cardio" && (
-                    <>
-                        <TextInput
-                            style={[styles.input, styles.valueCol, { color: textColor }]}
-                            value={duration}
-                            onChangeText={setDuration}
-                            placeholder={prefillDuration != null ? String(prefillDuration) : "—"}
-                            placeholderTextColor={colors.textTertiary}
-                            keyboardType="number-pad"
-                            selectTextOnFocus
-                        />
-                        <TextInput
-                            style={[styles.input, styles.valueCol, { color: textColor }]}
-                            value={distance}
-                            onChangeText={setDistance}
-                            placeholder={prefillDistance != null ? String(prefillDistance) : "—"}
-                            placeholderTextColor={colors.textTertiary}
-                            keyboardType="decimal-pad"
-                            selectTextOnFocus
-                        />
-                    </>
-                )}
-                {exerciseType !== "cardio" && (
-                    <TextInput
-                        style={[styles.input, styles.rirCol, { color: textColor }]}
-                        value={rir}
-                        onChangeText={setRir}
-                        placeholder={prefillRir != null ? String(prefillRir) : "—"}
-                        placeholderTextColor={colors.textTertiary}
-                        keyboardType="number-pad"
-                        selectTextOnFocus
-                    />
-                )}
-                <Pressable style={styles.checkCol} onPress={() => { handleConfirm(); setReEditing(false); }}>
-                    <Ionicons name="checkmark-circle-outline" size={22} color={colors.primary} />
-                </Pressable>
-            </View>
-        );
-    }
+    // Editable row — completed and active sets
+    const textColor = isActiveSet ? colors.text : colors.textSecondary;
+    const fieldStyle = (field: string) => focusedField === field ? styles.input : styles.inlineInput;
 
-    // Scheduled / pending (not active) — display-only dim row
-    const textColor = isScheduled ? colors.textTertiary : colors.text;
     return (
-        <Pressable
-            style={[styles.setRow, isScheduled && styles.setRowScheduled]}
-            onLongPress={handleLongPressSetNum}
-        >
-            <Text style={[styles.setCell, styles.setCol, { color: textColor }]}>{typeLabel}{index + 1}</Text>
-            <ReadOnlyCells set={set} exerciseType={exerciseType} textColor={textColor} styles={styles} />
-            {isFinished ? (
-                <View style={styles.checkCol}>
-                    <Ionicons name="ellipse-outline" size={20} color={colors.border} />
+        <View style={[styles.setRow, isActiveSet && styles.activeRow]}>
+            <Pressable onLongPress={handleLongPressSetNum} style={styles.setCol}>
+                <Text style={[
+                    styles.setCell,
+                    { color: isActiveSet ? colors.primary : textColor },
+                    isActiveSet && { fontWeight: "700" },
+                ]}>
+                    {typeLabel}{index + 1}
+                </Text>
+            </Pressable>
+
+            {exerciseType === "weight" && (
+                <View style={styles.weightInputGroup}>
+                    <TextInput
+                        style={[fieldStyle("weight"), styles.weightInput, { color: textColor }]}
+                        value={weight}
+                        onChangeText={setWeight}
+                        placeholder={prefillWeight != null ? String(prefillWeight) : "—"}
+                        placeholderTextColor={colors.textTertiary}
+                        keyboardType="decimal-pad"
+                        selectTextOnFocus
+                        editable={!isFinished}
+                        onFocus={() => setFocusedField("weight")}
+                        onBlur={() => handleBlurSave("weight")}
+                    />
+                    <Pressable onPress={!isFinished ? handleToggleUnit : undefined} style={styles.unitToggle}>
+                        <Text style={[styles.unitText, { color: colors.primary }]}>{unit}</Text>
+                    </Pressable>
                 </View>
-            ) : (
+            )}
+
+            {exerciseType !== "cardio" && (
+                <TextInput
+                    style={[fieldStyle("reps"), styles.valueCol, { color: textColor }]}
+                    value={reps}
+                    onChangeText={setReps}
+                    placeholder={prefillReps != null ? String(prefillReps) : "—"}
+                    placeholderTextColor={colors.textTertiary}
+                    keyboardType="number-pad"
+                    selectTextOnFocus
+                    editable={!isFinished}
+                    onFocus={() => setFocusedField("reps")}
+                    onBlur={() => handleBlurSave("reps")}
+                />
+            )}
+
+            {exerciseType === "cardio" && (
+                <>
+                    <TextInput
+                        style={[fieldStyle("duration"), styles.valueCol, { color: textColor }]}
+                        value={duration}
+                        onChangeText={setDuration}
+                        placeholder={prefillDuration != null ? String(prefillDuration) : "—"}
+                        placeholderTextColor={colors.textTertiary}
+                        keyboardType="number-pad"
+                        selectTextOnFocus
+                        editable={!isFinished}
+                        onFocus={() => setFocusedField("duration")}
+                        onBlur={() => handleBlurSave("duration")}
+                    />
+                    <TextInput
+                        style={[fieldStyle("distance"), styles.valueCol, { color: textColor }]}
+                        value={distance}
+                        onChangeText={setDistance}
+                        placeholder={prefillDistance != null ? String(prefillDistance) : "—"}
+                        placeholderTextColor={colors.textTertiary}
+                        keyboardType="decimal-pad"
+                        selectTextOnFocus
+                        editable={!isFinished}
+                        onFocus={() => setFocusedField("distance")}
+                        onBlur={() => handleBlurSave("distance")}
+                    />
+                </>
+            )}
+
+            {exerciseType !== "cardio" && (
+                <TextInput
+                    style={[fieldStyle("rir"), styles.rirCol, { color: textColor }]}
+                    value={rir}
+                    onChangeText={setRir}
+                    placeholder={prefillRir != null ? String(prefillRir) : "—"}
+                    placeholderTextColor={colors.textTertiary}
+                    keyboardType="number-pad"
+                    selectTextOnFocus
+                    editable={!isFinished}
+                    onFocus={() => setFocusedField("rir")}
+                    onBlur={() => handleBlurSave("rir")}
+                />
+            )}
+
+            {isActiveSet ? (
+                <Pressable style={styles.checkCol} onPress={handleConfirm}>
+                    <Ionicons name="checkmark-circle" size={20} color={colors.success} />
+                </Pressable>
+            ) : !isFinished ? (
                 <Pressable style={styles.checkCol} onPress={handleDelete}>
                     <Ionicons name="trash-outline" size={18} color={colors.textTertiary} />
                 </Pressable>
+            ) : (
+                <View style={styles.checkCol} />
             )}
-        </Pressable>
+        </View>
     );
 }

--- a/src/features/exercise/hooks/useWorkoutActions.ts
+++ b/src/features/exercise/hooks/useWorkoutActions.ts
@@ -51,6 +51,18 @@ export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestT
         workout.reload();
     }, [workout, restTimer]);
 
+    const handleUpdateSet = useCallback((setId: number, values: SetValues) => {
+        updateSet(setId, {
+            weight: values.weight,
+            weight_unit: values.weight_unit,
+            reps: values.reps,
+            rir: values.rir,
+            duration_seconds: values.duration_seconds,
+            distance_meters: values.distance_meters,
+            type: values.type,
+        });
+    }, []);
+
     const handleDeleteSet = useCallback((setId: number) => {
         deleteSet(setId);
         workout.reload();
@@ -90,6 +102,7 @@ export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestT
         handleMoveUp,
         handleMoveDown,
         handleConfirmSet,
+        handleUpdateSet,
         handleDeleteSet,
         handleSetTypeChange,
         handleAddSet,

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -115,6 +115,7 @@ export default function WorkoutScreen() {
                 onMoveDown={actions.handleMoveDown}
                 onNoteChange={actions.handleNoteChange}
                 onConfirmSet={actions.handleConfirmSet}
+                onUpdateSet={actions.handleUpdateSet}
                 onDeleteSet={actions.handleDeleteSet}
                 onSetTypeChange={actions.handleSetTypeChange}
                 onAddSet={actions.handleAddSet}


### PR DESCRIPTION
## Summary

Removes the edit/save icon toggle on exercise sets and replaces read-only text with always-editable inline TextInputs that auto-save on blur.

### Changes
- **SetInputRow**: Unified editable layout for completed + active sets; focus-based border styling; trash icon (tap) replaces green checkmark for completed rows
- **SetInputHelpers**: Replaced `ReadOnlyCells` with `ScheduledCells`; added `inlineInput`, `weightInput` styles; increased row padding
- **useWorkoutActions**: Added `handleUpdateSet` (update-only, no completion/rest timer)
- **ExerciseCardHelpers**: Increased exercise name/order font size (md → lg)
- **ExpandedExerciseCard / ExerciseCard / WorkoutScreen**: Wired `onUpdateSet` prop

Closes #259