### PR TITLE
[ENHANCE] Edit workout after it's done

### DIFF
--- a/src/features/exercise/components/EditWorkoutTimesModal.tsx
+++ b/src/features/exercise/components/EditWorkoutTimesModal.tsx
@@ -1,0 +1,244 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useCallback, useMemo, useState } from "react";
+import { KeyboardAvoidingView, Modal, Platform, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+
+interface EditWorkoutTimesModalProps {
+    visible: boolean;
+    onClose: () => void;
+    startedAt: number;
+    endedAt: number | null;
+    onSave: (startEpoch: number, endEpoch: number | null) => void;
+    labels: {
+        title: string;
+        startLabel: string;
+        endLabel: string;
+        save: string;
+    };
+}
+
+function epochToHourMin(epoch: number): { h: string; m: string } {
+    const d = new Date(epoch);
+    return {
+        h: String(d.getHours()).padStart(2, "0"),
+        m: String(d.getMinutes()).padStart(2, "0"),
+    };
+}
+
+function applyHourMin(epoch: number, h: number, m: number): number {
+    const d = new Date(epoch);
+    d.setHours(h, m, 0, 0);
+    return d.getTime();
+}
+
+function clampNumStr(val: string, min: number, max: number): string {
+    const n = parseInt(val, 10);
+    if (isNaN(n)) return "";
+    return String(Math.min(Math.max(n, min), max));
+}
+
+export default function EditWorkoutTimesModal({
+    visible, onClose, startedAt, endedAt, onSave, labels,
+}: EditWorkoutTimesModalProps) {
+    const colors = useThemeColors();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+
+    const initStart = epochToHourMin(startedAt);
+    const initEnd = endedAt ? epochToHourMin(endedAt) : null;
+
+    const [startH, setStartH] = useState(initStart.h);
+    const [startM, setStartM] = useState(initStart.m);
+    const [endH, setEndH] = useState(initEnd?.h ?? "");
+    const [endM, setEndM] = useState(initEnd?.m ?? "");
+
+    // Reset draft values when modal opens with new data
+    const resetDrafts = useCallback(() => {
+        const s = epochToHourMin(startedAt);
+        const e = endedAt ? epochToHourMin(endedAt) : null;
+        setStartH(s.h);
+        setStartM(s.m);
+        setEndH(e?.h ?? "");
+        setEndM(e?.m ?? "");
+    }, [startedAt, endedAt]);
+
+    function handleSave() {
+        const sh = parseInt(startH, 10) || 0;
+        const sm = parseInt(startM, 10) || 0;
+        const newStart = applyHourMin(startedAt, sh, sm);
+
+        let newEnd: number | null = null;
+        if (endedAt != null && endH !== "") {
+            const eh = parseInt(endH, 10) || 0;
+            const em = parseInt(endM, 10) || 0;
+            newEnd = applyHourMin(endedAt, eh, em);
+        }
+
+        onSave(newStart, newEnd);
+        onClose();
+    }
+
+    return (
+        <Modal
+            visible={visible}
+            transparent
+            animationType="fade"
+            onRequestClose={onClose}
+            onShow={resetDrafts}
+        >
+            <KeyboardAvoidingView
+                style={styles.keyboardView}
+                behavior={Platform.OS === "ios" ? "padding" : undefined}
+            >
+                <Pressable style={styles.overlay} onPress={onClose}>
+                    <Pressable style={styles.modal} onPress={() => {}}>
+                        <Text style={styles.title}>{labels.title}</Text>
+
+                        {/* Start time */}
+                        <Text style={styles.fieldLabel}>{labels.startLabel}</Text>
+                        <View style={styles.timeRow}>
+                            <TextInput
+                                style={styles.timeInput}
+                                value={startH}
+                                onChangeText={(v) => setStartH(v.replace(/[^0-9]/g, "").slice(0, 2))}
+                                onBlur={() => setStartH(clampNumStr(startH, 0, 23).padStart(2, "0"))}
+                                keyboardType="number-pad"
+                                maxLength={2}
+                                selectTextOnFocus
+                                placeholder="HH"
+                                placeholderTextColor={colors.textTertiary}
+                            />
+                            <Text style={styles.timeSeparator}>:</Text>
+                            <TextInput
+                                style={styles.timeInput}
+                                value={startM}
+                                onChangeText={(v) => setStartM(v.replace(/[^0-9]/g, "").slice(0, 2))}
+                                onBlur={() => setStartM(clampNumStr(startM, 0, 59).padStart(2, "0"))}
+                                keyboardType="number-pad"
+                                maxLength={2}
+                                selectTextOnFocus
+                                placeholder="MM"
+                                placeholderTextColor={colors.textTertiary}
+                            />
+                        </View>
+
+                        {/* End time (only shown if workout is finished) */}
+                        {endedAt != null && (
+                            <>
+                                <Text style={styles.fieldLabel}>{labels.endLabel}</Text>
+                                <View style={styles.timeRow}>
+                                    <TextInput
+                                        style={styles.timeInput}
+                                        value={endH}
+                                        onChangeText={(v) => setEndH(v.replace(/[^0-9]/g, "").slice(0, 2))}
+                                        onBlur={() => setEndH(clampNumStr(endH, 0, 23).padStart(2, "0"))}
+                                        keyboardType="number-pad"
+                                        maxLength={2}
+                                        selectTextOnFocus
+                                        placeholder="HH"
+                                        placeholderTextColor={colors.textTertiary}
+                                    />
+                                    <Text style={styles.timeSeparator}>:</Text>
+                                    <TextInput
+                                        style={styles.timeInput}
+                                        value={endM}
+                                        onChangeText={(v) => setEndM(v.replace(/[^0-9]/g, "").slice(0, 2))}
+                                        onBlur={() => setEndM(clampNumStr(endM, 0, 59).padStart(2, "0"))}
+                                        keyboardType="number-pad"
+                                        maxLength={2}
+                                        selectTextOnFocus
+                                        placeholder="MM"
+                                        placeholderTextColor={colors.textTertiary}
+                                    />
+                                </View>
+                            </>
+                        )}
+
+                        <Pressable style={styles.saveBtn} onPress={handleSave}>
+                            <Ionicons name="checkmark" size={18} color="#fff" />
+                            <Text style={styles.saveText}>{labels.save}</Text>
+                        </Pressable>
+                    </Pressable>
+                </Pressable>
+            </KeyboardAvoidingView>
+        </Modal>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        keyboardView: {
+            flex: 1,
+        },
+        overlay: {
+            flex: 1,
+            backgroundColor: "rgba(0,0,0,0.5)",
+            justifyContent: "center",
+            alignItems: "center",
+            padding: spacing.lg,
+        },
+        modal: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.lg,
+            width: "100%",
+            maxWidth: 300,
+            alignItems: "center",
+        },
+        title: {
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+            color: colors.text,
+            marginBottom: spacing.lg,
+            textAlign: "center",
+        },
+        fieldLabel: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            marginBottom: spacing.xs,
+            textAlign: "center",
+        },
+        timeRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "center",
+            marginBottom: spacing.md,
+            gap: spacing.xs,
+        },
+        timeInput: {
+            fontSize: fontSize.xl,
+            fontWeight: "700",
+            fontVariant: ["tabular-nums"],
+            color: colors.text,
+            backgroundColor: colors.background,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+            textAlign: "center",
+            width: 64,
+            paddingVertical: spacing.sm,
+        },
+        timeSeparator: {
+            fontSize: fontSize.xl,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        saveBtn: {
+            flexDirection: "row",
+            alignItems: "center",
+            alignSelf: "stretch",
+            justifyContent: "center",
+            gap: spacing.xs,
+            backgroundColor: colors.primary,
+            borderRadius: borderRadius.md,
+            paddingVertical: spacing.sm,
+            marginTop: spacing.sm,
+        },
+        saveText: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: "#fff",
+        },
+    });
+}

--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -48,8 +48,8 @@ export default function ExerciseCard({
     const [noteOpen, setNoteOpen] = useState(false);
     const [noteDraft, setNoteDraft] = useState(item.workoutExercise.notes ?? "");
 
-    // Show collapsed card for non-expanded, non-finished exercises
-    if (!isExpanded && !isFinished) {
+    // Show collapsed card for non-expanded exercises
+    if (!isExpanded) {
         return (
             <CollapsedExerciseCard
                 item={item}

--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -2,10 +2,11 @@ import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable, Text, View } from "react-native";
+import { Alert, Pressable, Text, View } from "react-native";
 import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
 import type { ExerciseType } from "../types";
 import { bestSetSummary, createCollapsedCardStyles } from "./ExerciseCardHelpers";
+import { ExerciseCardMenu, ExerciseNoteModal } from "./ExerciseCardModals";
 import { ExpandedExerciseCard } from "./ExpandedExerciseCard";
 import type { SetValues } from "./SetInputRow";
 
@@ -40,6 +41,7 @@ export default function ExerciseCard({
     onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExerciseCardProps) {
+    const { t } = useTranslation();
     const template = item.exerciseTemplate;
     const name = template?.name ?? "?";
     const exerciseType: ExerciseType = (template?.type as ExerciseType) ?? "weight";
@@ -48,15 +50,69 @@ export default function ExerciseCard({
     const [noteOpen, setNoteOpen] = useState(false);
     const [noteDraft, setNoteDraft] = useState(item.workoutExercise.notes ?? "");
 
+    function handleRemove() {
+        Alert.alert(
+            t("exercise.exerciseCard.remove"),
+            t("exercise.exerciseCard.removeConfirm"),
+            [
+                { text: t("common.cancel"), style: "cancel" },
+                { text: t("common.delete"), style: "destructive", onPress: () => onRemove(item.workoutExercise.id) },
+            ],
+        );
+        setMenuOpen(false);
+    }
+
+    function handleSaveNote() {
+        onNoteChange(item.workoutExercise.id, noteDraft.trim());
+        setNoteOpen(false);
+    }
+
     // Show collapsed card for non-expanded exercises
     if (!isExpanded) {
         return (
-            <CollapsedExerciseCard
-                item={item}
-                index={index}
-                name={name}
-                onExpand={onExpand}
-            />
+            <>
+                <CollapsedExerciseCard
+                    item={item}
+                    index={index}
+                    name={name}
+                    onExpand={onExpand}
+                    onLongPress={() => setMenuOpen(true)}
+                />
+                <ExerciseCardMenu
+                    visible={menuOpen}
+                    onClose={() => setMenuOpen(false)}
+                    index={index}
+                    totalExercises={totalExercises}
+                    isFinished={isFinished}
+                    hasNote={!!item.workoutExercise.notes}
+                    hasTemplate={!!template}
+                    onMoveUp={() => { onMoveUp(item.workoutExercise.id); setMenuOpen(false); }}
+                    onMoveDown={() => { onMoveDown(item.workoutExercise.id); setMenuOpen(false); }}
+                    onEditNote={() => { setMenuOpen(false); setNoteDraft(item.workoutExercise.notes ?? ""); setNoteOpen(true); }}
+                    onCopyFromLast={() => { onCopyFromLast(item.workoutExercise.id, template!.id); setMenuOpen(false); }}
+                    onRemove={handleRemove}
+                    labels={{
+                        moveUp: t("exercise.exerciseCard.moveUp"),
+                        moveDown: t("exercise.exerciseCard.moveDown"),
+                        editNote: t("exercise.exerciseCard.editNote"),
+                        addNote: t("exercise.exerciseCard.addNote"),
+                        copyFromLast: t("exercise.exerciseCard.copyFromLast"),
+                        remove: t("exercise.exerciseCard.remove"),
+                    }}
+                />
+                <ExerciseNoteModal
+                    visible={noteOpen}
+                    onClose={() => setNoteOpen(false)}
+                    value={noteDraft}
+                    onChangeText={setNoteDraft}
+                    onSave={handleSaveNote}
+                    labels={{
+                        title: t("exercise.exerciseCard.note"),
+                        placeholder: t("exercise.exerciseCard.notePlaceholder"),
+                        save: t("common.save"),
+                    }}
+                />
+            </>
         );
     }
 
@@ -102,9 +158,10 @@ interface CollapsedProps {
     index: number;
     name: string;
     onExpand: () => void;
+    onLongPress: () => void;
 }
 
-function CollapsedExerciseCard({ item, index, name, onExpand }: CollapsedProps) {
+function CollapsedExerciseCard({ item, index, name, onExpand, onLongPress }: CollapsedProps) {
     const colors = useThemeColors();
     const { t } = useTranslation();
     const styles = useMemo(() => createCollapsedCardStyles(colors), [colors]);
@@ -121,7 +178,7 @@ function CollapsedExerciseCard({ item, index, name, onExpand }: CollapsedProps) 
     }
 
     return (
-        <Pressable style={styles.card} onPress={onExpand}>
+        <Pressable style={styles.card} onPress={onExpand} onLongPress={onLongPress}>
             <Text style={styles.orderNum}>{index + 1}.</Text>
             <Text style={styles.name} numberOfLines={1}>{name}</Text>
 

--- a/src/features/exercise/components/ExerciseCardModals.tsx
+++ b/src/features/exercise/components/ExerciseCardModals.tsx
@@ -73,12 +73,10 @@ export function ExerciseCardMenu({
                         icon="create-outline"
                         onPress={onEditNote} colors={colors}
                     />
-                    {!isFinished && hasTemplate && (
+                    {hasTemplate && (
                         <MenuItem label={labels.copyFromLast} icon="copy-outline" onPress={onCopyFromLast} colors={colors} />
                     )}
-                    {!isFinished && (
-                        <MenuItem label={labels.remove} icon="trash-outline" onPress={onRemove} colors={colors} destructive />
-                    )}
+                    <MenuItem label={labels.remove} icon="trash-outline" onPress={onRemove} colors={colors} destructive />
                 </View>
             </Pressable>
         </Modal>

--- a/src/features/exercise/components/ExpandedExerciseCard.tsx
+++ b/src/features/exercise/components/ExpandedExerciseCard.tsx
@@ -164,11 +164,9 @@ export function ExpandedExerciseCard({
             )}
 
             {/* + Add Set button */}
-            {!isFinished && (
-                <Pressable style={styles.addSetBtn} onPress={() => onAddSet(item.workoutExercise.id)}>
-                    <Text style={styles.addSetText}>{t("exercise.exerciseCard.addSet")}</Text>
-                </Pressable>
-            )}
+            <Pressable style={styles.addSetBtn} onPress={() => onAddSet(item.workoutExercise.id)}>
+                <Text style={styles.addSetText}>{t("exercise.exerciseCard.addSet")}</Text>
+            </Pressable>
 
             <ExerciseCardMenu
                 visible={menuOpen}

--- a/src/features/exercise/components/SetInputRow.tsx
+++ b/src/features/exercise/components/SetInputRow.tsx
@@ -95,14 +95,13 @@ export default function SetInputRow({
     }, [isCompleted, set.id, buildValues, onUpdate]);
 
     const handleLongPressSetNum = useCallback(() => {
-        if (isCompleted || isFinished) return;
+        if (isCompleted) return;
         const currentIdx = SET_TYPES.indexOf(set.type as SetType);
         const nextIdx = (currentIdx + 1) % SET_TYPES.length;
         onTypeChange(set.id, SET_TYPES[nextIdx]);
-    }, [set.id, set.type, isCompleted, isFinished, onTypeChange]);
+    }, [set.id, set.type, isCompleted, onTypeChange]);
 
     const handleDelete = useCallback(() => {
-        if (isFinished) return;
         Alert.alert(
             t("exercise.exerciseCard.deleteSet"),
             t("exercise.exerciseCard.deleteSetConfirm"),
@@ -111,7 +110,7 @@ export default function SetInputRow({
                 { text: t("common.delete"), style: "destructive", onPress: () => onDelete(set.id) },
             ],
         );
-    }, [set.id, isFinished, onDelete, t]);
+    }, [set.id, onDelete, t]);
 
     // Scheduled / pending — display-only dim row
     if (isScheduled && !isActive) {
@@ -121,15 +120,9 @@ export default function SetInputRow({
                     {typeLabel}{index + 1}
                 </Text>
                 <ScheduledCells set={set} exerciseType={exerciseType} textColor={colors.textTertiary} styles={styles} />
-                {isFinished ? (
-                    <View style={styles.checkCol}>
-                        <Ionicons name="ellipse-outline" size={20} color={colors.border} />
-                    </View>
-                ) : (
-                    <Pressable style={styles.checkCol} onPress={handleDelete}>
-                        <Ionicons name="trash-outline" size={18} color={colors.textTertiary} />
-                    </Pressable>
-                )}
+                <Pressable style={styles.checkCol} onPress={handleDelete}>
+                    <Ionicons name="trash-outline" size={18} color={colors.textTertiary} />
+                </Pressable>
             </Pressable>
         );
     }
@@ -160,11 +153,10 @@ export default function SetInputRow({
                         placeholderTextColor={colors.textTertiary}
                         keyboardType="decimal-pad"
                         selectTextOnFocus
-                        editable={!isFinished}
                         onFocus={() => setFocusedField("weight")}
                         onBlur={() => handleBlurSave("weight")}
                     />
-                    <Pressable onPress={!isFinished ? handleToggleUnit : undefined} style={styles.unitToggle}>
+                    <Pressable onPress={handleToggleUnit} style={styles.unitToggle}>
                         <Text style={[styles.unitText, { color: colors.primary }]}>{unit}</Text>
                     </Pressable>
                 </View>
@@ -179,7 +171,6 @@ export default function SetInputRow({
                     placeholderTextColor={colors.textTertiary}
                     keyboardType="number-pad"
                     selectTextOnFocus
-                    editable={!isFinished}
                     onFocus={() => setFocusedField("reps")}
                     onBlur={() => handleBlurSave("reps")}
                 />
@@ -195,7 +186,6 @@ export default function SetInputRow({
                         placeholderTextColor={colors.textTertiary}
                         keyboardType="number-pad"
                         selectTextOnFocus
-                        editable={!isFinished}
                         onFocus={() => setFocusedField("duration")}
                         onBlur={() => handleBlurSave("duration")}
                     />
@@ -207,7 +197,6 @@ export default function SetInputRow({
                         placeholderTextColor={colors.textTertiary}
                         keyboardType="decimal-pad"
                         selectTextOnFocus
-                        editable={!isFinished}
                         onFocus={() => setFocusedField("distance")}
                         onBlur={() => handleBlurSave("distance")}
                     />
@@ -223,7 +212,6 @@ export default function SetInputRow({
                     placeholderTextColor={colors.textTertiary}
                     keyboardType="number-pad"
                     selectTextOnFocus
-                    editable={!isFinished}
                     onFocus={() => setFocusedField("rir")}
                     onBlur={() => handleBlurSave("rir")}
                 />
@@ -233,12 +221,10 @@ export default function SetInputRow({
                 <Pressable style={styles.checkCol} onPress={handleConfirm}>
                     <Ionicons name="checkmark-circle" size={20} color={colors.success} />
                 </Pressable>
-            ) : !isFinished ? (
+            ) : (
                 <Pressable style={styles.checkCol} onPress={handleDelete}>
                     <Ionicons name="trash-outline" size={18} color={colors.textTertiary} />
                 </Pressable>
-            ) : (
-                <View style={styles.checkCol} />
             )}
         </View>
     );

--- a/src/features/exercise/components/WorkoutHeader.tsx
+++ b/src/features/exercise/components/WorkoutHeader.tsx
@@ -14,11 +14,12 @@ interface WorkoutHeaderProps {
     onTitleChange: (title: string) => void;
     onFinish: () => void;
     onBack: () => void;
+    onTimerPress: () => void;
 }
 
 export default function WorkoutHeader({
     title, elapsedMs, isFinished, hasUnfinishedSets,
-    onTitleChange, onFinish, onBack,
+    onTitleChange, onFinish, onBack, onTimerPress,
 }: WorkoutHeaderProps) {
     const colors = useThemeColors();
     const { t } = useTranslation();
@@ -84,10 +85,10 @@ export default function WorkoutHeader({
                 </Pressable>
             )}
 
-            <View style={styles.timerWrap}>
+            <Pressable style={styles.timerWrap} onPress={onTimerPress} hitSlop={8}>
                 <Ionicons name="time-outline" size={16} color={colors.textSecondary} />
                 <Text style={styles.timer}>{formatElapsed(elapsedMs)}</Text>
-            </View>
+            </Pressable>
 
             {!isFinished && (
                 <Pressable onPress={handleFinish} style={styles.finishBtn} hitSlop={8}>

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { FlatList, Alert, LayoutAnimation, Platform, Text, UIManager, View } from "react-native";
 import AddExerciseModal from "../components/AddExerciseModal";
 import CopyWorkoutSheet from "../components/CopyWorkoutSheet";
+import EditWorkoutTimesModal from "../components/EditWorkoutTimesModal";
 import ExerciseCard from "../components/ExerciseCard";
 import WorkoutHeader from "../components/WorkoutHeader";
 import { useRestTimer } from "../hooks/useRestTimer";
@@ -36,6 +37,7 @@ export default function WorkoutScreen() {
     const actions = useWorkoutActions(workout, restTimer);
     const [showAddExercise, setShowAddExercise] = useState(false);
     const [showCopySheet, setShowCopySheet] = useState(false);
+    const [showTimesModal, setShowTimesModal] = useState(false);
 
     // Focus state: which exercise is expanded (null = none)
     const [expandedId, setExpandedId] = useState<number | null>(null);
@@ -80,6 +82,11 @@ export default function WorkoutScreen() {
     function handleFinish() {
         workout.finishCurrentWorkout();
         router.back();
+    }
+
+    function handleSaveTimes(startEpoch: number, endEpoch: number | null) {
+        workout.updateStartTime(startEpoch);
+        if (endEpoch != null) workout.updateEndTime(endEpoch);
     }
 
     function handleBack() {
@@ -141,6 +148,7 @@ export default function WorkoutScreen() {
                 onTitleChange={workout.updateTitle}
                 onFinish={handleFinish}
                 onBack={handleBack}
+                onTimerPress={() => setShowTimesModal(true)}
             />
 
             <FlatList
@@ -193,6 +201,22 @@ export default function WorkoutScreen() {
                     targetWorkoutId={workout.data.workout.id}
                     onClose={() => setShowCopySheet(false)}
                     onCopied={workout.reload}
+                />
+            )}
+
+            {workout.data?.workout && (
+                <EditWorkoutTimesModal
+                    visible={showTimesModal}
+                    onClose={() => setShowTimesModal(false)}
+                    startedAt={workout.data.workout.started_at}
+                    endedAt={workout.data.workout.ended_at}
+                    onSave={handleSaveTimes}
+                    labels={{
+                        title: t("exercise.workout.editTimes"),
+                        startLabel: t("exercise.workout.startedAt"),
+                        endLabel: t("exercise.workout.endedAt"),
+                        save: t("common.save"),
+                    }}
                 />
             )}
         </View>

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -100,7 +100,7 @@ export default function WorkoutScreen() {
     function renderExercise({ item, index }: { item: WorkoutExerciseWithSets; index: number }) {
         const tid = item.workoutExercise.exercise_template_id;
         const timerActive = restTimer.isRunning && restTimer.workoutExerciseId === item.workoutExercise.id;
-        const isExpanded = isFinished || expandedId === item.workoutExercise.id;
+        const isExpanded = expandedId === item.workoutExercise.id;
         return (
             <ExerciseCard
                 item={item}
@@ -153,27 +153,23 @@ export default function WorkoutScreen() {
                     <View style={styles.emptyWrap}>
                         <Ionicons name="barbell-outline" size={48} color={colors.textTertiary} />
                         <Text style={styles.emptyText}>{t("exercise.workout.emptyState")}</Text>
-                        {!isFinished && (
-                            <>
-                                <Button
-                                    title={t("exercise.workout.addExercise")}
-                                    variant="outline"
-                                    icon={<Ionicons name="add" size={18} color={colors.text} />}
-                                    onPress={() => setShowAddExercise(true)}
-                                    style={styles.addBtn}
-                                />
-                                <Button
-                                    title={t("exercise.workout.copyFromHistory")}
-                                    variant="ghost"
-                                    icon={<Ionicons name="copy-outline" size={18} color={colors.primary} />}
-                                    onPress={() => setShowCopySheet(true)}
-                                />
-                            </>
-                        )}
+                        <Button
+                            title={t("exercise.workout.addExercise")}
+                            variant="outline"
+                            icon={<Ionicons name="add" size={18} color={colors.text} />}
+                            onPress={() => setShowAddExercise(true)}
+                            style={styles.addBtn}
+                        />
+                        <Button
+                            title={t("exercise.workout.copyFromHistory")}
+                            variant="ghost"
+                            icon={<Ionicons name="copy-outline" size={18} color={colors.primary} />}
+                            onPress={() => setShowCopySheet(true)}
+                        />
                     </View>
                 }
                 ListFooterComponent={
-                    !isFinished && !isEmpty ? (
+                    !isEmpty ? (
                         <Button
                             title={t("exercise.workout.addExercise")}
                             variant="outline"

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -382,6 +382,7 @@ const de = {
             leaveContinue: "Training fortsetzen",
             leaveFinish: "Speichern & Beenden",
             leaveWithout: "Ohne Beenden verlassen",
+            editTimes: "Trainingszeiten bearbeiten",
         },
         restTimer: {
             rest: "Pause",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -380,6 +380,7 @@ const en = {
             leaveContinue: "Continue Workout",
             leaveFinish: "Save & Finish",
             leaveWithout: "Leave without Finishing",
+            editTimes: "Edit Workout Times",
         },
         restTimer: {
             rest: "Rest",


### PR DESCRIPTION
## Summary

Implements all three improvements from #261:

### 1. Remove view-only mode for finished workouts
All `isFinished` gates that previously locked completed workouts have been removed. Users can now edit set values, delete/add sets, reorder exercises, add/remove exercises, and access all context menu actions after a workout is done. Exercises can also be collapsed/expanded normally.

### 2. Add start/end time editing modal
Tapping the elapsed time in the workout header opens a modal with hour:minute inputs for start and end times. End time only shows for finished workouts. Uses `KeyboardAvoidingView` to stay above the keyboard. Leverages existing `updateStartTime`/`updateEndTime` hooks — no DB changes needed.

### 3. Long-press context menu on collapsed exercises
Long-pressing a collapsed exercise card opens the same context menu (move up/down, add/edit note, copy from last, remove) as the three-dot button in the expanded view.

Closes #261