### PR TITLE
feat: improve copy sets behaviour and add exercise UX

### DIFF
--- a/src/features/exercise/components/AddExerciseModal.tsx
+++ b/src/features/exercise/components/AddExerciseModal.tsx
@@ -25,7 +25,7 @@ import { useExerciseSearch } from "../hooks/useExerciseSearch";
 interface AddExerciseModalProps {
     visible: boolean;
     onClose: () => void;
-    onSelect: (template: ExerciseTemplate) => void;
+    onSelect: (template: ExerciseTemplate, copyFromLast: boolean) => void;
 }
 
 export default function AddExerciseModal({ visible, onClose, onSelect }: AddExerciseModalProps) {
@@ -45,13 +45,13 @@ export default function AddExerciseModal({ visible, onClose, onSelect }: AddExer
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [visible]);
 
-    function handleSelect(template: ExerciseTemplate) {
-        onSelect(template);
+    function handleSelect(template: ExerciseTemplate, copyFromLast: boolean) {
+        onSelect(template, copyFromLast);
     }
 
     function handleCreated(template: ExerciseTemplate) {
         setShowCreate(false);
-        onSelect(template);
+        onSelect(template, false);
     }
 
     function handleCloseSelf() {
@@ -66,6 +66,17 @@ export default function AddExerciseModal({ visible, onClose, onSelect }: AddExer
             : [];
 
     const showList = search.isSearching || !!search.selectedMuscleGroup;
+
+    function renderRow(item: ExerciseTemplate) {
+        return (
+            <ExerciseRow
+                key={item.id}
+                template={item}
+                onAddEmpty={() => handleSelect(item, false)}
+                onAddWithSets={() => handleSelect(item, true)}
+            />
+        );
+    }
 
     return (
         <>
@@ -102,9 +113,21 @@ export default function AddExerciseModal({ visible, onClose, onSelect }: AddExer
                         <FlatList
                             data={listData}
                             keyExtractor={(item) => item.id.toString()}
-                            renderItem={({ item }) => (
-                                <ExerciseRow template={item} onPress={() => handleSelect(item)} />
-                            )}
+                            renderItem={({ item }) => renderRow(item)}
+                            ListHeaderComponent={
+                                !search.isSearching ? (
+                                    <>
+                                        <Text style={styles.sectionLabel}>{t("exercise.addExercise.sectionByMuscle")}</Text>
+                                        <View style={styles.chipContainer}>
+                                            <ChipSelect
+                                                items={MUSCLE_GROUPS.map((mg) => ({ key: mg.key, label: t(mg.labelKey) }))}
+                                                selected={search.selectedMuscleGroup}
+                                                onSelect={(key) => search.handleSelectMuscleGroup(key as MuscleGroup)}
+                                            />
+                                        </View>
+                                    </>
+                                ) : null
+                            }
                             ListEmptyComponent={
                                 <Text style={styles.emptyText}>{t("exercise.addExercise.noResults")}</Text>
                             }
@@ -126,9 +149,7 @@ export default function AddExerciseModal({ visible, onClose, onSelect }: AddExer
                             {search.recentTemplates.length > 0 && (
                                 <>
                                     <Text style={styles.sectionLabel}>{t("exercise.addExercise.sectionRecent")}</Text>
-                                    {search.recentTemplates.map((item) => (
-                                        <ExerciseRow key={item.id} template={item} onPress={() => handleSelect(item)} />
-                                    ))}
+                                    {search.recentTemplates.map((item) => renderRow(item))}
                                 </>
                             )}
                         </ScrollView>

--- a/src/features/exercise/components/ExerciseRow.tsx
+++ b/src/features/exercise/components/ExerciseRow.tsx
@@ -2,20 +2,23 @@ import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import type { ExerciseTemplate } from "../services/exerciseDb";
 
 interface ExerciseRowProps {
     template: ExerciseTemplate;
-    onPress: () => void;
+    onAddEmpty: () => void;
+    onAddWithSets: () => void;
 }
 
-export default function ExerciseRow({ template, onPress }: ExerciseRowProps) {
+export default function ExerciseRow({ template, onAddEmpty, onAddWithSets }: ExerciseRowProps) {
     const colors = useThemeColors();
+    const { t } = useTranslation();
     const styles = useMemo(() => createRowStyles(colors), [colors]);
 
     return (
-        <Pressable onPress={onPress} style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}>
+        <View style={styles.row}>
             <View style={styles.info}>
                 <Text style={styles.name}>{template.name}</Text>
                 {(template.muscle_group || template.equipment) && (
@@ -24,8 +27,23 @@ export default function ExerciseRow({ template, onPress }: ExerciseRowProps) {
                     </Text>
                 )}
             </View>
-            <Ionicons name="chevron-forward" size={16} color={colors.textTertiary} />
-        </Pressable>
+            <Pressable
+                onPress={onAddEmpty}
+                hitSlop={8}
+                style={({ pressed }) => [styles.iconBtn, pressed && styles.iconBtnPressed]}
+                accessibilityLabel={t("exercise.addExercise.addEmpty")}
+            >
+                <Ionicons name="add-circle-outline" size={22} color={colors.primary} />
+            </Pressable>
+            <Pressable
+                onPress={onAddWithSets}
+                hitSlop={8}
+                style={({ pressed }) => [styles.iconBtn, pressed && styles.iconBtnPressed]}
+                accessibilityLabel={t("exercise.addExercise.addWithSets")}
+            >
+                <Ionicons name="copy-outline" size={20} color={colors.primary} />
+            </Pressable>
+        </View>
     );
 }
 
@@ -39,9 +57,13 @@ function createRowStyles(colors: ThemeColors) {
             borderBottomWidth: StyleSheet.hairlineWidth,
             borderBottomColor: colors.border,
         },
-        rowPressed: { backgroundColor: colors.primaryLight },
         info: { flex: 1 },
         name: { fontSize: fontSize.md, color: colors.text, fontWeight: "500" },
         meta: { fontSize: fontSize.sm, color: colors.textSecondary, marginTop: 2 },
+        iconBtn: {
+            padding: spacing.xs,
+            marginLeft: spacing.sm,
+        },
+        iconBtnPressed: { opacity: 0.5 },
     });
 }

--- a/src/features/exercise/components/ExpandedExerciseCard.tsx
+++ b/src/features/exercise/components/ExpandedExerciseCard.tsx
@@ -72,7 +72,11 @@ export function ExpandedExerciseCard({
         if (template) {
             router.push({
                 pathname: "/workout/exercise-history",
-                params: { templateId: String(template.id), name: template.name },
+                params: {
+                    templateId: String(template.id),
+                    name: template.name,
+                    workoutExerciseId: String(item.workoutExercise.id),
+                },
             });
         }
     }

--- a/src/features/exercise/components/ReadOnlyExerciseCard.tsx
+++ b/src/features/exercise/components/ReadOnlyExerciseCard.tsx
@@ -1,0 +1,155 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
+import type { ExerciseType } from "../types";
+
+interface ReadOnlyExerciseCardProps {
+    item: WorkoutExerciseWithSets;
+    onCopy?: () => void;
+}
+
+export default function ReadOnlyExerciseCard({ item, onCopy }: ReadOnlyExerciseCardProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const exerciseType: ExerciseType = (item.exerciseTemplate?.type as ExerciseType) ?? "weight";
+    const completedSets = item.sets.filter((s) => !!s.completed_at);
+
+    return (
+        <View style={styles.card}>
+            {/* Title row: date + copy icon */}
+            <View style={styles.titleRow}>
+                <Text style={styles.dateText}>{item.workout.date}</Text>
+                {onCopy && (
+                    <Pressable onPress={onCopy} hitSlop={8}>
+                        <Ionicons name="copy-outline" size={18} color={colors.primary} />
+                    </Pressable>
+                )}
+            </View>
+
+            {/* Column headers */}
+            <View style={styles.headerRow}>
+                <Text style={[styles.headerCell, styles.setCol]}>{t("exercise.exerciseCard.set")}</Text>
+                {exerciseType === "weight" && (
+                    <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.weight")}</Text>
+                )}
+                {exerciseType !== "cardio" && (
+                    <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.reps")}</Text>
+                )}
+                {exerciseType === "cardio" && (
+                    <>
+                        <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.duration")}</Text>
+                        <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.distance")}</Text>
+                    </>
+                )}
+                {exerciseType !== "cardio" && (
+                    <Text style={[styles.headerCell, styles.rirCol]}>{t("exercise.exerciseCard.rir")}</Text>
+                )}
+            </View>
+
+            {/* Set rows */}
+            {completedSets.map((set, i) => (
+                <ReadOnlySetRow key={set.id} set={set} index={i} exerciseType={exerciseType} styles={styles} colors={colors} />
+            ))}
+
+            {completedSets.length === 0 && (
+                <Text style={styles.emptyText}>{t("exercise.exerciseCard.noSetsYet")}</Text>
+            )}
+        </View>
+    );
+}
+
+function ReadOnlySetRow({ set, index, exerciseType, styles, colors }: {
+    set: ExerciseSet; index: number; exerciseType: ExerciseType;
+    styles: ReturnType<typeof createStyles>; colors: ReturnType<typeof useThemeColors>;
+}) {
+    const textColor = colors.text;
+    return (
+        <View style={styles.setRow}>
+            <Text style={[styles.setCell, styles.setCol, { color: colors.textSecondary }]}>{index + 1}</Text>
+            {exerciseType === "weight" && (
+                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>
+                    {set.weight != null ? `${set.weight} ${set.weight_unit}` : "—"}
+                </Text>
+            )}
+            {exerciseType !== "cardio" && (
+                <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>
+                    {set.reps ?? "—"}
+                </Text>
+            )}
+            {exerciseType === "cardio" && (
+                <>
+                    <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>
+                        {set.duration_seconds ? `${set.duration_seconds}s` : "—"}
+                    </Text>
+                    <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>
+                        {set.distance_meters ? `${set.distance_meters}m` : "—"}
+                    </Text>
+                </>
+            )}
+            {exerciseType !== "cardio" && (
+                <Text style={[styles.setCell, styles.rirCol, { color: textColor }]}>
+                    {set.rir ?? "—"}
+                </Text>
+            )}
+        </View>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        card: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.md,
+            marginBottom: spacing.sm,
+        },
+        titleRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            marginBottom: spacing.sm,
+        },
+        dateText: {
+            flex: 1,
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.text,
+        },
+        headerRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            paddingBottom: spacing.xs,
+            borderBottomWidth: 1,
+            borderBottomColor: colors.border,
+            marginBottom: spacing.xs,
+        },
+        headerCell: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            textTransform: "uppercase",
+        },
+        setCol: { width: 32 },
+        valueCol: { flex: 1, textAlign: "center" },
+        rirCol: { width: 36, textAlign: "center" },
+        setRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            paddingVertical: spacing.xs,
+        },
+        setCell: {
+            fontSize: fontSize.sm,
+            textAlign: "center",
+        },
+        emptyText: {
+            fontSize: fontSize.sm,
+            color: colors.textTertiary,
+            textAlign: "center",
+            paddingVertical: spacing.sm,
+        },
+    });
+}

--- a/src/features/exercise/screens/ExerciseHistoryScreen.tsx
+++ b/src/features/exercise/screens/ExerciseHistoryScreen.tsx
@@ -1,22 +1,31 @@
 import { useExerciseHistory } from "@/src/features/exercise/hooks/useExerciseHistory";
-import { getExerciseTemplateById, type ExerciseTemplate } from "@/src/features/exercise/services/exerciseDb";
+import {
+    copySetsFromWorkoutExercise,
+    getExerciseTemplateById,
+    type ExerciseTemplate,
+} from "@/src/features/exercise/services/exerciseDb";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { Ionicons } from "@expo/vector-icons";
-import { Stack, useLocalSearchParams } from "expo-router";
-import React, { useMemo } from "react";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import React, { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { ActivityIndicator, FlatList, StyleSheet, Text, View } from "react-native";
+import { ActivityIndicator, Alert, FlatList, StyleSheet, Text, View } from "react-native";
 import { LineChart } from "react-native-gifted-charts";
 import { kgToLb } from "../helpers/exerciseUnits";
-import { formatRirRange, formatSetSummary } from "../helpers/workoutSummary";
+import ReadOnlyExerciseCard from "../components/ReadOnlyExerciseCard";
 
 export default function ExerciseHistoryScreen() {
     const colors = useThemeColors();
     const { t } = useTranslation();
     const styles = useMemo(() => createStyles(colors), [colors]);
-    const { templateId } = useLocalSearchParams<{ templateId: string }>();
+    const router = useRouter();
+    const { templateId, workoutExerciseId } = useLocalSearchParams<{
+        templateId: string;
+        workoutExerciseId?: string;
+    }>();
     const parsedId = templateId ? Number(templateId) : undefined;
+    const parsedWeId = workoutExerciseId ? Number(workoutExerciseId) : undefined;
 
     const template: ExerciseTemplate | undefined = useMemo(
         () => (parsedId ? getExerciseTemplateById(parsedId) : undefined),
@@ -44,6 +53,17 @@ export default function ExerciseHistoryScreen() {
     const currentE1rm = e1rmSeries.length > 0
         ? toDisplayUnit(e1rmSeries[e1rmSeries.length - 1].e1rm)
         : null;
+
+    const handleCopySets = useCallback((sourceWeId: number) => {
+        if (!parsedWeId) return;
+        const count = copySetsFromWorkoutExercise(sourceWeId, parsedWeId);
+        if (count > 0) {
+            Alert.alert(t("exercise.history.copiedSets", { count }));
+            router.back();
+        } else {
+            Alert.alert(t("exercise.history.noSetsInSession"));
+        }
+    }, [parsedWeId, t, router]);
 
     if (isLoading) {
         return (
@@ -118,21 +138,12 @@ export default function ExerciseHistoryScreen() {
                         )}
                     </>
                 }
-                renderItem={({ item }) => {
-                    const summary = formatSetSummary(item.sets);
-                    const rir = formatRirRange(item.sets);
-                    return (
-                        <View style={styles.historyRow}>
-                            <Text style={styles.historyDate}>
-                                {item.workout.date}
-                            </Text>
-                            <Text style={styles.historySummary} numberOfLines={1}>
-                                {summary}
-                                {rir ? `  ${rir}` : ""}
-                            </Text>
-                        </View>
-                    );
-                }}
+                renderItem={({ item }) => (
+                    <ReadOnlyExerciseCard
+                        item={item}
+                        onCopy={parsedWeId ? () => handleCopySets(item.workoutExercise.id) : undefined}
+                    />
+                )}
                 ListEmptyComponent={
                     <View style={styles.center}>
                         <Ionicons name="bar-chart-outline" size={48} color={colors.textTertiary} />
@@ -176,22 +187,6 @@ function createStyles(colors: ThemeColors) {
             letterSpacing: 0.5,
             marginTop: spacing.sm,
             marginBottom: spacing.sm,
-        },
-        historyRow: {
-            backgroundColor: colors.surface,
-            borderRadius: borderRadius.md,
-            padding: spacing.md,
-            marginBottom: spacing.sm,
-        },
-        historyDate: {
-            fontSize: fontSize.sm,
-            fontWeight: "600",
-            color: colors.text,
-            marginBottom: 2,
-        },
-        historySummary: {
-            fontSize: fontSize.sm,
-            color: colors.textSecondary,
         },
         emptyText: {
             fontSize: fontSize.md,

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -68,10 +68,12 @@ export default function WorkoutScreen() {
         }, 100);
     }, []);
 
-    function handleExerciseSelected(template: ExerciseTemplate) {
+    function handleExerciseSelected(template: ExerciseTemplate, copyFromLast: boolean) {
         const weId = workout.addExercise(template.id);
         if (weId) {
-            copySetsFromLastSession(template.id, weId);
+            if (copyFromLast) {
+                copySetsFromLastSession(template.id, weId);
+            }
             LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
             setExpandedId(weId);
         }

--- a/src/features/exercise/services/exerciseDb.ts
+++ b/src/features/exercise/services/exerciseDb.ts
@@ -33,6 +33,7 @@ export {
     addSet,
     completeSet,
     copySetsFromLastSession,
+    copySetsFromWorkoutExercise,
     deleteSet,
     getLastCompletedSetsForTemplate,
     getSetsForExercise,

--- a/src/features/exercise/services/exerciseSetDb.ts
+++ b/src/features/exercise/services/exerciseSetDb.ts
@@ -1,7 +1,7 @@
 import exerciseDbSupport from "@/src/features/exercise/services/exerciseDbSupport";
 import { db } from "@/src/services/db";
 import { exerciseSets, workoutExercises, workouts } from "@/src/services/db/schema";
-import { and, asc, desc, eq, isNotNull } from "drizzle-orm";
+import { and, desc, eq, isNotNull } from "drizzle-orm";
 
 export type ExerciseSet = typeof exerciseSets.$inferSelect;
 export type NewExerciseSet = typeof exerciseSets.$inferInsert;
@@ -58,6 +58,34 @@ export function getLastCompletedSetsForTemplate(templateId: number): ExerciseSet
 /** Copies sets from a historical template instance into a target workout_exercise as scheduled. */
 export function copySetsFromLastSession(templateId: number, targetWorkoutExerciseId: number): number {
     const sourceSets = getLastCompletedSetsForTemplate(templateId);
+    if (sourceSets.length === 0) return 0;
+
+    const existing = exerciseDbSupport.listSetsForExercise(targetWorkoutExerciseId);
+    let order = existing.length + 1;
+
+    for (const s of sourceSets) {
+        db.insert(exerciseSets)
+            .values({
+                workout_exercise_id: targetWorkoutExerciseId,
+                set_order: order++,
+                type: s.type,
+                weight: s.weight,
+                weight_unit: s.weight_unit,
+                reps: s.reps,
+                duration_seconds: s.duration_seconds,
+                distance_meters: s.distance_meters,
+                rir: s.rir,
+                rest_seconds: s.rest_seconds,
+                is_scheduled: 1,
+            })
+            .run();
+    }
+    return sourceSets.length;
+}
+
+/** Copies completed sets from a specific workout exercise into a target as scheduled. */
+export function copySetsFromWorkoutExercise(sourceWorkoutExerciseId: number, targetWorkoutExerciseId: number): number {
+    const sourceSets = exerciseDbSupport.listSetsForExercise(sourceWorkoutExerciseId).filter((s) => !!s.completed_at);
     if (sourceSets.length === 0) return 0;
 
     const existing = exerciseDbSupport.listSetsForExercise(targetWorkoutExerciseId);

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -339,6 +339,8 @@ const de = {
             sectionByMuscle: "NACH MUSKELGRUPPE",
             createNew: "Neue Übung erstellen",
             noResults: "Keine Übungen gefunden",
+            addEmpty: "Leer hinzufügen",
+            addWithSets: "Mit letzten Sätzen",
         },
         createExercise: {
             title: "Neue Übung",
@@ -401,6 +403,8 @@ const de = {
             current: "Aktuell",
             copyToCurrent: "Sätze übernehmen",
             noHistory: "Noch kein Verlauf",
+            copiedSets: "{{count}} Sätze kopiert",
+            noSetsInSession: "Keine abgeschlossenen Sätze in dieser Einheit",
         },
         copyWorkout: {
             title: "Aus Verlauf starten",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -338,6 +338,8 @@ const en = {
             sectionByMuscle: "BY MUSCLE GROUP",
             createNew: "Create New Exercise",
             noResults: "No exercises found",
+            addEmpty: "Add empty",
+            addWithSets: "Add with last sets",
         },
         createExercise: {
             title: "New Exercise",
@@ -399,6 +401,8 @@ const en = {
             current: "Current",
             copyToCurrent: "Copy Sets to Current",
             noHistory: "No history yet",
+            copiedSets: "Copied {{count}} sets",
+            noSetsInSession: "No completed sets in this session",
         },
         copyWorkout: {
             title: "Start from History",


### PR DESCRIPTION
## Summary

Closes #263

### Changes

**Add Exercise Modal:**
- ExerciseRow now shows two action icons instead of a forward chevron:
  - `add-circle-outline` — adds an empty exercise (no sets copied)
  - `copy-outline` — adds exercise with sets copied from the most recent session
- Muscle group chips remain visible after selection (no longer disappear when a group is picked). Pressing the selected chip deselects it.

**Exercise History Screen:**
- History entries now show full read-only exercise cards (date + set details table) instead of compact summary rows
- Each card has a copy icon that imports the sets from that specific session as scheduled sets into the current exercise
- The screen receives the current `workoutExerciseId` to know where to copy sets

**Database:**
- New `copySetsFromWorkoutExercise()` function to copy sets from any specific historical workout exercise (not just the last session)

**i18n:**
- Added English and German translation keys for new UI elements
