### PR TITLE
feat: manage exercise templates (edit & hard delete)

### DIFF
--- a/src/features/exercise/components/CreateExerciseModal.tsx
+++ b/src/features/exercise/components/CreateExerciseModal.tsx
@@ -3,7 +3,7 @@ import Input from "@/src/shared/atoms/Input";
 import ModalHeader from "@/src/shared/atoms/ModalHeader";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
     KeyboardAvoidingView,
@@ -16,20 +16,22 @@ import {
     View,
 } from "react-native";
 import { EQUIPMENT_LIST, EXERCISE_TYPES, MUSCLE_GROUPS } from "../constants";
-import { createExerciseTemplate, type ExerciseTemplate } from "../services/exerciseDb";
+import { createExerciseTemplate, getExerciseTemplateById, updateExerciseTemplate, type ExerciseTemplate } from "../services/exerciseDb";
 import type { Equipment, ExerciseType, MuscleGroup, ResistanceMode, WeightUnit } from "../types";
 import ChipSelect from "./ChipSelect";
 
 interface CreateExerciseModalProps {
     visible: boolean;
+    exerciseId?: number;
     onClose: () => void;
     onCreated: (template: ExerciseTemplate) => void;
 }
 
-export default function CreateExerciseModal({ visible, onClose, onCreated }: CreateExerciseModalProps) {
+export default function CreateExerciseModal({ visible, exerciseId, onClose, onCreated }: CreateExerciseModalProps) {
     const colors = useThemeColors();
     const { t } = useTranslation();
     const styles = useMemo(() => createStyles(colors), [colors]);
+    const isEditing = exerciseId != null;
 
     const [name, setName] = useState("");
     const [type, setType] = useState<ExerciseType>("weight");
@@ -38,6 +40,18 @@ export default function CreateExerciseModal({ visible, onClose, onCreated }: Cre
     const [resistanceMode, setResistanceMode] = useState<ResistanceMode>("resistance");
     const [defaultUnit, setDefaultUnit] = useState<WeightUnit>("kg");
     const [nameError, setNameError] = useState(false);
+
+    useEffect(() => {
+        if (!visible || exerciseId == null) return;
+        const existing = getExerciseTemplateById(exerciseId);
+        if (!existing) return;
+        setName(existing.name);
+        setType((existing.type as ExerciseType) ?? "weight");
+        setMuscleGroup((existing.muscle_group as MuscleGroup) ?? null);
+        setEquipment((existing.equipment as Equipment) ?? null);
+        setResistanceMode((existing.resistance_mode as ResistanceMode) ?? "resistance");
+        setDefaultUnit((existing.default_weight_unit as WeightUnit) ?? "kg");
+    }, [visible, exerciseId]);
 
     function resetForm() {
         setName("");
@@ -60,16 +74,30 @@ export default function CreateExerciseModal({ visible, onClose, onCreated }: Cre
             setNameError(true);
             return;
         }
-        const template = createExerciseTemplate({
-            name: trimmed,
-            type,
-            muscle_group: muscleGroup,
-            equipment,
-            resistance_mode: resistanceMode,
-            default_weight_unit: defaultUnit,
-        });
-        resetForm();
-        onCreated(template);
+        if (isEditing) {
+            updateExerciseTemplate(exerciseId, {
+                name: trimmed,
+                type,
+                muscle_group: muscleGroup,
+                equipment,
+                resistance_mode: resistanceMode,
+                default_weight_unit: defaultUnit,
+            });
+            const updated = getExerciseTemplateById(exerciseId)!;
+            resetForm();
+            onCreated(updated);
+        } else {
+            const template = createExerciseTemplate({
+                name: trimmed,
+                type,
+                muscle_group: muscleGroup,
+                equipment,
+                resistance_mode: resistanceMode,
+                default_weight_unit: defaultUnit,
+            });
+            resetForm();
+            onCreated(template);
+        }
     }
 
     return (
@@ -83,7 +111,7 @@ export default function CreateExerciseModal({ visible, onClose, onCreated }: Cre
                 behavior={Platform.OS === "ios" ? "padding" : undefined}
                 style={styles.flex}
             >
-                <ModalHeader title={t("exercise.createExercise.title")} onClose={handleClose} />
+                <ModalHeader title={t(isEditing ? "exercise.createExercise.editTitle" : "exercise.createExercise.title")} onClose={handleClose} />
                 <ScrollView
                     contentContainerStyle={styles.form}
                     keyboardShouldPersistTaps="handled"

--- a/src/features/exercise/screens/CreateExerciseScreen.tsx
+++ b/src/features/exercise/screens/CreateExerciseScreen.tsx
@@ -1,10 +1,14 @@
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
 import CreateExerciseModal from "../components/CreateExerciseModal";
 
 export default function CreateExerciseScreen() {
+    const { exerciseId } = useLocalSearchParams<{ exerciseId?: string }>();
+    const parsedId = exerciseId ? Number(exerciseId) : undefined;
+
     return (
         <CreateExerciseModal
             visible
+            exerciseId={parsedId}
             onClose={() => router.back()}
             onCreated={() => router.back()}
         />

--- a/src/features/exercise/services/exerciseDb.ts
+++ b/src/features/exercise/services/exerciseDb.ts
@@ -1,6 +1,7 @@
 // Barrel — re-exports from domain-focused modules for backward compatibility.
 export {
     createExerciseTemplate,
+    deleteExerciseTemplate,
     getAllExerciseTemplates,
     getExerciseTemplateById,
     getExerciseTemplatesByMuscleGroup,

--- a/src/features/exercise/services/exerciseTemplateDb.ts
+++ b/src/features/exercise/services/exerciseTemplateDb.ts
@@ -1,6 +1,6 @@
 import exerciseDbSupport from "@/src/features/exercise/services/exerciseDbSupport";
 import { db } from "@/src/services/db";
-import { exerciseTemplates, workoutExercises, workouts } from "@/src/services/db/schema";
+import { exerciseSets, exerciseTemplates, workoutExercises, workouts } from "@/src/services/db/schema";
 import { formatDateKey, shiftCalendarDate } from "@/src/utils/date";
 import { and, asc, desc, eq, gte, like, sql } from "drizzle-orm";
 
@@ -88,4 +88,18 @@ export function updateExerciseTemplate(id: number, data: Partial<NewExerciseTemp
 export function softDeleteExerciseTemplate(id: number) {
     exerciseDbSupport.getExerciseTemplateOrThrow(id);
     db.update(exerciseTemplates).set({ deleted: 1 }).where(eq(exerciseTemplates.id, id)).run();
+}
+
+export function deleteExerciseTemplate(id: number) {
+    exerciseDbSupport.getExerciseTemplateOrThrow(id);
+    const exercises = db
+        .select({ id: workoutExercises.id })
+        .from(workoutExercises)
+        .where(eq(workoutExercises.exercise_template_id, id))
+        .all();
+    for (const we of exercises) {
+        db.delete(exerciseSets).where(eq(exerciseSets.workout_exercise_id, we.id)).run();
+    }
+    db.delete(workoutExercises).where(eq(workoutExercises.exercise_template_id, id)).run();
+    db.delete(exerciseTemplates).where(eq(exerciseTemplates.id, id)).run();
 }

--- a/src/features/templates/components/TemplateCard.tsx
+++ b/src/features/templates/components/TemplateCard.tsx
@@ -29,13 +29,13 @@ export default function TemplateCard({ kind, data, subtitle, onDelete }: Templat
             router.push({ pathname: "/templates/edit", params: { recipeId: String(data.id) } } as unknown as Href);
         } else if (kind === "food") {
             router.push({ pathname: "/templates/food-edit", params: { foodId: String(data.id) } } as unknown as Href);
+        } else {
+            router.push({ pathname: "/templates/exercise-edit", params: { exerciseId: String(data.id) } } as unknown as Href);
         }
     }
 
-    const Wrapper = kind === "exercise" ? View : Pressable;
-
     return (
-        <Wrapper style={styles.card} {...(kind !== "exercise" && { onPress: handlePress })}>
+        <Pressable style={styles.card} onPress={handlePress}>
             <Ionicons name={config.icon} size={22} color={config.color} style={styles.cardIcon} />
             <View style={styles.cardInfo}>
                 <Text style={styles.cardName} numberOfLines={1}>{data.name}</Text>
@@ -44,7 +44,7 @@ export default function TemplateCard({ kind, data, subtitle, onDelete }: Templat
             <Pressable onPress={onDelete} hitSlop={8}>
                 <Ionicons name="trash-outline" size={20} color={colors.danger} />
             </Pressable>
-        </Wrapper>
+        </Pressable>
     );
 }
 

--- a/src/features/templates/hooks/useTemplateList.ts
+++ b/src/features/templates/hooks/useTemplateList.ts
@@ -1,5 +1,6 @@
 import {
     type ExerciseTemplate,
+    deleteExerciseTemplate,
     getAllExerciseTemplates,
     searchExerciseTemplates,
     softDeleteExerciseTemplate,
@@ -115,15 +116,23 @@ export function useTemplateList() {
     function handleDeleteExercise(exercise: ExerciseTemplate) {
         Alert.alert(
             t("templates.deleteExercise"),
-            t("templates.deleteExerciseConfirm", { name: exercise.name }),
+            t("templates.deleteTitle"),
             [
                 { text: t("common.cancel"), style: "cancel" },
                 {
-                    text: t("common.delete"),
-                    style: "destructive",
+                    text: t("templates.deleteFutureOnly"),
                     onPress: () => {
                         softDeleteExerciseTemplate(exercise.id);
                         logger.info("[DB] Soft-deleted exercise template", { id: exercise.id });
+                        load();
+                    },
+                },
+                {
+                    text: t("templates.deleteEverything"),
+                    style: "destructive",
+                    onPress: () => {
+                        deleteExerciseTemplate(exercise.id);
+                        logger.info("[DB] Deleted exercise template", { id: exercise.id });
                         load();
                     },
                 },

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -349,6 +349,7 @@ const de = {
         },
         createExercise: {
             title: "Neue Übung",
+            editTitle: "Übung bearbeiten",
             name: "Name",
             namePlaceholder: "z. B. Bankdrücken",
             type: "Typ",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -348,6 +348,7 @@ const en = {
         },
         createExercise: {
             title: "New Exercise",
+            editTitle: "Edit Exercise",
             name: "Name",
             namePlaceholder: "e.g., Bench Press",
             type: "Type",


### PR DESCRIPTION
## Summary

- Tapping an exercise template card now navigates to the exercise editor pre-filled with all existing values
- The exercise delete dialog now shows the same two-tier options used by food/recipe templates:
  - **Keep past entries** (soft delete – hides template from searches)
  - **Delete everything** (hard delete – cascades to workout exercises & sets)

Closes #267