### PR TITLE
feat: add exercise logging and all DB tables to import/export

### DIFF
--- a/src/features/settings/services/importExport.ts
+++ b/src/features/settings/services/importExport.ts
@@ -1,5 +1,22 @@
 import { db } from "@/src/services/db";
-import { entries, foods, goals, recipeItems, recipeLogs, recipes, servingUnits, weightLogs } from "@/src/services/db/schema";
+import {
+    aiMemories,
+    chatMessages,
+    chatSessions,
+    entries,
+    exerciseSets,
+    exerciseTemplates,
+    foods,
+    goals,
+    notificationSettings,
+    recipeItems,
+    recipeLogs,
+    recipes,
+    servingUnits,
+    weightLogs,
+    workoutExercises,
+    workouts,
+} from "@/src/services/db/schema";
 import * as DocumentPicker from "expo-document-picker";
 import { File, Paths } from "expo-file-system";
 import * as Sharing from "expo-sharing";
@@ -17,6 +34,14 @@ interface ExportPayload {
     recipeLogs?: (typeof recipeLogs.$inferSelect)[];
     weightLogs?: (typeof weightLogs.$inferSelect)[];
     servingUnits?: (typeof servingUnits.$inferSelect)[];
+    notificationSettings?: (typeof notificationSettings.$inferSelect)[];
+    chatSessions?: (typeof chatSessions.$inferSelect)[];
+    chatMessages?: (typeof chatMessages.$inferSelect)[];
+    aiMemories?: (typeof aiMemories.$inferSelect)[];
+    exerciseTemplates?: (typeof exerciseTemplates.$inferSelect)[];
+    workouts?: (typeof workouts.$inferSelect)[];
+    workoutExercises?: (typeof workoutExercises.$inferSelect)[];
+    exerciseSets?: (typeof exerciseSets.$inferSelect)[];
 }
 
 // ── Export ──────────────────────────────────────────────────
@@ -33,6 +58,14 @@ export async function exportData(): Promise<void> {
         recipeLogs: db.select().from(recipeLogs).all(),
         weightLogs: db.select().from(weightLogs).all(),
         servingUnits: db.select().from(servingUnits).all(),
+        notificationSettings: db.select().from(notificationSettings).all(),
+        chatSessions: db.select().from(chatSessions).all(),
+        chatMessages: db.select().from(chatMessages).all(),
+        aiMemories: db.select().from(aiMemories).all(),
+        exerciseTemplates: db.select().from(exerciseTemplates).all(),
+        workouts: db.select().from(workouts).all(),
+        workoutExercises: db.select().from(workoutExercises).all(),
+        exerciseSets: db.select().from(exerciseSets).all(),
     };
 
     const json = JSON.stringify(payload, null, 2);
@@ -68,7 +101,14 @@ export async function importData(): Promise<{ inserted: number }> {
 
     // Wrap everything in a transaction so partial imports don't corrupt the DB
     db.transaction((tx) => {
-        // Clear existing data (order matters for FK constraints)
+        // Clear existing data (order matters for FK constraints — children first)
+        tx.delete(exerciseSets).run();
+        tx.delete(workoutExercises).run();
+        tx.delete(workouts).run();
+        tx.delete(exerciseTemplates).run();
+        tx.delete(chatMessages).run();
+        tx.delete(chatSessions).run();
+        tx.delete(aiMemories).run();
         tx.delete(entries).run();
         tx.delete(recipeLogs).run();
         tx.delete(recipeItems).run();
@@ -76,6 +116,7 @@ export async function importData(): Promise<{ inserted: number }> {
         tx.delete(servingUnits).run();
         tx.delete(foods).run();
         tx.delete(weightLogs).run();
+        tx.delete(notificationSettings).run();
 
         for (const row of data.foods) {
             tx.insert(foods).values(row).run();
@@ -118,6 +159,54 @@ export async function importData(): Promise<{ inserted: number }> {
             }
             inserted++;
         }
+        if (data.notificationSettings) {
+            for (const row of data.notificationSettings) {
+                tx.insert(notificationSettings).values(row).run();
+                inserted++;
+            }
+        }
+        if (data.aiMemories) {
+            for (const row of data.aiMemories) {
+                tx.insert(aiMemories).values(row).run();
+                inserted++;
+            }
+        }
+        if (data.chatSessions) {
+            for (const row of data.chatSessions) {
+                tx.insert(chatSessions).values(row).run();
+                inserted++;
+            }
+        }
+        if (data.chatMessages) {
+            for (const row of data.chatMessages) {
+                tx.insert(chatMessages).values(row).run();
+                inserted++;
+            }
+        }
+        if (data.exerciseTemplates) {
+            for (const row of data.exerciseTemplates) {
+                tx.insert(exerciseTemplates).values(row).run();
+                inserted++;
+            }
+        }
+        if (data.workouts) {
+            for (const row of data.workouts) {
+                tx.insert(workouts).values(row).run();
+                inserted++;
+            }
+        }
+        if (data.workoutExercises) {
+            for (const row of data.workoutExercises) {
+                tx.insert(workoutExercises).values(row).run();
+                inserted++;
+            }
+        }
+        if (data.exerciseSets) {
+            for (const row of data.exerciseSets) {
+                tx.insert(exerciseSets).values(row).run();
+                inserted++;
+            }
+        }
     });
 
     return { inserted };
@@ -147,5 +236,29 @@ function validate(data: unknown): asserts data is ExportPayload {
     }
     if (d.servingUnits !== undefined && !Array.isArray(d.servingUnits)) {
         throw new Error(`Invalid backup file: "servingUnits" must be an array.`);
+    }
+    if (d.notificationSettings !== undefined && !Array.isArray(d.notificationSettings)) {
+        throw new Error(`Invalid backup file: "notificationSettings" must be an array.`);
+    }
+    if (d.chatSessions !== undefined && !Array.isArray(d.chatSessions)) {
+        throw new Error(`Invalid backup file: "chatSessions" must be an array.`);
+    }
+    if (d.chatMessages !== undefined && !Array.isArray(d.chatMessages)) {
+        throw new Error(`Invalid backup file: "chatMessages" must be an array.`);
+    }
+    if (d.aiMemories !== undefined && !Array.isArray(d.aiMemories)) {
+        throw new Error(`Invalid backup file: "aiMemories" must be an array.`);
+    }
+    if (d.exerciseTemplates !== undefined && !Array.isArray(d.exerciseTemplates)) {
+        throw new Error(`Invalid backup file: "exerciseTemplates" must be an array.`);
+    }
+    if (d.workouts !== undefined && !Array.isArray(d.workouts)) {
+        throw new Error(`Invalid backup file: "workouts" must be an array.`);
+    }
+    if (d.workoutExercises !== undefined && !Array.isArray(d.workoutExercises)) {
+        throw new Error(`Invalid backup file: "workoutExercises" must be an array.`);
+    }
+    if (d.exerciseSets !== undefined && !Array.isArray(d.exerciseSets)) {
+        throw new Error(`Invalid backup file: "exerciseSets" must be an array.`);
     }
 }


### PR DESCRIPTION
Closes #268

## Changes
- Added all exercise logging tables to import/export: `exerciseTemplates`, `workouts`, `workoutExercises`, `exerciseSets`
- Added remaining DB tables: `notificationSettings`, `chatSessions`, `chatMessages`, `aiMemories`
- All new fields are optional in `ExportPayload` for backwards compatibility with older backups
- Updated delete order in the transaction to respect FK constraints (children deleted first)
- Added validation for each new optional array field