### PR TITLE
fix(log): Remove workout overlay button from Logs screen

### DIFF
--- a/src/features/log/hooks/useLogData.ts
+++ b/src/features/log/hooks/useLogData.ts
@@ -170,10 +170,6 @@ export function useLogData() {
         router.push({ pathname: "/log/add", params: mealType ? { mealType } : undefined });
     };
 
-    const navigateToWorkout = () => {
-        router.push({ pathname: "/workout", params: { date: formatDateKey(selectedDate) } });
-    };
-
     function exitSelectionMode() { setSelectionMode(false); setSelectedEntryIds(new Set()); }
 
     function handleToggleEntries(entryIds: number[]) {
@@ -242,7 +238,7 @@ export function useLogData() {
         handleConfirmEntry, handleConfirmRecipeLog,
         handleAddWeight, handleDeleteWeight,
         handleEdit, handleEditRecipeGroup, handleSavePortionMultiplier,
-        navigateToAdd, navigateToWorkout, exitSelectionMode,
+        navigateToAdd, exitSelectionMode,
         handleToggleEntries, handleActivateSelection, handleActivateSelectionMultiple,
         handleMoveCopy, handleDateChange,
         loadAllDays, SCREEN_WIDTH,

--- a/src/features/log/screens/LogScreen.tsx
+++ b/src/features/log/screens/LogScreen.tsx
@@ -156,14 +156,6 @@ export default function LogScreen() {
                 <Ionicons name={d.selectionMode ? "move-outline" : "add"} size={28} color="#fff" />
             </Pressable>
 
-            {!d.selectionMode && (
-                <Pressable
-                    style={({ pressed }) => [styles.fabSecondary, { bottom: d.chatBarVisible ? CHAT_BAR_TOTAL_HEIGHT + 8 : 24 }, pressed && styles.fabPressed]}
-                    onPress={d.navigateToWorkout}
-                >
-                    <Ionicons name="barbell-outline" size={24} color="#fff" />
-                </Pressable>
-            )}
 
             <Modal visible={!!d.editingRecipeGroup} transparent animationType="fade" onRequestClose={() => d.setEditingRecipeGroup(null)}>
                 <Pressable style={styles.overlay} onPress={() => d.setEditingRecipeGroup(null)}>
@@ -217,12 +209,6 @@ function createStyles(colors: ThemeColors) {
         fab: {
             position: "absolute", right: 24, width: 56, height: 56, borderRadius: 28,
             backgroundColor: colors.primary, alignItems: "center", justifyContent: "center",
-            elevation: 4, shadowColor: "#000", shadowOffset: { width: 0, height: 2 },
-            shadowOpacity: 0.25, shadowRadius: 4,
-        },
-        fabSecondary: {
-            position: "absolute", right: 92, width: 48, height: 48, borderRadius: 24,
-            backgroundColor: colors.weight, alignItems: "center", justifyContent: "center",
             elevation: 4, shadowColor: "#000", shadowOffset: { width: 0, height: 2 },
             shadowOpacity: 0.25, shadowRadius: 4,
         },


### PR DESCRIPTION
closes #274

## Changes
- Removed the secondary floating action button (barbell icon) from the Logs screen
- Removed the `navigateToWorkout` helper from `useLogData` as it is no longer used
- Users can still start a workout via the + / quick-add button in the Workouts section