### PR TITLE
fix: stabilize workoutDate with useMemo to prevent crash on new workout

### DIFF
--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -30,7 +30,10 @@ export default function WorkoutScreen() {
     const router = useRouter();
     const params = useLocalSearchParams<{ workoutId?: string; date?: string }>();
     const workoutId = params.workoutId ? Number(params.workoutId) : undefined;
-    const workoutDate = params.date ? parseDateKey(params.date) : undefined;
+    const workoutDate = useMemo(
+        () => (params.date ? parseDateKey(params.date) : undefined),
+        [params.date]
+    );
 
     const workout = useWorkout({ workoutId, date: workoutDate });
     const restTimer = useRestTimer();


### PR DESCRIPTION
## Summary

Resolves #277

### Root Cause

In `WorkoutScreen.tsx`, `workoutDate` was computed inline during render:
```tsx
const workoutDate = params.date ? parseDateKey(params.date) : undefined;
```

`parseDateKey` returns a **new `Date` object on every render**. `useWorkout`'s auto-resume `useEffect` has `date` in its dependency array — React's `Object.is` sees the new instance as changed every render, so the effect re-fires, calls `setData()`, triggers another render, and so on until the "Maximum update depth exceeded" error occurs.

### Fix

Wrap `workoutDate` in `useMemo` so the `Date` object is only recreated when `params.date` (a stable string) actually changes:
```tsx
const workoutDate = useMemo(
    () => (params.date ? parseDateKey(params.date) : undefined),
    [params.date]
);
```