### PR TITLE
fix(#281): refresh workout section after quick-add exercise

### DIFF
--- a/src/features/log/hooks/useLogData.ts
+++ b/src/features/log/hooks/useLogData.ts
@@ -234,6 +234,7 @@ export function useLogData() {
         portionInput, setPortionInput,
         selectionMode, selectedEntryIds, moveModalVisible, setMoveModalVisible,
         weightTrend, dayWeightLogs, meanWeightKg, weightDaysAgo, workoutRefreshKey,
+        bumpWorkoutRefreshKey: () => setWorkoutRefreshKey((k) => k + 1),
         handleScrollEnd, handleDelete, handleDeleteRecipeLog,
         handleConfirmEntry, handleConfirmRecipeLog,
         handleAddWeight, handleDeleteWeight,

--- a/src/features/log/screens/LogScreen.tsx
+++ b/src/features/log/screens/LogScreen.tsx
@@ -131,7 +131,7 @@ export default function LogScreen() {
         }
 
         setShowAddExercise(false);
-        d.loadAllDays(d.selectedDate);
+        d.bumpWorkoutRefreshKey();
     }
 
     return (


### PR DESCRIPTION
## Summary

Resolves #281

After using the thunderbolt quick-add button to add an exercise, the `WorkoutSummarySection` was not reloading because `workoutRefreshKey` was never incremented — only `loadAllDays` was called, which reloads food-log data but is not a dependency of the workout section's `useEffect`.

## Root Cause

`handleQuickAddExercise` in `LogScreen` called `d.loadAllDays()` after saving, but `WorkoutSummarySection` listens to `refreshKey` (mapped from `workoutRefreshKey`) to decide when to re-query the database. Since `workoutRefreshKey` was only bumped on screen focus / date change, the new exercise was invisible until the user navigated away and back.

## Changes

- **`useLogData`**: expose `bumpWorkoutRefreshKey` helper that increments the key
- **`LogScreen`**: call `d.bumpWorkoutRefreshKey()` instead of `d.loadAllDays()` after a successful quick-add