### PR TITLE
fix(#283): remove duplicate +

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -380,7 +380,7 @@ const de = {
             finishConfirm:
                 "Es gibt noch nicht abgeschlossene geplante Sätze. Trotzdem beenden?",
             elapsed: "Dauer",
-            addExercise: "+ Übung hinzufügen",
+            addExercise: "Übung hinzufügen",
             emptyState: "Füge eine Übung hinzu, um loszulegen",
             copyFromHistory: "Aus Verlauf starten",
             startedAt: "Gestartet um",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -378,7 +378,7 @@ const en = {
             finishConfirm:
                 "There are unfinished scheduled sets. Finish anyway?",
             elapsed: "Elapsed",
-            addExercise: "+ Add Exercise",
+            addExercise: "Add Exercise",
             emptyState: "Add an exercise to get started",
             copyFromHistory: "Start from History",
             startedAt: "Started at",


### PR DESCRIPTION
## Summary

Closes #283

Remove the leading plus from the workout Add Exercise label in both English and German locales so the button shows only one plus overall.
