### PR TITLE
[FEAT] Prevent sleep in workout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,17 +1,19 @@
 import "@/polyfills";
-import { getGoals, getNotificationSettings } from "@/src/features/settings/services/settingsDb";
-import { createAutoBackup } from "@/src/features/settings/services/autoBackup";
 import { getEntriesByDate, getWeightLogsForDate } from "@/src/features/log/services/logDb";
+import { createAutoBackup } from "@/src/features/settings/services/autoBackup";
+import { getGoals, getNotificationSettings } from "@/src/features/settings/services/settingsDb";
 import i18n from "@/src/i18n";
 import { initDB } from "@/src/services/db";
+import { deactivateKeepAwakeAsync, KEEP_AWAKE_DEFAULT_TAG, WORKOUT_KEEP_AWAKE_TAG } from "@/src/services/keepAwake";
 import { scheduleAllReminders } from "@/src/services/notifications";
 import { ThemeProvider, useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { useAppStore } from "@/src/shared/store/useAppStore";
 import type { AppearanceMode, Language, MealType, UnitSystem } from "@/src/shared/types";
 import Constants from "expo-constants";
-import { Stack } from "expo-router";
+import { Stack, usePathname } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import { useEffect } from "react";
+import { AppState } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 
 const LAST_SEEN_VERSION_KEY = "last_seen_app_version";
@@ -32,6 +34,9 @@ function InnerLayout() {
   const setLanguage = useAppStore((s) => s.setLanguage);
   const setAppearanceMode = useAppStore((s) => s.setAppearanceMode);
   const setUnitSystem = useAppStore((s) => s.setUnitSystem);
+  const setKeepAwakeInWorkout = useAppStore((s) => s.setKeepAwakeInWorkout);
+  const keepAwakeInWorkout = useAppStore((s) => s.keepAwakeInWorkout);
+  const pathname = usePathname();
 
   useEffect(() => {
     const goals = getGoals();
@@ -46,6 +51,7 @@ function InnerLayout() {
     if (goals?.unit_system === "metric" || goals?.unit_system === "imperial") {
       setUnitSystem(goals.unit_system as UnitSystem);
     }
+    setKeepAwakeInWorkout(goals?.keep_awake === 1);
 
     // Schedule notification reminders on app start
     const mealLabels: Record<MealType, string> = {
@@ -55,7 +61,32 @@ function InnerLayout() {
       snack: i18n.t("settings.notificationSnack"),
     };
     scheduleAllReminders(mealLabels, i18n.t("settings.notificationWeight"), getNotificationSettings() ?? null, new Set(getEntriesByDate(new Date()).map(e => e.entries.meal_type as MealType)), getWeightLogsForDate(new Date()).length > 0);
-  }, [setLanguage, setAppearanceMode, setUnitSystem]);
+  }, [setLanguage, setAppearanceMode, setUnitSystem, setKeepAwakeInWorkout]);
+
+  useEffect(() => {
+    const isWorkoutRoute = pathname?.startsWith("/workout") ?? false;
+    const shouldAllowKeepAwake = isWorkoutRoute && keepAwakeInWorkout;
+    if (shouldAllowKeepAwake) return;
+
+    const releaseKeepAwake = () => {
+      void deactivateKeepAwakeAsync(WORKOUT_KEEP_AWAKE_TAG).catch(() => { });
+      void deactivateKeepAwakeAsync(KEEP_AWAKE_DEFAULT_TAG).catch(() => { });
+    };
+
+    releaseKeepAwake();
+
+    const interval = setInterval(releaseKeepAwake, 3000);
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        releaseKeepAwake();
+      }
+    });
+
+    return () => {
+      clearInterval(interval);
+      subscription.remove();
+    };
+  }, [keepAwakeInWorkout, pathname]);
 
   return (
     <Stack

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,11 @@
+const path = require("path");
+const { getDefaultConfig } = require("expo/metro-config");
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.extraNodeModules = {
+    ...(config.resolver.extraNodeModules || {}),
+    "expo-keep-awake": path.resolve(__dirname, "src/shims/expoKeepAwake.ts"),
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-keep-awake": "~15.0.8",
     "expo-linear-gradient": "^55.0.9",
     "expo-linking": "~8.0.11",
     "expo-localization": "~17.0.8",

--- a/src/features/exercise/components/WorkoutKeepAwake.tsx
+++ b/src/features/exercise/components/WorkoutKeepAwake.tsx
@@ -1,0 +1,22 @@
+import { WORKOUT_KEEP_AWAKE_TAG, useKeepAwake } from "@/src/services/keepAwake";
+import { useIsFocused } from "@react-navigation/native";
+
+interface WorkoutKeepAwakeProps {
+    enabled: boolean;
+}
+
+export default function WorkoutKeepAwake({ enabled }: WorkoutKeepAwakeProps) {
+    const isFocused = useIsFocused();
+
+    if (!enabled || !isFocused) {
+        return null;
+    }
+
+    return <ActiveWorkoutKeepAwake />;
+}
+
+function ActiveWorkoutKeepAwake() {
+    useKeepAwake(WORKOUT_KEEP_AWAKE_TAG);
+
+    return null;
+}

--- a/src/features/exercise/hooks/useWorkout.ts
+++ b/src/features/exercise/hooks/useWorkout.ts
@@ -40,6 +40,9 @@ export function useWorkout({ workoutId, date }: UseWorkoutOptions = {}): UseWork
     const [isResumed, setIsResumed] = useState(false);
     const [elapsedMs, setElapsedMs] = useState(0);
     const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const workoutIdRef = useRef<number | null>(null);
+    const currentWorkout = data?.workout ?? null;
+    const currentExercises = data?.exercises ?? [];
 
     const loadWorkout = useCallback((id: number) => {
         const result = getWorkoutById(id);
@@ -48,8 +51,12 @@ export function useWorkout({ workoutId, date }: UseWorkoutOptions = {}): UseWork
     }, []);
 
     const reload = useCallback(() => {
-        if (data?.workout.id) loadWorkout(data.workout.id);
-    }, [data?.workout.id, loadWorkout]);
+        if (workoutIdRef.current) loadWorkout(workoutIdRef.current);
+    }, [loadWorkout]);
+
+    useEffect(() => {
+        workoutIdRef.current = currentWorkout?.id ?? null;
+    }, [currentWorkout]);
 
     // Auto-load or auto-resume on mount
     useEffect(() => {
@@ -71,14 +78,14 @@ export function useWorkout({ workoutId, date }: UseWorkoutOptions = {}): UseWork
     useEffect(() => {
         if (timerRef.current) clearInterval(timerRef.current);
 
-        if (data?.workout && !data.workout.ended_at) {
-            const tick = () => setElapsedMs(Date.now() - data.workout.started_at);
+        if (currentWorkout && !currentWorkout.ended_at) {
+            const tick = () => setElapsedMs(Date.now() - currentWorkout.started_at);
             tick();
             timerRef.current = setInterval(tick, 60000);
         } else {
             setElapsedMs(
-                data?.workout.ended_at && data?.workout.started_at
-                    ? data.workout.ended_at - data.workout.started_at
+                currentWorkout?.ended_at && currentWorkout.started_at
+                    ? currentWorkout.ended_at - currentWorkout.started_at
                     : 0,
             );
         }
@@ -86,7 +93,7 @@ export function useWorkout({ workoutId, date }: UseWorkoutOptions = {}): UseWork
         return () => {
             if (timerRef.current) clearInterval(timerRef.current);
         };
-    }, [data?.workout?.id, data?.workout?.started_at, data?.workout?.ended_at]);
+    }, [currentWorkout]);
 
     const startWorkout = useCallback((startDate?: Date) => {
         const dateKey = formatDateKey(startDate ?? new Date());
@@ -98,83 +105,83 @@ export function useWorkout({ workoutId, date }: UseWorkoutOptions = {}): UseWork
     }, []);
 
     const finishCurrentWorkout = useCallback(() => {
-        if (!data?.workout) return false;
-        finishWorkout(data.workout.id);
-        loadWorkout(data.workout.id);
+        if (!currentWorkout) return false;
+        finishWorkout(currentWorkout.id);
+        loadWorkout(currentWorkout.id);
         return true;
-    }, [data?.workout, loadWorkout]);
+    }, [currentWorkout, loadWorkout]);
 
     const updateTitle = useCallback(
         (title: string) => {
-            if (!data?.workout) return;
-            updateWorkout(data.workout.id, { title });
+            if (!currentWorkout) return;
+            updateWorkout(currentWorkout.id, { title });
             setData((prev) =>
                 prev ? { ...prev, workout: { ...prev.workout, title } } : null,
             );
         },
-        [data?.workout],
+        [currentWorkout],
     );
 
     const updateStartTime = useCallback(
         (epoch: number) => {
-            if (!data?.workout) return;
-            updateWorkout(data.workout.id, { started_at: epoch });
+            if (!currentWorkout) return;
+            updateWorkout(currentWorkout.id, { started_at: epoch });
             setData((prev) =>
                 prev ? { ...prev, workout: { ...prev.workout, started_at: epoch } } : null,
             );
         },
-        [data?.workout],
+        [currentWorkout],
     );
 
     const updateEndTime = useCallback(
         (epoch: number) => {
-            if (!data?.workout) return;
-            updateWorkout(data.workout.id, { ended_at: epoch });
+            if (!currentWorkout) return;
+            updateWorkout(currentWorkout.id, { ended_at: epoch });
             setData((prev) =>
                 prev ? { ...prev, workout: { ...prev.workout, ended_at: epoch } } : null,
             );
         },
-        [data?.workout],
+        [currentWorkout],
     );
 
     const addExercise = useCallback(
         (templateId: number) => {
-            if (!data?.workout) return undefined;
+            if (!currentWorkout) return undefined;
             const we = addExerciseToWorkout({
-                workout_id: data.workout.id,
+                workout_id: currentWorkout.id,
                 exercise_template_id: templateId,
-                sort_order: data.exercises.length + 1,
+                sort_order: currentExercises.length + 1,
             });
-            const exercises = getExercisesForWorkout(data.workout.id);
+            const exercises = getExercisesForWorkout(currentWorkout.id);
             setData((prev) => (prev ? { ...prev, exercises } : null));
             return we.id;
         },
-        [data?.workout, data?.exercises.length],
+        [currentWorkout, currentExercises.length],
     );
 
     const removeExercise = useCallback(
         (workoutExerciseId: number) => {
-            if (!data?.workout) return;
+            if (!currentWorkout) return;
             removeExerciseFromWorkout(workoutExerciseId);
-            const exercises = getExercisesForWorkout(data.workout.id);
+            const exercises = getExercisesForWorkout(currentWorkout.id);
             setData((prev) => (prev ? { ...prev, exercises } : null));
         },
-        [data?.workout],
+        [currentWorkout],
     );
 
     const moveExercise = useCallback(
         (workoutExerciseId: number, newOrder: number) => {
-            if (!data?.workout) return;
+            if (!currentWorkout) return;
             reorderExercise(workoutExerciseId, newOrder);
-            const exercises = getExercisesForWorkout(data.workout.id);
+            const exercises = getExercisesForWorkout(currentWorkout.id);
             setData((prev) => (prev ? { ...prev, exercises } : null));
         },
-        [data?.workout],
+        [currentWorkout],
     );
 
     const hasUnfinishedSets = useMemo(
-        () => data?.workout ? hasUnfinishedScheduledSets(data.workout.id) : false,
-        [data?.workout?.id, data?.exercises],
+        () => currentWorkout ? hasUnfinishedScheduledSets(currentWorkout.id) : false,
+        [currentWorkout],
     );
 
     return {

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -1,23 +1,25 @@
 import Button from "@/src/shared/atoms/Button";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { useAppStore } from "@/src/shared/store/useAppStore";
 import { parseDateKey } from "@/src/utils/date";
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FlatList, Alert, BackHandler, KeyboardAvoidingView, LayoutAnimation, Platform, Text, UIManager, View } from "react-native";
+import { Alert, BackHandler, FlatList, KeyboardAvoidingView, LayoutAnimation, Platform, Text, UIManager, View } from "react-native";
 import AddExerciseModal from "../components/AddExerciseModal";
 import CopyWorkoutSheet from "../components/CopyWorkoutSheet";
 import EditWorkoutTimesModal from "../components/EditWorkoutTimesModal";
 import ExerciseCard from "../components/ExerciseCard";
 import WorkoutHeader from "../components/WorkoutHeader";
+import WorkoutKeepAwake from "../components/WorkoutKeepAwake";
 import { useRestTimer } from "../hooks/useRestTimer";
 import { useWorkout } from "../hooks/useWorkout";
 import { useWorkoutActions } from "../hooks/useWorkoutActions";
-import { createWorkoutScreenStyles } from "./WorkoutScreenStyles";
 import {
     copySetsFromLastSession, type ExerciseTemplate, type WorkoutExerciseWithSets,
 } from "../services/exerciseDb";
+import { createWorkoutScreenStyles } from "./WorkoutScreenStyles";
 
 if (Platform.OS === "android" && UIManager.setLayoutAnimationEnabledExperimental) {
     UIManager.setLayoutAnimationEnabledExperimental(true);
@@ -38,6 +40,10 @@ export default function WorkoutScreen() {
     const workout = useWorkout({ workoutId, date: workoutDate });
     const restTimer = useRestTimer();
     const actions = useWorkoutActions(workout, restTimer);
+    const keepAwakeInWorkout = useAppStore((s) => s.keepAwakeInWorkout);
+    const workoutData = workout.data;
+    const reloadWorkout = workout.reload;
+    const finishCurrentWorkout = workout.finishCurrentWorkout;
     const [showAddExercise, setShowAddExercise] = useState(false);
     const [showCopySheet, setShowCopySheet] = useState(false);
     const [showTimesModal, setShowTimesModal] = useState(false);
@@ -50,7 +56,7 @@ export default function WorkoutScreen() {
         if (!workout.data && !workoutId && !workout.isResumed) {
             workout.startWorkout(workoutDate);
         }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [workout.data, workoutId, workout.isResumed, workout.startWorkout, workoutDate]);
 
     // Auto-expand an exercise when data loads
@@ -88,7 +94,7 @@ export default function WorkoutScreen() {
     }
 
     function handleFinish() {
-        workout.finishCurrentWorkout();
+        finishCurrentWorkout();
         router.back();
     }
 
@@ -98,7 +104,7 @@ export default function WorkoutScreen() {
     }
 
     const handleBack = useCallback(() => {
-        const isInProgress = workout.data?.workout && !workout.data.workout.ended_at;
+        const isInProgress = workoutData?.workout && !workoutData.workout.ended_at;
         if (!isInProgress) { router.back(); return; }
 
         Alert.alert(
@@ -106,16 +112,16 @@ export default function WorkoutScreen() {
             t("exercise.workout.leaveMessage"),
             [
                 { text: t("exercise.workout.leaveContinue"), style: "cancel" },
-                { text: t("exercise.workout.leaveFinish"), onPress: () => { workout.finishCurrentWorkout(); router.back(); } },
+                { text: t("exercise.workout.leaveFinish"), onPress: () => { finishCurrentWorkout(); router.back(); } },
                 { text: t("exercise.workout.leaveWithout"), style: "destructive", onPress: () => router.back() },
             ],
         );
-    }, [workout, router, t]);
+    }, [finishCurrentWorkout, router, t, workoutData]);
 
     useFocusEffect(
         useCallback(() => {
-            workout.reload();
-        }, [workout.reload]),
+            reloadWorkout();
+        }, [reloadWorkout]),
     );
 
     useFocusEffect(
@@ -163,6 +169,7 @@ export default function WorkoutScreen() {
     return (
         <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined} style={styles.screen}>
             <Stack.Screen options={{ headerShown: false }} />
+            <WorkoutKeepAwake enabled={keepAwakeInWorkout} />
 
             <WorkoutHeader
                 title={workout.data?.workout.title || t("exercise.workout.defaultTitle")}

--- a/src/features/log/hooks/useLogData.ts
+++ b/src/features/log/hooks/useLogData.ts
@@ -35,7 +35,7 @@ export function useLogData() {
     const [nextGrouped, setNextGrouped] = useState(emptyGrouped);
     const [dailyGoals, setDailyGoals] = useState<Goals>({
         id: 1, calories: 2000, protein: 150, carbs: 250, fat: 70,
-        unit_system: "metric", language: "en", appearance_mode: "system",
+        unit_system: "metric", language: "en", appearance_mode: "system", keep_awake: 0,
     });
 
     const [editingEntry, setEditingEntry] = useState<EntryWithFood | null>(null);
@@ -62,6 +62,7 @@ export function useLogData() {
             if (g.unit_system === "metric" || g.unit_system === "imperial") {
                 useAppStore.getState().setUnitSystem(g.unit_system as "metric" | "imperial");
             }
+            useAppStore.getState().setKeepAwakeInWorkout(g.keep_awake !== 0);
         }
         const dayWeights = getWeightLogsForDate(center);
         setDayWeightLogs(dayWeights);

--- a/src/features/settings/components/SettingsToggleRow.tsx
+++ b/src/features/settings/components/SettingsToggleRow.tsx
@@ -1,0 +1,74 @@
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import React from "react";
+import { StyleSheet, Switch, Text, View } from "react-native";
+
+interface SettingsToggleRowProps {
+    colors: ThemeColors;
+    label: string;
+    description?: string;
+    value: boolean;
+    onValueChange: (value: boolean) => void;
+}
+
+export default function SettingsToggleRow({
+    colors,
+    label,
+    description,
+    value,
+    onValueChange,
+}: SettingsToggleRowProps) {
+    const styles = React.useMemo(() => createStyles(colors), [colors]);
+
+    return (
+        <>
+            <Text style={styles.sectionLabel}>{label}</Text>
+            {description ? <Text style={styles.description}>{description}</Text> : null}
+            <View style={styles.row}>
+                <Text style={styles.valueLabel}>{label}</Text>
+                <Switch
+                    value={value}
+                    onValueChange={onValueChange}
+                    trackColor={{ false: colors.border, true: colors.primary }}
+                    thumbColor={value ? colors.primaryLight : colors.surface}
+                />
+            </View>
+        </>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        sectionLabel: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            letterSpacing: 0.5,
+            marginBottom: spacing.sm,
+            marginTop: spacing.md,
+        },
+        description: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            marginBottom: spacing.md,
+        },
+        row: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm + 2,
+            marginBottom: spacing.md,
+            gap: spacing.md,
+        },
+        valueLabel: {
+            flex: 1,
+            fontSize: fontSize.sm,
+            color: colors.text,
+            fontWeight: "500",
+        },
+    });
+}

--- a/src/features/settings/screens/BackupScreen.tsx
+++ b/src/features/settings/screens/BackupScreen.tsx
@@ -23,6 +23,7 @@ export default function BackupScreen() {
 
     const setUnitSystem = useAppStore((s) => s.setUnitSystem);
     const setAppearanceMode = useAppStore((s) => s.setAppearanceMode);
+    const setKeepAwakeInWorkout = useAppStore((s) => s.setKeepAwakeInWorkout);
 
     const [exporting, setExporting] = useState(false);
     const [importing, setImporting] = useState(false);
@@ -63,6 +64,7 @@ export default function BackupScreen() {
                 if (g.appearance_mode === "light" || g.appearance_mode === "dark" || g.appearance_mode === "system") {
                     setAppearanceMode(g.appearance_mode as AppearanceMode);
                 }
+                setKeepAwakeInWorkout(g.keep_awake !== 0);
             }
             Alert.alert(
                 t("settings.importComplete"),

--- a/src/features/settings/screens/SettingsScreen.tsx
+++ b/src/features/settings/screens/SettingsScreen.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import NotificationSettings from "../components/NotificationSettings";
+import SettingsToggleRow from "../components/SettingsToggleRow";
 import { setGoals } from "../services/settingsDb";
 
 const LANGUAGE_LABELS: Record<Language, string> = {
@@ -30,6 +31,8 @@ export default function SettingsScreen() {
     const setAppearanceMode = useAppStore((s) => s.setAppearanceMode);
     const language = useAppStore((s) => s.language);
     const setLanguage = useAppStore((s) => s.setLanguage);
+    const keepAwakeInWorkout = useAppStore((s) => s.keepAwakeInWorkout);
+    const setKeepAwakeInWorkout = useAppStore((s) => s.setKeepAwakeInWorkout);
 
     const UNIT_OPTIONS: { key: UnitSystem; label: string }[] = [
         { key: "metric", label: t("settings.unitsMetric") },
@@ -50,6 +53,11 @@ export default function SettingsScreen() {
     function handleLanguageChange(lang: Language) {
         setLanguage(lang);
         setGoals({ language: lang });
+    }
+
+    function handleKeepAwakeChange(value: boolean) {
+        setKeepAwakeInWorkout(value);
+        setGoals({ keep_awake: value ? 1 : 0 });
     }
 
     return (
@@ -109,6 +117,14 @@ export default function SettingsScreen() {
                     </Pressable>
                 ))}
             </View>
+
+            <SettingsToggleRow
+                colors={colors}
+                label={t("settings.keepAwakeInWorkout")}
+                description={t("settings.keepAwakeInWorkoutDescription")}
+                value={keepAwakeInWorkout}
+                onValueChange={handleKeepAwakeChange}
+            />
 
             <NotificationSettings colors={colors} />
         </ScrollView>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -62,6 +62,8 @@ const de = {
         exportData: "Daten exportieren",
         importData: "Daten importieren",
         language: "SPRACHE",
+        keepAwakeInWorkout: "BILDSCHIRM WÄHREND DES TRAININGS AKTIV HALTEN",
+        keepAwakeInWorkoutDescription: "Verhindert, dass das Gerät in den Ruhezustand wechselt, solange der Trainingsbildschirm geöffnet ist.",
         saved: "Gespeichert",
         goalsUpdated: "Deine Ziele wurden aktualisiert.",
         invalid: "Ungültig",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -63,6 +63,8 @@ const en = {
         exportData: "Export Data",
         importData: "Import Data",
         language: "LANGUAGE",
+        keepAwakeInWorkout: "KEEP SCREEN AWAKE DURING WORKOUTS",
+        keepAwakeInWorkoutDescription: "Prevent the device from sleeping while the workout screen is open.",
         saved: "Saved",
         goalsUpdated: "Your goals have been updated.",
         invalid: "Invalid",

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -54,7 +54,8 @@ export function initDB() {
       protein REAL NOT NULL DEFAULT 150,
       carbs REAL NOT NULL DEFAULT 250,
       fat REAL NOT NULL DEFAULT 70,
-      unit_system TEXT NOT NULL DEFAULT 'metric'
+      unit_system TEXT NOT NULL DEFAULT 'metric',
+      keep_awake INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS recipe_items (
@@ -185,6 +186,7 @@ export function initDB() {
     "ALTER TABLE foods ADD COLUMN last_logged_amount REAL",
     "ALTER TABLE foods ADD COLUMN last_logged_unit TEXT",
     "ALTER TABLE goals ADD COLUMN appearance_mode TEXT NOT NULL DEFAULT 'system'",
+    "ALTER TABLE goals ADD COLUMN keep_awake INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE foods ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE recipes ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE foods ADD COLUMN last_logged_meal TEXT",

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -48,6 +48,7 @@ export const goals = sqliteTable("goals", {
     unit_system: text("unit_system").notNull().default("metric"),
     language: text("language").notNull().default("en"),
     appearance_mode: text("appearance_mode").notNull().default("system"),
+    keep_awake: integer("keep_awake").notNull().default(0),
 });
 
 export const recipes = sqliteTable("recipes", {

--- a/src/services/keepAwake.ts
+++ b/src/services/keepAwake.ts
@@ -1,0 +1,40 @@
+import { requireNativeModule } from "expo-modules-core";
+import { useEffect, useId } from "react";
+
+interface ExpoKeepAwakeModule {
+    activate(tag: string): Promise<void>;
+    deactivate(tag: string): Promise<void>;
+}
+
+const ExpoKeepAwake = requireNativeModule<ExpoKeepAwakeModule>("ExpoKeepAwake");
+
+export const KEEP_AWAKE_DEFAULT_TAG = "ExpoKeepAwakeDefaultTag";
+export const WORKOUT_KEEP_AWAKE_TAG = `${KEEP_AWAKE_DEFAULT_TAG}-workout`;
+
+export async function activateKeepAwakeAsync(tag: string = KEEP_AWAKE_DEFAULT_TAG) {
+    await ExpoKeepAwake.activate(tag);
+}
+
+export async function deactivateKeepAwakeAsync(tag: string = KEEP_AWAKE_DEFAULT_TAG) {
+    await ExpoKeepAwake.deactivate(tag);
+}
+
+export function useKeepAwake(tag?: string) {
+    const generatedTag = useId();
+    const activeTag = tag ?? generatedTag;
+
+    useEffect(() => {
+        let isMounted = true;
+
+        activateKeepAwakeAsync(activeTag).catch(() => { });
+
+        return () => {
+            isMounted = false;
+            void deactivateKeepAwakeAsync(activeTag).catch(() => {
+                if (isMounted) {
+                    throw new Error("Failed to release keep awake state");
+                }
+            });
+        };
+    }, [activeTag]);
+}

--- a/src/shared/store/useAppStore.ts
+++ b/src/shared/store/useAppStore.ts
@@ -1,7 +1,7 @@
+import i18n, { defaultLanguage } from "@/src/i18n";
 import type { AppearanceMode, Language, UnitSystem } from "@/src/shared/types";
 import { normalizeCalendarDate } from "@/src/utils/date";
 import { create } from "zustand";
-import i18n, { defaultLanguage } from "@/src/i18n";
 
 interface AppState {
     selectedDate: Date;
@@ -12,6 +12,8 @@ interface AppState {
     setAppearanceMode: (mode: AppearanceMode) => void;
     language: Language;
     setLanguage: (lang: Language) => void;
+    keepAwakeInWorkout: boolean;
+    setKeepAwakeInWorkout: (value: boolean) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -26,4 +28,6 @@ export const useAppStore = create<AppState>((set) => ({
         i18n.changeLanguage(lang);
         set({ language: lang });
     },
+    keepAwakeInWorkout: false,
+    setKeepAwakeInWorkout: (value) => set({ keepAwakeInWorkout: value }),
 }));

--- a/src/shims/expoKeepAwake.ts
+++ b/src/shims/expoKeepAwake.ts
@@ -1,0 +1,10 @@
+export const ExpoKeepAwakeTag = "ExpoKeepAwakeDefaultTag";
+
+export function useKeepAwake() {
+    // Expo's dev wrapper auto-imports expo-keep-awake when the package is present.
+    // This shim prevents a global dev-only wake lock.
+}
+
+export async function activateKeepAwakeAsync() { }
+
+export async function deactivateKeepAwake() { }


### PR DESCRIPTION
## Summary
- add a settings toggle to keep the screen awake during workouts
- persist and hydrate the new keep-awake preference via goals
- apply keep-awake only while workout is focused and enabled
- add a root-level release guard to avoid unintended global wake locks in dev

## Validation
- npx eslint on all touched files
- adb dumpsys checks for KEEP_SCREEN_ON state during debugging

closes #320