### PR TITLE
feat(exercise): set-level drag-and-drop via drag handle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-keep-awake": "~15.0.8",
         "expo-linear-gradient": "^55.0.9",
         "expo-linking": "~8.0.11",
         "expo-localization": "~17.0.8",
@@ -45,6 +46,7 @@
         "react-dom": "19.1.0",
         "react-i18next": "^16.6.6",
         "react-native": "0.81.5",
+        "react-native-draggable-flatlist": "^4.0.3",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-gifted-charts": "^1.4.76",
         "react-native-markdown-display": "^7.0.2",
@@ -11674,6 +11676,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-draggable-flatlist": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-draggable-flatlist/-/react-native-draggable-flatlist-4.0.3.tgz",
+      "integrity": "sha512-2F4x5BFieWdGq9SetD2nSAR7s7oQCSgNllYgERRXXtNfSOuAGAVbDb/3H3lP0y5f7rEyNwabKorZAD/SyyNbDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/preset-typescript": "^7.17.12"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.64.0",
+        "react-native-gesture-handler": ">=2.0.0",
+        "react-native-reanimated": ">=2.8.0"
       }
     },
     "node_modules/react-native-fit-image": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-dom": "19.1.0",
     "react-i18next": "^16.6.6",
     "react-native": "0.81.5",
+    "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-gifted-charts": "^1.4.76",
     "react-native-markdown-display": "^7.0.2",

--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -26,6 +26,7 @@ interface ExerciseCardProps {
     onSetTypeChange: (setId: number, type: string) => void;
     onAddSet: (workoutExerciseId: number) => void;
     onCopyFromLast: (workoutExerciseId: number, templateId: number) => void;
+    onReorderSets: (workoutExerciseId: number, from: number, to: number) => void;
     restTimerActive: boolean;
     restTimerElapsed: number;
     restTimerTarget: number;
@@ -36,7 +37,7 @@ interface ExerciseCardProps {
 export default function ExerciseCard({
     item, index, isFinished, isExpanded, onExpand, onDragStart, lastWorkoutSets,
     onRemove, onNoteChange,
-    onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
+    onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast, onReorderSets,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExerciseCardProps) {
     const { t } = useTranslation();
@@ -132,6 +133,7 @@ export default function ExerciseCard({
             onSetTypeChange={onSetTypeChange}
             onAddSet={onAddSet}
             onCopyFromLast={onCopyFromLast}
+            onReorderSets={onReorderSets}
             restTimerActive={restTimerActive}
             restTimerElapsed={restTimerElapsed}
             restTimerTarget={restTimerTarget}

--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -13,14 +13,12 @@ import type { SetValues } from "./SetInputRow";
 interface ExerciseCardProps {
     item: WorkoutExerciseWithSets;
     index: number;
-    totalExercises: number;
     isFinished: boolean;
     isExpanded: boolean;
     onExpand: () => void;
+    onDragStart: () => void;
     lastWorkoutSets: ExerciseSet[];
     onRemove: (workoutExerciseId: number) => void;
-    onMoveUp: (workoutExerciseId: number) => void;
-    onMoveDown: (workoutExerciseId: number) => void;
     onNoteChange: (workoutExerciseId: number, note: string) => void;
     onConfirmSet: (setId: number, values: SetValues) => void;
     onUpdateSet: (setId: number, values: SetValues) => void;
@@ -36,8 +34,8 @@ interface ExerciseCardProps {
 }
 
 export default function ExerciseCard({
-    item, index, totalExercises, isFinished, isExpanded, onExpand, lastWorkoutSets,
-    onRemove, onMoveUp, onMoveDown, onNoteChange,
+    item, index, isFinished, isExpanded, onExpand, onDragStart, lastWorkoutSets,
+    onRemove, onNoteChange,
     onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExerciseCardProps) {
@@ -76,24 +74,18 @@ export default function ExerciseCard({
                     index={index}
                     name={name}
                     onExpand={onExpand}
-                    onLongPress={() => setMenuOpen(true)}
+                    onLongPress={onDragStart}
                 />
                 <ExerciseCardMenu
                     visible={menuOpen}
                     onClose={() => setMenuOpen(false)}
-                    index={index}
-                    totalExercises={totalExercises}
                     isFinished={isFinished}
                     hasNote={!!item.workoutExercise.notes}
                     hasTemplate={!!template}
-                    onMoveUp={() => { onMoveUp(item.workoutExercise.id); setMenuOpen(false); }}
-                    onMoveDown={() => { onMoveDown(item.workoutExercise.id); setMenuOpen(false); }}
                     onEditNote={() => { setMenuOpen(false); setNoteDraft(item.workoutExercise.notes ?? ""); setNoteOpen(true); }}
                     onCopyFromLast={() => { onCopyFromLast(item.workoutExercise.id, template!.id); setMenuOpen(false); }}
                     onRemove={handleRemove}
                     labels={{
-                        moveUp: t("exercise.exerciseCard.moveUp"),
-                        moveDown: t("exercise.exerciseCard.moveDown"),
                         editNote: t("exercise.exerciseCard.editNote"),
                         addNote: t("exercise.exerciseCard.addNote"),
                         copyFromLast: t("exercise.exerciseCard.copyFromLast"),
@@ -120,7 +112,6 @@ export default function ExerciseCard({
         <ExpandedExerciseCard
             item={item}
             index={index}
-            totalExercises={totalExercises}
             isFinished={isFinished}
             name={name}
             exerciseType={exerciseType}
@@ -128,13 +119,12 @@ export default function ExerciseCard({
             lastWorkoutSets={lastWorkoutSets}
             menuOpen={menuOpen}
             setMenuOpen={setMenuOpen}
+            onDragStart={onDragStart}
             noteOpen={noteOpen}
             setNoteOpen={setNoteOpen}
             noteDraft={noteDraft}
             setNoteDraft={setNoteDraft}
             onRemove={onRemove}
-            onMoveUp={onMoveUp}
-            onMoveDown={onMoveDown}
             onNoteChange={onNoteChange}
             onConfirmSet={onConfirmSet}
             onUpdateSet={onUpdateSet}

--- a/src/features/exercise/components/ExerciseCardHelpers.ts
+++ b/src/features/exercise/components/ExerciseCardHelpers.ts
@@ -108,6 +108,7 @@ export function createExerciseCardStyles(colors: ThemeColors) {
             textTransform: "uppercase",
         },
         setCol: { width: 32 },
+        handleCol: { width: 24 },
         valueCol: { flex: 1, textAlign: "center" as const },
         rirCol: { width: 36, textAlign: "center" as const },
         emptyCol: { width: 28, alignItems: "center" as const },

--- a/src/features/exercise/components/ExerciseCardModals.tsx
+++ b/src/features/exercise/components/ExerciseCardModals.tsx
@@ -29,19 +29,13 @@ const menuItemStyles = StyleSheet.create({
 interface ExerciseCardMenuProps {
     visible: boolean;
     onClose: () => void;
-    index: number;
-    totalExercises: number;
     isFinished: boolean;
     hasNote: boolean;
     hasTemplate: boolean;
-    onMoveUp: () => void;
-    onMoveDown: () => void;
     onEditNote: () => void;
     onCopyFromLast: () => void;
     onRemove: () => void;
     labels: {
-        moveUp: string;
-        moveDown: string;
         editNote: string;
         addNote: string;
         copyFromLast: string;
@@ -50,9 +44,9 @@ interface ExerciseCardMenuProps {
 }
 
 export function ExerciseCardMenu({
-    visible, onClose, index, totalExercises, isFinished,
+    visible, onClose, isFinished,
     hasNote, hasTemplate,
-    onMoveUp, onMoveDown, onEditNote, onCopyFromLast, onRemove,
+    onEditNote, onCopyFromLast, onRemove,
     labels,
 }: ExerciseCardMenuProps) {
     const colors = useThemeColors();
@@ -62,12 +56,6 @@ export function ExerciseCardMenu({
         <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
             <Pressable style={styles.overlay} onPress={onClose}>
                 <View style={styles.menu}>
-                    {index > 0 && (
-                        <MenuItem label={labels.moveUp} icon="arrow-up" onPress={onMoveUp} colors={colors} />
-                    )}
-                    {index < totalExercises - 1 && (
-                        <MenuItem label={labels.moveDown} icon="arrow-down" onPress={onMoveDown} colors={colors} />
-                    )}
                     <MenuItem
                         label={hasNote ? labels.editNote : labels.addNote}
                         icon="create-outline"

--- a/src/features/exercise/components/ExpandedExerciseCard.tsx
+++ b/src/features/exercise/components/ExpandedExerciseCard.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Pressable, Text, View } from "react-native";
+import DraggableFlatList, { type RenderItemParams } from "react-native-draggable-flatlist";
 import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
 import type { ExerciseType } from "../types";
 import { createExerciseCardStyles, getPrefillForSet, isActiveSet } from "./ExerciseCardHelpers";
@@ -34,6 +35,7 @@ interface ExpandedExerciseCardProps {
     onSetTypeChange: (setId: number, type: string) => void;
     onAddSet: (workoutExerciseId: number) => void;
     onCopyFromLast: (workoutExerciseId: number, templateId: number) => void;
+    onReorderSets: (workoutExerciseId: number, from: number, to: number) => void;
     restTimerActive: boolean;
     restTimerElapsed: number;
     restTimerTarget: number;
@@ -47,6 +49,7 @@ export function ExpandedExerciseCard({
     menuOpen, setMenuOpen, onDragStart, noteOpen, setNoteOpen, noteDraft, setNoteDraft,
     onRemove, onNoteChange,
     onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
+    onReorderSets,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExpandedExerciseCardProps) {
     const colors = useThemeColors();
@@ -107,6 +110,7 @@ export function ExpandedExerciseCard({
 
             {/* Column headers */}
             <View style={styles.headerRow}>
+                <View style={styles.handleCol} />
                 <Text style={[styles.headerCell, styles.setCol]}>{t("exercise.exerciseCard.set")}</Text>
                 {exerciseType === "weight" && (
                     <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.weight")}</Text>
@@ -127,38 +131,47 @@ export function ExpandedExerciseCard({
             </View>
 
             {/* Set rows */}
-            {item.sets.map((set, si) => {
-                const prefill = getPrefillForSet(si, item.sets, lastWorkoutSets);
-                const isActive = isActiveSet(set, si, item.sets);
-                return (
-                    <React.Fragment key={set.id}>
-                        {isActive && restTimerActive && (
-                            <RestTimer
-                                elapsedSeconds={restTimerElapsed}
-                                targetSeconds={restTimerTarget}
-                                isTargetReached={restTimerReached}
-                                onSkip={onRestTimerSkip}
+            <DraggableFlatList
+                data={item.sets}
+                keyExtractor={(set) => String(set.id)}
+                scrollEnabled={false}
+                activationDistance={0}
+                onDragEnd={({ from, to }) => onReorderSets(item.workoutExercise.id, from, to)}
+                renderItem={({ item: set, drag, getIndex }: RenderItemParams<ExerciseSet>) => {
+                    const si = getIndex() ?? 0;
+                    const prefill = getPrefillForSet(si, item.sets, lastWorkoutSets);
+                    const active = isActiveSet(set, si, item.sets);
+                    return (
+                        <React.Fragment key={set.id}>
+                            {active && restTimerActive && (
+                                <RestTimer
+                                    elapsedSeconds={restTimerElapsed}
+                                    targetSeconds={restTimerTarget}
+                                    isTargetReached={restTimerReached}
+                                    onSkip={onRestTimerSkip}
+                                />
+                            )}
+                            <SetInputRow
+                                set={set}
+                                index={si}
+                                exerciseType={exerciseType}
+                                isActive={active}
+                                isFinished={isFinished}
+                                prefillWeight={prefill.weight}
+                                prefillReps={prefill.reps}
+                                prefillRir={prefill.rir}
+                                prefillDuration={prefill.duration}
+                                prefillDistance={prefill.distance}
+                                onConfirm={onConfirmSet}
+                                onUpdate={onUpdateSet}
+                                onDelete={onDeleteSet}
+                                onTypeChange={onSetTypeChange}
+                                onDragStart={drag}
                             />
-                        )}
-                        <SetInputRow
-                            set={set}
-                            index={si}
-                            exerciseType={exerciseType}
-                            isActive={isActive}
-                            isFinished={isFinished}
-                            prefillWeight={prefill.weight}
-                            prefillReps={prefill.reps}
-                            prefillRir={prefill.rir}
-                            prefillDuration={prefill.duration}
-                            prefillDistance={prefill.distance}
-                            onConfirm={onConfirmSet}
-                            onUpdate={onUpdateSet}
-                            onDelete={onDeleteSet}
-                            onTypeChange={onSetTypeChange}
-                        />
-                    </React.Fragment>
-                );
-            })}
+                        </React.Fragment>
+                    );
+                }}
+            />
 
             {/* Empty state */}
             {item.sets.length === 0 && (

--- a/src/features/exercise/components/ExpandedExerciseCard.tsx
+++ b/src/features/exercise/components/ExpandedExerciseCard.tsx
@@ -14,7 +14,6 @@ import SetInputRow, { type SetValues } from "./SetInputRow";
 interface ExpandedExerciseCardProps {
     item: WorkoutExerciseWithSets;
     index: number;
-    totalExercises: number;
     isFinished: boolean;
     name: string;
     exerciseType: ExerciseType;
@@ -22,13 +21,12 @@ interface ExpandedExerciseCardProps {
     lastWorkoutSets: ExerciseSet[];
     menuOpen: boolean;
     setMenuOpen: (v: boolean) => void;
+    onDragStart: () => void;
     noteOpen: boolean;
     setNoteOpen: (v: boolean) => void;
     noteDraft: string;
     setNoteDraft: (v: string) => void;
     onRemove: (workoutExerciseId: number) => void;
-    onMoveUp: (workoutExerciseId: number) => void;
-    onMoveDown: (workoutExerciseId: number) => void;
     onNoteChange: (workoutExerciseId: number, note: string) => void;
     onConfirmSet: (setId: number, values: SetValues) => void;
     onUpdateSet: (setId: number, values: SetValues) => void;
@@ -44,10 +42,10 @@ interface ExpandedExerciseCardProps {
 }
 
 export function ExpandedExerciseCard({
-    item, index, totalExercises, isFinished, name, exerciseType, template,
+    item, index, isFinished, name, exerciseType, template,
     lastWorkoutSets,
-    menuOpen, setMenuOpen, noteOpen, setNoteOpen, noteDraft, setNoteDraft,
-    onRemove, onMoveUp, onMoveDown, onNoteChange,
+    menuOpen, setMenuOpen, onDragStart, noteOpen, setNoteOpen, noteDraft, setNoteDraft,
+    onRemove, onNoteChange,
     onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
 }: ExpandedExerciseCardProps) {
@@ -87,7 +85,7 @@ export function ExpandedExerciseCard({
     }
 
     return (
-        <View style={styles.card}>
+        <Pressable style={styles.card} onLongPress={onDragStart} delayLongPress={180}>
             {/* Title row */}
             <View style={styles.titleRow}>
                 <Text style={styles.orderNum}>{index + 1}.</Text>
@@ -175,19 +173,13 @@ export function ExpandedExerciseCard({
             <ExerciseCardMenu
                 visible={menuOpen}
                 onClose={() => setMenuOpen(false)}
-                index={index}
-                totalExercises={totalExercises}
                 isFinished={isFinished}
                 hasNote={!!item.workoutExercise.notes}
                 hasTemplate={!!template}
-                onMoveUp={() => { onMoveUp(item.workoutExercise.id); setMenuOpen(false); }}
-                onMoveDown={() => { onMoveDown(item.workoutExercise.id); setMenuOpen(false); }}
                 onEditNote={() => { setMenuOpen(false); setNoteDraft(item.workoutExercise.notes ?? ""); setNoteOpen(true); }}
                 onCopyFromLast={() => { onCopyFromLast(item.workoutExercise.id, template!.id); setMenuOpen(false); }}
                 onRemove={handleRemove}
                 labels={{
-                    moveUp: t("exercise.exerciseCard.moveUp"),
-                    moveDown: t("exercise.exerciseCard.moveDown"),
                     editNote: t("exercise.exerciseCard.editNote"),
                     addNote: t("exercise.exerciseCard.addNote"),
                     copyFromLast: t("exercise.exerciseCard.copyFromLast"),
@@ -207,6 +199,6 @@ export function ExpandedExerciseCard({
                     save: t("common.save"),
                 }}
             />
-        </View>
+        </Pressable>
     );
 }

--- a/src/features/exercise/components/SetInputHelpers.tsx
+++ b/src/features/exercise/components/SetInputHelpers.tsx
@@ -60,6 +60,7 @@ export function createSetInputStyles(colors: ThemeColors) {
             fontSize: fontSize.sm,
         },
         setCol: { width: 32, justifyContent: "center" },
+        handleCol: { width: 24, alignItems: "center", justifyContent: "center" },
         valueCol: { flex: 1, textAlign: "center" },
         rirCol: { width: 36, textAlign: "center" },
         checkCol: { width: 28, alignItems: "center" },

--- a/src/features/exercise/components/SetInputRow.tsx
+++ b/src/features/exercise/components/SetInputRow.tsx
@@ -23,6 +23,7 @@ interface SetInputRowProps {
     onUpdate: (id: number, values: SetValues) => void;
     onDelete: (id: number) => void;
     onTypeChange: (id: number, type: string) => void;
+    onDragStart?: () => void;
 }
 
 export type { SetValues } from "../types";
@@ -30,7 +31,7 @@ export type { SetValues } from "../types";
 export default function SetInputRow({
     set, index, exerciseType, isActive, isFinished,
     prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance,
-    onConfirm, onUpdate, onDelete, onTypeChange,
+    onConfirm, onUpdate, onDelete, onTypeChange, onDragStart,
 }: SetInputRowProps) {
     const colors = useThemeColors();
     const { t } = useTranslation();
@@ -116,6 +117,9 @@ export default function SetInputRow({
     if (isScheduled && !isActive) {
         return (
             <Pressable style={[styles.setRow, styles.setRowScheduled]} onLongPress={handleLongPressSetNum}>
+                <Pressable style={styles.handleCol} onLongPress={onDragStart} hitSlop={8}>
+                    <Ionicons name="reorder-two-outline" size={16} color={colors.textTertiary} />
+                </Pressable>
                 <Text style={[styles.setCell, styles.setCol, { color: colors.textTertiary }]}>
                     {typeLabel}{index + 1}
                 </Text>
@@ -133,6 +137,9 @@ export default function SetInputRow({
 
     return (
         <View style={[styles.setRow, isActiveSet && styles.activeRow]}>
+            <Pressable style={styles.handleCol} onLongPress={onDragStart} hitSlop={8}>
+                <Ionicons name="reorder-two-outline" size={16} color={colors.textTertiary} />
+            </Pressable>
             <Pressable onLongPress={handleLongPressSetNum} style={styles.setCol}>
                 <Text style={[
                     styles.setCell,

--- a/src/features/exercise/hooks/useWorkoutActions.ts
+++ b/src/features/exercise/hooks/useWorkoutActions.ts
@@ -6,7 +6,7 @@ import type { UseRestTimerReturn } from "./useRestTimer";
 import type { UseWorkoutReturn } from "./useWorkout";
 import {
     addSet, completeSet, copySetsFromLastSession, deleteSet,
-    getLastCompletedSetsForTemplate, updateSet,
+    getLastCompletedSetsForTemplate, updateSet, reorderSet,
     updateWorkoutExercise, type ExerciseSet,
 } from "../services/exerciseDb";
 
@@ -88,6 +88,16 @@ export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestT
         workout.reload();
     }, [workout, t]);
 
+    const handleReorderSets = useCallback((workoutExerciseId: number, from: number, to: number) => {
+        if (from === to) return;
+        const ex = workout.data?.exercises.find((e) => e.workoutExercise.id === workoutExerciseId);
+        if (!ex) return;
+        const movedSet = ex.sets[from];
+        if (!movedSet) return;
+        reorderSet(movedSet.id, to + 1);
+        workout.reload();
+    }, [workout]);
+
     const lastSetsCache = useMemo(() => {
         const cache = new Map<number, ExerciseSet[]>();
         for (const ex of workout.data?.exercises ?? []) {
@@ -109,6 +119,7 @@ export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestT
         handleSetTypeChange,
         handleAddSet,
         handleCopyFromLast,
+        handleReorderSets,
         lastSetsCache,
     };
 }

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -170,6 +170,7 @@ export default function WorkoutScreen() {
                     onSetTypeChange={actions.handleSetTypeChange}
                     onAddSet={actions.handleAddSet}
                     onCopyFromLast={actions.handleCopyFromLast}
+                    onReorderSets={actions.handleReorderSets}
                     restTimerActive={timerActive}
                     restTimerElapsed={timerActive ? restTimer.elapsedSeconds : 0}
                     restTimerTarget={timerActive ? restTimer.targetSeconds : 0}

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -4,9 +4,10 @@ import { useAppStore } from "@/src/shared/store/useAppStore";
 import { parseDateKey } from "@/src/utils/date";
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Alert, BackHandler, FlatList, KeyboardAvoidingView, LayoutAnimation, Platform, Text, UIManager, View } from "react-native";
+import { Alert, BackHandler, KeyboardAvoidingView, LayoutAnimation, Platform, Text, UIManager, View } from "react-native";
+import DraggableFlatList, { type RenderItemParams } from "react-native-draggable-flatlist";
 import AddExerciseModal from "../components/AddExerciseModal";
 import CopyWorkoutSheet from "../components/CopyWorkoutSheet";
 import EditWorkoutTimesModal from "../components/EditWorkoutTimesModal";
@@ -47,10 +48,10 @@ export default function WorkoutScreen() {
     const [showAddExercise, setShowAddExercise] = useState(false);
     const [showCopySheet, setShowCopySheet] = useState(false);
     const [showTimesModal, setShowTimesModal] = useState(false);
+    const [isDragging, setIsDragging] = useState(false);
 
     // Focus state: which exercise is expanded (null = none)
     const [expandedId, setExpandedId] = useState<number | null>(null);
-    const flatListRef = useRef<FlatList>(null);
 
     useEffect(() => {
         if (!workout.data && !workoutId && !workout.isResumed) {
@@ -72,13 +73,11 @@ export default function WorkoutScreen() {
     const isFinished = !!workout.data?.workout.ended_at;
     const isEmpty = (workout.data?.exercises.length ?? 0) === 0;
 
-    const handleExpand = useCallback((weId: number, index: number) => {
+    const handleExpand = useCallback((weId: number) => {
+        if (isDragging) return;
         LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
         setExpandedId(weId);
-        setTimeout(() => {
-            flatListRef.current?.scrollToIndex({ index, animated: true, viewOffset: 8 });
-        }, 100);
-    }, []);
+    }, [isDragging]);
 
     function handleExerciseSelected(template: ExerciseTemplate, copyFromLast: boolean) {
         const weId = workout.addExercise(template.id);
@@ -134,35 +133,50 @@ export default function WorkoutScreen() {
         }, [handleBack]),
     );
 
-    function renderExercise({ item, index }: { item: WorkoutExerciseWithSets; index: number }) {
+    const exercises = useMemo(
+        () => workout.data?.exercises ?? [],
+        [workout.data?.exercises],
+    );
+
+    const handleDragEnd = useCallback(({ from, to }: { from: number; to: number }) => {
+        setIsDragging(false);
+        if (from === to) return;
+        const movedExercise = exercises[from];
+        if (!movedExercise) return;
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        workout.moveExercise(movedExercise.workoutExercise.id, to + 1);
+    }, [exercises, workout]);
+
+    function renderExercise({ item, drag, isActive, getIndex }: RenderItemParams<WorkoutExerciseWithSets>) {
+        const index = getIndex() ?? 0;
         const tid = item.workoutExercise.exercise_template_id;
         const timerActive = restTimer.isRunning;
         const isExpanded = expandedId === item.workoutExercise.id;
         return (
-            <ExerciseCard
-                item={item}
-                index={index}
-                totalExercises={workout.data?.exercises.length ?? 0}
-                isFinished={isFinished}
-                isExpanded={isExpanded}
-                onExpand={() => handleExpand(item.workoutExercise.id, index)}
-                lastWorkoutSets={tid ? (actions.lastSetsCache.get(tid) ?? []) : []}
-                onRemove={workout.removeExercise}
-                onMoveUp={actions.handleMoveUp}
-                onMoveDown={actions.handleMoveDown}
-                onNoteChange={actions.handleNoteChange}
-                onConfirmSet={actions.handleConfirmSet}
-                onUpdateSet={actions.handleUpdateSet}
-                onDeleteSet={actions.handleDeleteSet}
-                onSetTypeChange={actions.handleSetTypeChange}
-                onAddSet={actions.handleAddSet}
-                onCopyFromLast={actions.handleCopyFromLast}
-                restTimerActive={timerActive}
-                restTimerElapsed={timerActive ? restTimer.elapsedSeconds : 0}
-                restTimerTarget={timerActive ? restTimer.targetSeconds : 0}
-                restTimerReached={timerActive ? restTimer.isTargetReached : false}
-                onRestTimerSkip={restTimer.skip}
-            />
+            <View style={isActive ? styles.draggingCard : undefined}>
+                <ExerciseCard
+                    item={item}
+                    index={index}
+                    isFinished={isFinished}
+                    isExpanded={isExpanded}
+                    onExpand={() => handleExpand(item.workoutExercise.id)}
+                    onDragStart={drag}
+                    lastWorkoutSets={tid ? (actions.lastSetsCache.get(tid) ?? []) : []}
+                    onRemove={workout.removeExercise}
+                    onNoteChange={actions.handleNoteChange}
+                    onConfirmSet={actions.handleConfirmSet}
+                    onUpdateSet={actions.handleUpdateSet}
+                    onDeleteSet={actions.handleDeleteSet}
+                    onSetTypeChange={actions.handleSetTypeChange}
+                    onAddSet={actions.handleAddSet}
+                    onCopyFromLast={actions.handleCopyFromLast}
+                    restTimerActive={timerActive}
+                    restTimerElapsed={timerActive ? restTimer.elapsedSeconds : 0}
+                    restTimerTarget={timerActive ? restTimer.targetSeconds : 0}
+                    restTimerReached={timerActive ? restTimer.isTargetReached : false}
+                    onRestTimerSkip={restTimer.skip}
+                />
+            </View>
         );
     }
 
@@ -182,12 +196,16 @@ export default function WorkoutScreen() {
                 onTimerPress={() => setShowTimesModal(true)}
             />
 
-            <FlatList
-                ref={flatListRef}
-                data={workout.data?.exercises ?? []}
+            <DraggableFlatList
+                data={exercises}
                 keyExtractor={(item) => String(item.workoutExercise.id)}
                 renderItem={renderExercise}
                 contentContainerStyle={styles.list}
+                activationDistance={0}
+                autoscrollThreshold={80}
+                autoscrollSpeed={180}
+                onDragBegin={() => setIsDragging(true)}
+                onDragEnd={handleDragEnd}
                 ListEmptyComponent={
                     <View style={styles.emptyWrap}>
                         <Ionicons name="barbell-outline" size={48} color={colors.textTertiary} />

--- a/src/features/exercise/screens/WorkoutScreenStyles.ts
+++ b/src/features/exercise/screens/WorkoutScreenStyles.ts
@@ -25,5 +25,9 @@ export function createWorkoutScreenStyles(colors: ThemeColors) {
         addBtn: {
             marginTop: spacing.sm,
         },
+        draggingCard: {
+            opacity: 0.95,
+            transform: [{ scale: 1.01 }],
+        },
     });
 }

--- a/src/features/exercise/services/exerciseDb.ts
+++ b/src/features/exercise/services/exerciseDb.ts
@@ -40,6 +40,7 @@ export {
     getLastCompletedSetsForTemplate,
     getSetsForExercise,
     updateSet,
+    reorderSet,
 } from "./exerciseSetDb";
 export type { ExerciseSet, NewExerciseSet } from "./exerciseSetDb";
 

--- a/src/features/exercise/services/exerciseSetDb.ts
+++ b/src/features/exercise/services/exerciseSetDb.ts
@@ -35,6 +35,25 @@ export function deleteSet(id: number) {
     exerciseDbSupport.normalizeSetOrder(set.workout_exercise_id);
 }
 
+export function reorderSet(id: number, newOrder: number) {
+    const set = exerciseDbSupport.getExerciseSetOrThrow(id);
+    const sets = exerciseDbSupport.listSetsForExercise(set.workout_exercise_id);
+
+    const sourceIndex = sets.findIndex((s) => s.id === id);
+    if (sourceIndex === -1) throw new Error(`Exercise set ${id} not found`);
+
+    const [setToMove] = sets.splice(sourceIndex, 1);
+    const targetIndex = Math.max(0, Math.min(newOrder - 1, sets.length));
+    sets.splice(targetIndex, 0, setToMove);
+
+    sets.forEach((s, index) => {
+        const sortOrder = index + 1;
+        if (s.set_order !== sortOrder) {
+            db.update(exerciseSets).set({ set_order: sortOrder }).where(eq(exerciseSets.id, s.id)).run();
+        }
+    });
+}
+
 export function getSetsForExercise(workoutExerciseId: number): ExerciseSet[] {
     exerciseDbSupport.getWorkoutExerciseOrThrow(workoutExerciseId);
     return exerciseDbSupport.listSetsForExercise(workoutExerciseId);


### PR DESCRIPTION
## Summary

Closes #299 (set-level part)

Adds a drag handle on the left of every set row in the expanded exercise card, allowing the user to reorder sets via long-press drag-and-drop.

## Changes

- **`exerciseSetDb.ts`**: Add `reorderSet(id, newOrder)` — mirrors `reorderExercise` pattern, reassigns `set_order` values after splice
- **`exerciseDb.ts`**: Export `reorderSet` from barrel
- **`useWorkoutActions.ts`**: Add `handleReorderSets(workoutExerciseId, from, to)` which calls `reorderSet` and reloads workout
- **`SetInputHelpers.tsx`** / **`ExerciseCardHelpers.ts`**: Add `handleCol` style (width 24) for the handle column
- **`SetInputRow.tsx`**: Add `onDragStart` prop; render `reorder-two-outline` icon handle on the left of every set row
- **`ExpandedExerciseCard.tsx`**: Replace sets `map()` with `DraggableFlatList` (scrollEnabled=false); pass `drag` from renderItem as `onDragStart` to `SetInputRow`; add handle column spacer in the header row
- **`ExerciseCard.tsx`** / **`WorkoutScreen.tsx`**: Thread `onReorderSets` prop through the component tree