### PR TITLE
feat(exercise): polish rest timer UI and persist last used duration

### DIFF
--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -32,6 +32,7 @@ interface ExerciseCardProps {
     restTimerTarget: number;
     restTimerReached: boolean;
     onRestTimerSkip: () => void;
+    onRestTimerChangeDuration: (seconds: number) => void;
 }
 
 export default function ExerciseCard({
@@ -39,6 +40,7 @@ export default function ExerciseCard({
     onRemove, onNoteChange,
     onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast, onReorderSets,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
+    onRestTimerChangeDuration,
 }: ExerciseCardProps) {
     const { t } = useTranslation();
     const template = item.exerciseTemplate;
@@ -139,6 +141,7 @@ export default function ExerciseCard({
             restTimerTarget={restTimerTarget}
             restTimerReached={restTimerReached}
             onRestTimerSkip={onRestTimerSkip}
+            onRestTimerChangeDuration={onRestTimerChangeDuration}
         />
     );
 }

--- a/src/features/exercise/components/ExpandedExerciseCard.tsx
+++ b/src/features/exercise/components/ExpandedExerciseCard.tsx
@@ -41,6 +41,7 @@ interface ExpandedExerciseCardProps {
     restTimerTarget: number;
     restTimerReached: boolean;
     onRestTimerSkip: () => void;
+    onRestTimerChangeDuration: (seconds: number) => void;
 }
 
 export function ExpandedExerciseCard({
@@ -51,6 +52,7 @@ export function ExpandedExerciseCard({
     onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
     onReorderSets,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
+    onRestTimerChangeDuration,
 }: ExpandedExerciseCardProps) {
     const colors = useThemeColors();
     const { t } = useTranslation();
@@ -149,6 +151,7 @@ export function ExpandedExerciseCard({
                                     targetSeconds={restTimerTarget}
                                     isTargetReached={restTimerReached}
                                     onSkip={onRestTimerSkip}
+                                    onChangeDuration={onRestTimerChangeDuration}
                                 />
                             )}
                             <SetInputRow

--- a/src/features/exercise/components/RestTimer.tsx
+++ b/src/features/exercise/components/RestTimer.tsx
@@ -175,8 +175,6 @@ function createStyles(colors: ThemeColors) {
             paddingHorizontal: spacing.sm,
             paddingBottom: spacing.sm,
             paddingTop: spacing.xs,
-            borderTopWidth: 1,
-            borderTopColor: colors.border,
             gap: spacing.sm,
         },
         sectionLabel: {
@@ -186,12 +184,13 @@ function createStyles(colors: ThemeColors) {
         },
         presetsRow: {
             flexDirection: "row",
+            justifyContent: "space-between",
             gap: spacing.xs,
-            flexWrap: "wrap",
         },
         presetBtn: {
+            flex: 1,
+            alignItems: "center",
             paddingVertical: spacing.xs,
-            paddingHorizontal: spacing.sm,
             borderRadius: borderRadius.sm,
             borderWidth: 1,
             borderColor: colors.border,

--- a/src/features/exercise/components/RestTimer.tsx
+++ b/src/features/exercise/components/RestTimer.tsx
@@ -1,7 +1,7 @@
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { Ionicons } from "@expo/vector-icons";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
@@ -10,30 +10,108 @@ interface RestTimerProps {
     targetSeconds: number;
     isTargetReached: boolean;
     onSkip: () => void;
+    onChangeDuration: (seconds: number) => void;
 }
 
-export default function RestTimer({ elapsedSeconds, targetSeconds, isTargetReached, onSkip }: RestTimerProps) {
+const QUICK_PRESETS = [30, 60, 90, 120, 180, 300];
+
+export default function RestTimer({
+    elapsedSeconds,
+    targetSeconds,
+    isTargetReached,
+    onSkip,
+    onChangeDuration,
+}: RestTimerProps) {
     const colors = useThemeColors();
     const { t } = useTranslation();
     const styles = useMemo(() => createStyles(colors), [colors]);
+    const [isExpanded, setIsExpanded] = useState(false);
 
     const progress = Math.min(elapsedSeconds / targetSeconds, 1);
-    const accentColor = isTargetReached ? "#f59e0b" : colors.primary;
+    const accentColor = isTargetReached ? colors.warning : colors.primary;
 
     return (
         <View style={styles.container}>
-            <View style={styles.progressBg}>
-                <View style={[styles.progressFill, { width: `${progress * 100}%`, backgroundColor: accentColor }]} />
-            </View>
-            <View style={styles.row}>
+            {/* ── Header row ─────────────────────────────────── */}
+            <Pressable style={styles.header} onPress={() => setIsExpanded((v) => !v)} hitSlop={6}>
                 <Ionicons name="timer-outline" size={16} color={accentColor} />
-                <Text style={[styles.timeText, { color: accentColor }]}>
-                    {t("exercise.restTimer.label")}: {formatTime(elapsedSeconds)} / {formatTime(targetSeconds)}
+                <Text style={[styles.headerText, { color: accentColor }]}>
+                    {t("exercise.restTimer.label")} {formatTime(elapsedSeconds)} / {formatTime(targetSeconds)}
                 </Text>
                 <Pressable onPress={onSkip} style={styles.skipBtn} hitSlop={8}>
-                    <Text style={[styles.skipText, { color: colors.primary }]}>{t("exercise.restTimer.skip")}</Text>
+                    <Text style={[styles.skipText, { color: colors.textSecondary }]}>
+                        {t("exercise.restTimer.skip")}
+                    </Text>
                 </Pressable>
+                <Ionicons
+                    name={isExpanded ? "chevron-up" : "chevron-down"}
+                    size={14}
+                    color={colors.textSecondary}
+                />
+            </Pressable>
+
+            {/* ── Progress bar ────────────────────────────────── */}
+            <View style={styles.progressBg}>
+                <View
+                    style={[
+                        styles.progressFill,
+                        { width: `${progress * 100}%`, backgroundColor: accentColor },
+                    ]}
+                />
             </View>
+
+            {/* ── Expanded body ───────────────────────────────── */}
+            {isExpanded && (
+                <View style={styles.body}>
+                    <Text style={styles.sectionLabel}>{t("exercise.restTimer.adjustDuration")}</Text>
+
+                    {/* Quick presets */}
+                    <View style={styles.presetsRow}>
+                        {QUICK_PRESETS.map((s) => (
+                            <Pressable
+                                key={s}
+                                style={[
+                                    styles.presetBtn,
+                                    targetSeconds === s && { backgroundColor: colors.primaryLight, borderColor: colors.primary },
+                                ]}
+                                onPress={() => onChangeDuration(s)}
+                            >
+                                <Text
+                                    style={[
+                                        styles.presetText,
+                                        targetSeconds === s && { color: colors.primary, fontWeight: "700" },
+                                    ]}
+                                >
+                                    {formatPreset(s)}
+                                </Text>
+                            </Pressable>
+                        ))}
+                    </View>
+
+                    {/* Fine-grained adjustment */}
+                    <View style={styles.fineRow}>
+                        <Pressable
+                            style={styles.fineBtn}
+                            onPress={() => onChangeDuration(targetSeconds - 15)}
+                        >
+                            <Ionicons name="remove" size={16} color={colors.text} />
+                            <Text style={styles.fineBtnText}>15s</Text>
+                        </Pressable>
+                        <View style={styles.currentDuration}>
+                            <Text style={[styles.currentDurationText, { color: accentColor }]}>
+                                {formatTime(targetSeconds)}
+                            </Text>
+                        </View>
+                        <Pressable
+                            style={styles.fineBtn}
+                            onPress={() => onChangeDuration(targetSeconds + 15)}
+                        >
+                            <Ionicons name="add" size={16} color={colors.text} />
+                            <Text style={styles.fineBtnText}>15s</Text>
+                        </Pressable>
+                    </View>
+                </View>
+            )}
         </View>
     );
 }
@@ -41,42 +119,118 @@ export default function RestTimer({ elapsedSeconds, targetSeconds, isTargetReach
 function formatTime(seconds: number): string {
     const m = Math.floor(seconds / 60);
     const s = seconds % 60;
-    return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+    return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function formatPreset(seconds: number): string {
+    if (seconds < 60) return `${seconds}s`;
+    const m = seconds / 60;
+    return Number.isInteger(m) ? `${m}m` : `${Math.floor(m)}:${String(seconds % 60).padStart(2, "0")}`;
 }
 
 function createStyles(colors: ThemeColors) {
     return StyleSheet.create({
         container: {
-            marginVertical: spacing.xs,
+            marginVertical: spacing.sm,
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+            overflow: "hidden",
+        },
+        header: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.xs,
+            paddingHorizontal: spacing.sm,
+            paddingTop: spacing.sm,
+            paddingBottom: spacing.xs,
+        },
+        headerText: {
+            flex: 1,
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+        },
+        skipBtn: {
+            paddingVertical: 2,
+            paddingHorizontal: spacing.xs,
+        },
+        skipText: {
+            fontSize: fontSize.xs,
+            fontWeight: "500",
         },
         progressBg: {
             height: 3,
             backgroundColor: colors.border,
+            marginHorizontal: spacing.sm,
+            marginBottom: spacing.xs,
             borderRadius: borderRadius.sm,
             overflow: "hidden",
-            marginBottom: spacing.xs,
         },
         progressFill: {
             height: "100%",
             borderRadius: borderRadius.sm,
         },
-        row: {
+        body: {
+            paddingHorizontal: spacing.sm,
+            paddingBottom: spacing.sm,
+            paddingTop: spacing.xs,
+            borderTopWidth: 1,
+            borderTopColor: colors.border,
+            gap: spacing.sm,
+        },
+        sectionLabel: {
+            fontSize: fontSize.xs,
+            color: colors.textSecondary,
+            fontWeight: "500",
+        },
+        presetsRow: {
+            flexDirection: "row",
+            gap: spacing.xs,
+            flexWrap: "wrap",
+        },
+        presetBtn: {
+            paddingVertical: spacing.xs,
+            paddingHorizontal: spacing.sm,
+            borderRadius: borderRadius.sm,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.background,
+        },
+        presetText: {
+            fontSize: fontSize.xs,
+            color: colors.text,
+            fontWeight: "500",
+        },
+        fineRow: {
             flexDirection: "row",
             alignItems: "center",
-            gap: spacing.xs,
+            gap: spacing.sm,
         },
-        timeText: {
-            fontSize: fontSize.xs,
-            fontWeight: "600",
-            flex: 1,
-        },
-        skipBtn: {
-            paddingVertical: 2,
+        fineBtn: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 4,
+            paddingVertical: spacing.xs,
             paddingHorizontal: spacing.sm,
+            borderRadius: borderRadius.sm,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.background,
         },
-        skipText: {
+        fineBtnText: {
             fontSize: fontSize.xs,
-            fontWeight: "600",
+            color: colors.text,
+            fontWeight: "500",
+        },
+        currentDuration: {
+            flex: 1,
+            alignItems: "center",
+        },
+        currentDurationText: {
+            fontSize: fontSize.lg,
+            fontWeight: "700",
         },
     });
 }
+

--- a/src/features/exercise/hooks/useRestTimer.ts
+++ b/src/features/exercise/hooks/useRestTimer.ts
@@ -13,6 +13,7 @@ interface TimerState {
     startedAtEpoch: number;
     targetDurationSeconds: number;
     workoutExerciseId: number | null;
+    lastUsedDuration: number | null;
 }
 
 interface TimerStore extends TimerState {
@@ -26,17 +27,20 @@ const useTimerStore = create<TimerStore>((set) => ({
     startedAtEpoch: 0,
     targetDurationSeconds: 120,
     workoutExerciseId: null,
+    lastUsedDuration: null,
     start: (workoutExerciseId, setType) =>
-        set({
+        set((state) => ({
             isRunning: true,
             startedAtEpoch: Date.now(),
-            targetDurationSeconds: REST_DEFAULTS[setType] ?? 120,
+            targetDurationSeconds: state.lastUsedDuration ?? REST_DEFAULTS[setType] ?? 120,
             workoutExerciseId,
-        }),
+        })),
     stop: () =>
         set({ isRunning: false, startedAtEpoch: 0, workoutExerciseId: null }),
-    setDuration: (seconds) =>
-        set({ targetDurationSeconds: Math.max(15, seconds) }),
+    setDuration: (seconds) => {
+        const clamped = Math.max(15, seconds);
+        set({ targetDurationSeconds: clamped, lastUsedDuration: clamped });
+    },
 }));
 
 export interface UseRestTimerReturn {

--- a/src/features/exercise/hooks/useRestTimer.ts
+++ b/src/features/exercise/hooks/useRestTimer.ts
@@ -18,6 +18,7 @@ interface TimerState {
 interface TimerStore extends TimerState {
     start: (workoutExerciseId: number, setType: string) => void;
     stop: () => void;
+    setDuration: (seconds: number) => void;
 }
 
 const useTimerStore = create<TimerStore>((set) => ({
@@ -34,6 +35,8 @@ const useTimerStore = create<TimerStore>((set) => ({
         }),
     stop: () =>
         set({ isRunning: false, startedAtEpoch: 0, workoutExerciseId: null }),
+    setDuration: (seconds) =>
+        set({ targetDurationSeconds: Math.max(15, seconds) }),
 }));
 
 export interface UseRestTimerReturn {
@@ -43,6 +46,7 @@ export interface UseRestTimerReturn {
     workoutExerciseId: number | null;
     start: (workoutExerciseId: number, setType: string) => void;
     skip: () => void;
+    setDuration: (seconds: number) => void;
     isTargetReached: boolean;
 }
 
@@ -89,6 +93,7 @@ export function useRestTimer(): UseRestTimerReturn {
         workoutExerciseId: store.workoutExerciseId,
         start: store.start,
         skip,
+        setDuration: store.setDuration,
         isTargetReached: elapsedSeconds >= store.targetDurationSeconds,
     };
 }

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -176,6 +176,7 @@ export default function WorkoutScreen() {
                     restTimerTarget={timerActive ? restTimer.targetSeconds : 0}
                     restTimerReached={timerActive ? restTimer.isTargetReached : false}
                     onRestTimerSkip={restTimer.skip}
+                    onRestTimerChangeDuration={restTimer.setDuration}
                 />
             </View>
         );

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -396,9 +396,11 @@ const de = {
             editTimes: "Trainingszeiten bearbeiten",
         },
         restTimer: {
+            label: "Pause",
             rest: "Pause",
             skip: "Überspringen",
             target: "Ziel",
+            adjustDuration: "Dauer anpassen",
         },
         quickAdd: {
             title: "Übung schnell hinzufügen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -394,9 +394,11 @@ const en = {
             editTimes: "Edit Workout Times",
         },
         restTimer: {
+            label: "Rest",
             rest: "Rest",
             skip: "Skip",
             target: "Target",
+            adjustDuration: "Adjust duration",
         },
         quickAdd: {
             title: "Quick Add Exercise",


### PR DESCRIPTION
## Summary
- remove the header/body border divider so the progress bar acts as the visual separator
- make preset duration buttons equal-width and evenly distributed
- persist `lastUsedDuration` in `useRestTimer` so subsequent timer starts reuse the last value instead of resetting to defaults

## Testing
- not run (UI/state behavior change)

Closes #333
