### PR TITLE
feat: database schema & CRUD for progress photos

### DIFF
--- a/src/features/photos/services/photoDb.ts
+++ b/src/features/photos/services/photoDb.ts
@@ -1,0 +1,66 @@
+import { db } from "@/src/services/db";
+import { progressPhotos, workouts } from "@/src/services/db/schema";
+import { eq } from "drizzle-orm";
+import type { PhotoWithRelations } from "../types";
+
+type Photo = typeof progressPhotos.$inferSelect;
+type NewPhoto = typeof progressPhotos.$inferInsert;
+
+export function createPhoto(photo: Omit<NewPhoto, "created_at" | "updated_at">): Photo {
+    const now = Date.now();
+    return db
+        .insert(progressPhotos)
+        .values({ ...photo, created_at: now, updated_at: now })
+        .returning()
+        .get();
+}
+
+export function getPhotoById(id: number): Photo | undefined {
+    return db.select().from(progressPhotos).where(eq(progressPhotos.id, id)).get();
+}
+
+export function listByLogEntry(logEntryId: number): Photo[] {
+    return db
+        .select()
+        .from(progressPhotos)
+        .where(eq(progressPhotos.log_entry_id, logEntryId))
+        .orderBy(progressPhotos.created_at)
+        .all();
+}
+
+export function listByLogEntryWithRelations(logEntryId: number): PhotoWithRelations[] {
+    const rows = db
+        .select({
+            photo: progressPhotos,
+            workout: {
+                id: workouts.id,
+                title: workouts.title,
+                date: workouts.date,
+            },
+        })
+        .from(progressPhotos)
+        .leftJoin(workouts, eq(progressPhotos.workout_tag_id, workouts.id))
+        .where(eq(progressPhotos.log_entry_id, logEntryId))
+        .orderBy(progressPhotos.created_at)
+        .all();
+
+    return rows.map(({ photo, workout }) => ({
+        ...photo,
+        workoutTag: workout?.id
+            ? { workoutId: workout.id, workoutTitle: workout.title ?? null, workoutDate: workout.date }
+            : null,
+    }));
+}
+
+export function updatePhoto(id: number, changes: Partial<Omit<NewPhoto, "id" | "created_at">>): Photo | undefined {
+    return db
+        .update(progressPhotos)
+        .set({ ...changes, updated_at: Date.now() })
+        .where(eq(progressPhotos.id, id))
+        .returning()
+        .get();
+}
+
+export function deletePhoto(id: number): void {
+    db.delete(progressPhotos).where(eq(progressPhotos.id, id)).run();
+}

--- a/src/features/photos/types.ts
+++ b/src/features/photos/types.ts
@@ -1,0 +1,22 @@
+export interface Photo {
+    id: number;
+    log_entry_id: number | null;
+    image_path: string | null;
+    image_data: string | null;
+    workout_tag_id: number | null;
+    notes: string | null;
+    created_at: number;
+    updated_at: number;
+}
+
+export type NewPhoto = Omit<Photo, "id">;
+
+export interface PhotoTag {
+    workoutId: number;
+    workoutTitle: string | null;
+    workoutDate: string;
+}
+
+export interface PhotoWithRelations extends Photo {
+    workoutTag: PhotoTag | null;
+}

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -163,6 +163,17 @@ export function initDB() {
       is_scheduled INTEGER NOT NULL DEFAULT 0
     );
 
+    CREATE TABLE IF NOT EXISTS progress_photos (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      log_entry_id INTEGER REFERENCES entries(id),
+      image_path TEXT,
+      image_data TEXT,
+      workout_tag_id INTEGER REFERENCES workouts(id),
+      notes TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
     INSERT OR IGNORE INTO goals (id) VALUES (1);
     INSERT OR IGNORE INTO notification_settings (id) VALUES (1);
   `);

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -166,3 +166,14 @@ export const exerciseSets = sqliteTable("exercise_sets", {
     completed_at: integer("completed_at"),
     is_scheduled: integer("is_scheduled").notNull().default(0),
 });
+
+export const progressPhotos = sqliteTable("progress_photos", {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    log_entry_id: integer("log_entry_id").references(() => entries.id),
+    image_path: text("image_path"),
+    image_data: text("image_data"),
+    workout_tag_id: integer("workout_tag_id").references(() => workouts.id),
+    notes: text("notes"),
+    created_at: integer("created_at").notNull(),
+    updated_at: integer("updated_at").notNull(),
+});


### PR DESCRIPTION
## Summary

Implements issue #335 (326-A): the database foundation for progress photos.

### Changes
- **Schema**: Added `progressPhotos` Drizzle table to `src/services/db/schema.ts` with columns: `id`, `log_entry_id`, `image_path`, `image_data`, `workout_tag_id` (optional FK → workouts), `notes`, `created_at`, `updated_at`
- **initDB**: Registered `progress_photos` via `CREATE TABLE IF NOT EXISTS` for zero-migration compatibility on existing installs
- **Types**: `src/features/photos/types.ts` exports `Photo`, `NewPhoto`, `PhotoTag`, `PhotoWithRelations`
- **Service**: `src/features/photos/services/photoDb.ts` implements `createPhoto`, `getPhotoById`, `listByLogEntry`, `listByLogEntryWithRelations`, `updatePhoto`, `deletePhoto`

closes #335