### PR TITLE
feat: free-form custom fields for "other" exercises (#362)

### DIFF
--- a/src/features/exercise/components/CreateExerciseModal.tsx
+++ b/src/features/exercise/components/CreateExerciseModal.tsx
@@ -16,9 +16,11 @@ import {
     View,
 } from "react-native";
 import { EQUIPMENT_LIST, EXERCISE_TYPES, MUSCLE_GROUPS } from "../constants";
+import { parseCustomFields, serializeCustomFields, type CustomField } from "../helpers/customFields";
 import { createExerciseTemplate, getExerciseTemplateById, updateExerciseTemplate, type ExerciseTemplate } from "../services/exerciseDb";
 import type { Equipment, ExerciseType, MuscleGroup, ResistanceMode, WeightUnit } from "../types";
 import ChipSelect from "./ChipSelect";
+import CustomFieldsEditor from "./CustomFieldsEditor";
 
 interface CreateExerciseModalProps {
     visible: boolean;
@@ -40,6 +42,7 @@ export default function CreateExerciseModal({ visible, exerciseId, initialName, 
     const [equipment, setEquipment] = useState<Equipment | null>(null);
     const [resistanceMode, setResistanceMode] = useState<ResistanceMode>("resistance");
     const [defaultUnit, setDefaultUnit] = useState<WeightUnit>("kg");
+    const [customFields, setCustomFields] = useState<CustomField[]>([]);
     const [nameError, setNameError] = useState(false);
 
     useEffect(() => {
@@ -54,10 +57,12 @@ export default function CreateExerciseModal({ visible, exerciseId, initialName, 
             setEquipment((existing.equipment as Equipment) ?? null);
             setResistanceMode((existing.resistance_mode as ResistanceMode) ?? "resistance");
             setDefaultUnit((existing.default_weight_unit as WeightUnit) ?? "kg");
+            setCustomFields(parseCustomFields(existing.custom_fields));
             return;
         }
 
         setName(initialName?.trim() ?? "");
+        setCustomFields([]);
         setNameError(false);
     }, [visible, exerciseId, initialName]);
 
@@ -68,6 +73,7 @@ export default function CreateExerciseModal({ visible, exerciseId, initialName, 
         setEquipment(null);
         setResistanceMode("resistance");
         setDefaultUnit("kg");
+        setCustomFields([]);
         setNameError(false);
     }
 
@@ -82,6 +88,7 @@ export default function CreateExerciseModal({ visible, exerciseId, initialName, 
             setNameError(true);
             return;
         }
+        const customFieldsJson = type === "other" ? serializeCustomFields(customFields) : null;
         if (isEditing) {
             updateExerciseTemplate(exerciseId, {
                 name: trimmed,
@@ -90,6 +97,7 @@ export default function CreateExerciseModal({ visible, exerciseId, initialName, 
                 equipment,
                 resistance_mode: resistanceMode,
                 default_weight_unit: defaultUnit,
+                custom_fields: customFieldsJson,
             });
             const updated = getExerciseTemplateById(exerciseId)!;
             resetForm();
@@ -102,6 +110,7 @@ export default function CreateExerciseModal({ visible, exerciseId, initialName, 
                 equipment,
                 resistance_mode: resistanceMode,
                 default_weight_unit: defaultUnit,
+                custom_fields: customFieldsJson,
             });
             resetForm();
             onCreated(template);
@@ -159,6 +168,10 @@ export default function CreateExerciseModal({ visible, exerciseId, initialName, 
                         onSelect={setEquipment}
                         noneLabel={t("exercise.createExercise.none")}
                     />
+
+                    {type === "other" && (
+                        <CustomFieldsEditor fields={customFields} onChange={setCustomFields} />
+                    )}
 
                     {type === "weight" && (
                         <>

--- a/src/features/exercise/components/CustomFieldsEditor.tsx
+++ b/src/features/exercise/components/CustomFieldsEditor.tsx
@@ -1,0 +1,134 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { newCustomFieldId, type CustomField } from "../helpers/customFields";
+
+interface CustomFieldsEditorProps {
+    fields: CustomField[];
+    onChange: (fields: CustomField[]) => void;
+}
+
+export default function CustomFieldsEditor({ fields, onChange }: CustomFieldsEditorProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+
+    function update(id: string, patch: Partial<CustomField>) {
+        onChange(fields.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+    }
+
+    function remove(id: string) {
+        onChange(fields.filter((f) => f.id !== id));
+    }
+
+    function add() {
+        onChange([...fields, { id: newCustomFieldId(), name: "", unit: "", higherIsBetter: true }]);
+    }
+
+    return (
+        <View style={styles.container}>
+            <Text style={styles.fieldLabel}>{t("exercise.createExercise.customFields")}</Text>
+            <Text style={styles.hint}>{t("exercise.createExercise.customFieldsHint")}</Text>
+
+            {fields.map((field) => (
+                <View key={field.id} style={styles.fieldRow}>
+                    <TextInput
+                        style={[styles.input, styles.nameInput]}
+                        value={field.name}
+                        onChangeText={(v) => update(field.id, { name: v })}
+                        placeholder={t("exercise.createExercise.customFieldName")}
+                        placeholderTextColor={colors.textTertiary}
+                        returnKeyType="done"
+                    />
+                    <TextInput
+                        style={[styles.input, styles.unitInput]}
+                        value={field.unit}
+                        onChangeText={(v) => update(field.id, { unit: v })}
+                        placeholder={t("exercise.createExercise.customFieldUnit")}
+                        placeholderTextColor={colors.textTertiary}
+                        returnKeyType="done"
+                    />
+                    <Pressable
+                        onPress={() => update(field.id, { higherIsBetter: !field.higherIsBetter })}
+                        style={styles.dirToggle}
+                        hitSlop={6}
+                    >
+                        <Ionicons
+                            name={field.higherIsBetter ? "arrow-up" : "arrow-down"}
+                            size={18}
+                            color={colors.primary}
+                        />
+                    </Pressable>
+                    <Pressable onPress={() => remove(field.id)} style={styles.removeBtn} hitSlop={6}>
+                        <Ionicons name="close-circle" size={20} color={colors.textTertiary} />
+                    </Pressable>
+                </View>
+            ))}
+
+            <Pressable onPress={add} style={styles.addBtn}>
+                <Ionicons name="add-circle-outline" size={18} color={colors.primary} />
+                <Text style={styles.addText}>{t("exercise.createExercise.addCustomField")}</Text>
+            </Pressable>
+        </View>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        container: { gap: spacing.sm },
+        fieldLabel: {
+            fontSize: fontSize.sm,
+            fontWeight: "500",
+            color: colors.textSecondary,
+            marginBottom: spacing.xs,
+        },
+        hint: {
+            fontSize: fontSize.xs,
+            color: colors.textTertiary,
+            marginTop: -spacing.xs,
+        },
+        fieldRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+        },
+        input: {
+            backgroundColor: colors.surface,
+            borderWidth: 1,
+            borderColor: colors.border,
+            borderRadius: borderRadius.md,
+            paddingVertical: spacing.sm,
+            paddingHorizontal: spacing.md,
+            fontSize: fontSize.md,
+            color: colors.text,
+        },
+        nameInput: { flex: 1 },
+        unitInput: { width: 72 },
+        dirToggle: {
+            width: 32,
+            height: 32,
+            borderRadius: borderRadius.sm,
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: colors.primaryLight,
+        },
+        removeBtn: {
+            alignItems: "center",
+            justifyContent: "center",
+        },
+        addBtn: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.xs,
+            paddingVertical: spacing.xs,
+        },
+        addText: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.primary,
+        },
+    });
+}

--- a/src/features/exercise/components/ExerciseCardHelpers.ts
+++ b/src/features/exercise/components/ExerciseCardHelpers.ts
@@ -1,5 +1,6 @@
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { StyleSheet } from "react-native";
+import { parseCustomValues, type CustomValues } from "../helpers/customFields";
 import type { ExerciseSet } from "../services/exerciseDb";
 
 export interface Prefill {
@@ -8,6 +9,7 @@ export interface Prefill {
     rir: number | null;
     duration: number | null;
     distance: number | null;
+    custom: CustomValues;
 }
 
 /** Determine if a set is the "active" (first non-completed) set. */
@@ -22,22 +24,25 @@ export function getPrefillForSet(index: number, sets: ExerciseSet[], lastWorkout
     // 1. Previous completed set in same exercise
     for (let i = index - 1; i >= 0; i--) {
         if (sets[i].completed_at) {
-            return {
-                weight: sets[i].weight, reps: sets[i].reps, rir: sets[i].rir,
-                duration: sets[i].duration_seconds, distance: sets[i].distance_meters,
-            };
+            return prefillFromSet(sets[i]);
         }
     }
     // 2. Matching set from last workout
     if (lastWorkoutSets.length > index) {
-        const lw = lastWorkoutSets[index];
-        return { weight: lw.weight, reps: lw.reps, rir: lw.rir, duration: lw.duration_seconds, distance: lw.distance_meters };
+        return prefillFromSet(lastWorkoutSets[index]);
     }
     if (lastWorkoutSets.length > 0) {
-        const lw = lastWorkoutSets[lastWorkoutSets.length - 1];
-        return { weight: lw.weight, reps: lw.reps, rir: lw.rir, duration: lw.duration_seconds, distance: lw.distance_meters };
+        return prefillFromSet(lastWorkoutSets[lastWorkoutSets.length - 1]);
     }
-    return { weight: null, reps: null, rir: null, duration: null, distance: null };
+    return { weight: null, reps: null, rir: null, duration: null, distance: null, custom: {} };
+}
+
+function prefillFromSet(s: ExerciseSet): Prefill {
+    return {
+        weight: s.weight, reps: s.reps, rir: s.rir,
+        duration: s.duration_seconds, distance: s.distance_meters,
+        custom: parseCustomValues(s.custom_values),
+    };
 }
 
 /** Build a compact summary string for a set list, e.g. "80kg × 8" for the best completed set. */

--- a/src/features/exercise/components/ExpandedExerciseCard.tsx
+++ b/src/features/exercise/components/ExpandedExerciseCard.tsx
@@ -5,6 +5,7 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Pressable, Text, View } from "react-native";
 import DraggableFlatList, { type RenderItemParams } from "react-native-draggable-flatlist";
+import { parseCustomFields } from "../helpers/customFields";
 import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
 import type { ExerciseType } from "../types";
 import { createExerciseCardStyles, getPrefillForSet, isActiveSet } from "./ExerciseCardHelpers";
@@ -58,6 +59,8 @@ export function ExpandedExerciseCard({
     const { t } = useTranslation();
     const styles = useMemo(() => createExerciseCardStyles(colors), [colors]);
     const router = useRouter();
+    const customFields = parseCustomFields(template?.custom_fields);
+    const useCustom = exerciseType === "other" && customFields.length > 0;
 
     function handleRemove() {
         Alert.alert(
@@ -117,7 +120,7 @@ export function ExpandedExerciseCard({
                 {exerciseType === "weight" && (
                     <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.weight")}</Text>
                 )}
-                {exerciseType !== "cardio" && (
+                {exerciseType !== "cardio" && !useCustom && (
                     <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.reps")}</Text>
                 )}
                 {exerciseType === "cardio" && (
@@ -126,7 +129,12 @@ export function ExpandedExerciseCard({
                         <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.distance")}</Text>
                     </>
                 )}
-                {exerciseType !== "cardio" && (
+                {useCustom && customFields.map((f) => (
+                    <Text key={f.id} style={[styles.headerCell, styles.valueCol]} numberOfLines={1}>
+                        {f.name}{f.unit ? ` (${f.unit})` : ""}
+                    </Text>
+                ))}
+                {exerciseType !== "cardio" && !useCustom && (
                     <Text style={[styles.headerCell, styles.rirCol]}>{t("exercise.exerciseCard.rir")}</Text>
                 )}
                 <Text style={[styles.headerCell, styles.emptyCol]}></Text>
@@ -158,6 +166,7 @@ export function ExpandedExerciseCard({
                                 set={set}
                                 index={si}
                                 exerciseType={exerciseType}
+                                customFields={customFields}
                                 isActive={active}
                                 isFinished={isFinished}
                                 prefillWeight={prefill.weight}
@@ -165,6 +174,7 @@ export function ExpandedExerciseCard({
                                 prefillRir={prefill.rir}
                                 prefillDuration={prefill.duration}
                                 prefillDistance={prefill.distance}
+                                prefillCustom={prefill.custom}
                                 onConfirm={onConfirmSet}
                                 onUpdate={onUpdateSet}
                                 onDelete={onDeleteSet}

--- a/src/features/exercise/components/ReadOnlyExerciseCard.tsx
+++ b/src/features/exercise/components/ReadOnlyExerciseCard.tsx
@@ -4,6 +4,7 @@ import { Ionicons } from "@expo/vector-icons";
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { parseCustomFields, parseCustomValues, type CustomField } from "../helpers/customFields";
 import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
 import type { ExerciseType } from "../types";
 
@@ -17,6 +18,8 @@ export default function ReadOnlyExerciseCard({ item, onCopy }: ReadOnlyExerciseC
     const { t } = useTranslation();
     const styles = useMemo(() => createStyles(colors), [colors]);
     const exerciseType: ExerciseType = (item.exerciseTemplate?.type as ExerciseType) ?? "weight";
+    const customFields = parseCustomFields(item.exerciseTemplate?.custom_fields);
+    const useCustom = exerciseType === "other" && customFields.length > 0;
     const completedSets = item.sets.filter((s) => !!s.completed_at);
 
     return (
@@ -37,7 +40,7 @@ export default function ReadOnlyExerciseCard({ item, onCopy }: ReadOnlyExerciseC
                 {exerciseType === "weight" && (
                     <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.weight")}</Text>
                 )}
-                {exerciseType !== "cardio" && (
+                {exerciseType !== "cardio" && !useCustom && (
                     <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.reps")}</Text>
                 )}
                 {exerciseType === "cardio" && (
@@ -46,14 +49,19 @@ export default function ReadOnlyExerciseCard({ item, onCopy }: ReadOnlyExerciseC
                         <Text style={[styles.headerCell, styles.valueCol]}>{t("exercise.exerciseCard.distance")}</Text>
                     </>
                 )}
-                {exerciseType !== "cardio" && (
+                {useCustom && customFields.map((f) => (
+                    <Text key={f.id} style={[styles.headerCell, styles.valueCol]} numberOfLines={1}>
+                        {f.name}{f.unit ? ` (${f.unit})` : ""}
+                    </Text>
+                ))}
+                {exerciseType !== "cardio" && !useCustom && (
                     <Text style={[styles.headerCell, styles.rirCol]}>{t("exercise.exerciseCard.rir")}</Text>
                 )}
             </View>
 
             {/* Set rows */}
             {completedSets.map((set, i) => (
-                <ReadOnlySetRow key={set.id} set={set} index={i} exerciseType={exerciseType} styles={styles} colors={colors} />
+                <ReadOnlySetRow key={set.id} set={set} index={i} exerciseType={exerciseType} customFields={customFields} styles={styles} colors={colors} />
             ))}
 
             {completedSets.length === 0 && (
@@ -63,11 +71,13 @@ export default function ReadOnlyExerciseCard({ item, onCopy }: ReadOnlyExerciseC
     );
 }
 
-function ReadOnlySetRow({ set, index, exerciseType, styles, colors }: {
-    set: ExerciseSet; index: number; exerciseType: ExerciseType;
+function ReadOnlySetRow({ set, index, exerciseType, customFields, styles, colors }: {
+    set: ExerciseSet; index: number; exerciseType: ExerciseType; customFields: CustomField[];
     styles: ReturnType<typeof createStyles>; colors: ReturnType<typeof useThemeColors>;
 }) {
     const textColor = colors.text;
+    const useCustom = exerciseType === "other" && customFields.length > 0;
+    const customValues = useCustom ? parseCustomValues(set.custom_values) : {};
     return (
         <View style={styles.setRow}>
             <Text style={[styles.setCell, styles.setCol, { color: colors.textSecondary }]}>{index + 1}</Text>
@@ -76,7 +86,7 @@ function ReadOnlySetRow({ set, index, exerciseType, styles, colors }: {
                     {set.weight != null ? `${set.weight} ${set.weight_unit}` : "—"}
                 </Text>
             )}
-            {exerciseType !== "cardio" && (
+            {exerciseType !== "cardio" && !useCustom && (
                 <Text style={[styles.setCell, styles.valueCol, { color: textColor }]}>
                     {set.reps ?? "—"}
                 </Text>
@@ -91,7 +101,12 @@ function ReadOnlySetRow({ set, index, exerciseType, styles, colors }: {
                     </Text>
                 </>
             )}
-            {exerciseType !== "cardio" && (
+            {useCustom && customFields.map((f) => (
+                <Text key={f.id} style={[styles.setCell, styles.valueCol, { color: textColor }]}>
+                    {customValues[f.id] != null ? `${customValues[f.id]}${f.unit ? ` ${f.unit}` : ""}` : "—"}
+                </Text>
+            ))}
+            {exerciseType !== "cardio" && !useCustom && (
                 <Text style={[styles.setCell, styles.rirCol, { color: textColor }]}>
                     {set.rir ?? "—"}
                 </Text>

--- a/src/features/exercise/components/SetInputHelpers.tsx
+++ b/src/features/exercise/components/SetInputHelpers.tsx
@@ -1,14 +1,19 @@
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import React from "react";
-import { StyleSheet, Text } from "react-native";
+import { StyleSheet, Text, TextInput } from "react-native";
+import { parseCustomValues, type CustomField, type CustomValues } from "../helpers/customFields";
 import type { ExerciseSet } from "../services/exerciseDb";
 
-type ExerciseType = "weight" | "bodyweight" | "cardio";
+type ExerciseType = "weight" | "bodyweight" | "cardio" | "other";
 
-export function ScheduledCells({ set, exerciseType, textColor, styles }: {
-    set: ExerciseSet; exerciseType: ExerciseType; textColor: string;
+export function ScheduledCells({ set, exerciseType, customFields, textColor, styles }: {
+    set: ExerciseSet; exerciseType: ExerciseType; customFields: CustomField[]; textColor: string;
     styles: ReturnType<typeof createSetInputStyles>;
 }) {
+    const useCustom = exerciseType === "other" && customFields.length > 0;
+    if (useCustom) {
+        return <CustomReadonlyCells fields={customFields} values={parseCustomValues(set.custom_values)} textColor={textColor} styles={styles} />;
+    }
     return (
         <>
             {exerciseType === "weight" && (
@@ -36,6 +41,60 @@ export function ScheduledCells({ set, exerciseType, textColor, styles }: {
                     {set.rir ?? "—"}
                 </Text>
             )}
+        </>
+    );
+}
+
+/** Read-only display of a set's custom field values (one flex cell per field). */
+export function CustomReadonlyCells({ fields, values, textColor, styles }: {
+    fields: CustomField[]; values: CustomValues; textColor: string;
+    styles: { setCell: object; valueCol: object };
+}) {
+    return (
+        <>
+            {fields.map((f) => (
+                <Text key={f.id} style={[styles.setCell, styles.valueCol, { color: textColor }]}>
+                    {values[f.id] != null ? `${values[f.id]}${f.unit ? ` ${f.unit}` : ""}` : "—"}
+                </Text>
+            ))}
+        </>
+    );
+}
+
+/** Editable inputs for a set's custom fields (one per field), used in active/completed rows. */
+export function CustomEditableCells({ fields, inputs, cleared, prefill, focusedField, textColor, placeholderColor, onFocusField, onChangeField, onBlurField, styles }: {
+    fields: CustomField[];
+    inputs: Record<string, string>;
+    cleared: Partial<Record<string, boolean>>;
+    prefill: CustomValues;
+    focusedField: string | null;
+    textColor: string;
+    placeholderColor: string;
+    onFocusField: (key: string) => void;
+    onChangeField: (id: string, text: string) => void;
+    onBlurField: (key: string) => void;
+    styles: ReturnType<typeof createSetInputStyles>;
+}) {
+    return (
+        <>
+            {fields.map((f) => {
+                const key = `cf_${f.id}`;
+                const showPrefill = !cleared[f.id] && prefill[f.id] != null;
+                return (
+                    <TextInput
+                        key={f.id}
+                        style={[focusedField === key ? styles.input : styles.inlineInput, styles.valueCol, { color: textColor }]}
+                        value={inputs[f.id] ?? ""}
+                        onChangeText={(text) => onChangeField(f.id, text)}
+                        placeholder={showPrefill ? String(prefill[f.id]) : "—"}
+                        placeholderTextColor={placeholderColor}
+                        keyboardType="decimal-pad"
+                        selectTextOnFocus
+                        onFocus={() => onFocusField(key)}
+                        onBlur={() => onBlurField(key)}
+                    />
+                );
+            })}
         </>
     );
 }

--- a/src/features/exercise/components/SetInputRow.tsx
+++ b/src/features/exercise/components/SetInputRow.tsx
@@ -3,9 +3,10 @@ import { Ionicons } from "@expo/vector-icons";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Pressable, Text, TextInput, View } from "react-native";
+import { parseCustomValues, type CustomField, type CustomValues } from "../helpers/customFields";
 import type { ExerciseSet } from "../services/exerciseDb";
-import type { ExerciseType } from "../types";
-import { ScheduledCells, createSetInputStyles } from "./SetInputHelpers";
+import type { ExerciseType, SetValues } from "../types";
+import { CustomEditableCells, ScheduledCells, createSetInputStyles } from "./SetInputHelpers";
 
 const SET_TYPES = ["warmup", "working", "dropset", "failure"] as const;
 type SetType = (typeof SET_TYPES)[number];
@@ -16,9 +17,11 @@ const SET_TYPE_LABELS: Record<SetType, string> = {
 
 interface SetInputRowProps {
     set: ExerciseSet; index: number; exerciseType: ExerciseType;
+    customFields: CustomField[];
     isActive: boolean; isFinished: boolean;
     prefillWeight: number | null; prefillReps: number | null; prefillRir: number | null;
     prefillDuration: number | null; prefillDistance: number | null;
+    prefillCustom: CustomValues;
     onConfirm: (id: number, values: SetValues) => void;
     onUpdate: (id: number, values: SetValues) => void;
     onDelete: (id: number) => void;
@@ -26,11 +29,20 @@ interface SetInputRowProps {
     onDragStart?: () => void;
 }
 
-export type { SetValues } from "../types";
+export type { SetValues };
+
+function customValuesToInputs(json: string | null | undefined): Record<string, string> {
+    const values = parseCustomValues(json);
+    const inputs: Record<string, string> = {};
+    for (const [key, value] of Object.entries(values)) {
+        if (value != null) inputs[key] = String(value);
+    }
+    return inputs;
+}
 
 export default function SetInputRow({
-    set, index, exerciseType, isActive, isFinished,
-    prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance,
+    set, index, exerciseType, customFields, isActive, isFinished,
+    prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance, prefillCustom,
     onConfirm, onUpdate, onDelete, onTypeChange, onDragStart,
 }: SetInputRowProps) {
     const colors = useThemeColors();
@@ -40,6 +52,7 @@ export default function SetInputRow({
     const isCompleted = !!set.completed_at;
     const isScheduled = !!set.is_scheduled && !isCompleted;
     const isActiveSet = isActive && !isFinished;
+    const useCustom = exerciseType === "other" && customFields.length > 0;
 
     const [weight, setWeight] = useState(set.weight != null ? String(set.weight) : "");
     const [reps, setReps] = useState(set.reps != null ? String(set.reps) : "");
@@ -47,10 +60,11 @@ export default function SetInputRow({
     const [duration, setDuration] = useState(set.duration_seconds != null ? String(set.duration_seconds) : "");
     const [distance, setDistance] = useState(set.distance_meters != null ? String(set.distance_meters) : "");
     const [unit, setUnit] = useState<"kg" | "lb">((set.weight_unit as "kg" | "lb") ?? "kg");
+    const [customInputs, setCustomInputs] = useState<Record<string, string>>(() => customValuesToInputs(set.custom_values));
     const [focusedField, setFocusedField] = useState<string | null>(null);
     // Tracks fields the user has explicitly cleared; used to distinguish "never set" (show prefill)
     // from "intentionally cleared" (show "—" and save null). Reset when navigating to a new set.
-    const [clearedFields, setClearedFields] = useState<Partial<Record<"weight" | "reps" | "rir" | "duration" | "distance", boolean>>>({});
+    const [clearedFields, setClearedFields] = useState<Partial<Record<string, boolean>>>({});
 
     // Sync input state from DB when set values change (e.g., after a save)
     useEffect(() => {
@@ -59,8 +73,9 @@ export default function SetInputRow({
         setRir(set.rir != null ? String(set.rir) : "");
         setDuration(set.duration_seconds != null ? String(set.duration_seconds) : "");
         setDistance(set.distance_meters != null ? String(set.distance_meters) : "");
+        setCustomInputs(customValuesToInputs(set.custom_values));
         setUnit((set.weight_unit as "kg" | "lb") ?? "kg");
-    }, [set.id, set.weight, set.reps, set.rir, set.duration_seconds, set.distance_meters, set.weight_unit]);
+    }, [set.id, set.weight, set.reps, set.rir, set.duration_seconds, set.distance_meters, set.custom_values, set.weight_unit]);
 
     // Reset cleared-field tracking only when switching to a different set
     useEffect(() => {
@@ -69,16 +84,29 @@ export default function SetInputRow({
 
     const typeLabel = SET_TYPE_LABELS[set.type as SetType] ?? "";
 
-    const buildValues = useCallback((): SetValues => ({
-        weight: weight ? parseFloat(weight) : (clearedFields.weight ? null : prefillWeight),
-        weight_unit: unit,
-        reps: reps ? parseInt(reps, 10) : (clearedFields.reps ? null : prefillReps),
-        rir: rir ? parseInt(rir, 10) : (clearedFields.rir ? null : prefillRir),
-        duration_seconds: duration ? parseInt(duration, 10) : (clearedFields.duration ? null : prefillDuration),
-        distance_meters: distance ? parseFloat(distance) : (clearedFields.distance ? null : prefillDistance),
-        type: set.type,
-    }), [weight, reps, rir, duration, distance, unit, set.type, clearedFields,
-        prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance]);
+    const buildValues = useCallback((): SetValues => {
+        const custom_values: CustomValues = {};
+        for (const f of customFields) {
+            const raw = customInputs[f.id];
+            custom_values[f.id] = raw ? parseFloat(raw) : (clearedFields[f.id] ? null : (prefillCustom[f.id] ?? null));
+        }
+        return {
+            weight: weight ? parseFloat(weight) : (clearedFields.weight ? null : prefillWeight),
+            weight_unit: unit,
+            reps: reps ? parseInt(reps, 10) : (clearedFields.reps ? null : prefillReps),
+            rir: rir ? parseInt(rir, 10) : (clearedFields.rir ? null : prefillRir),
+            duration_seconds: duration ? parseInt(duration, 10) : (clearedFields.duration ? null : prefillDuration),
+            distance_meters: distance ? parseFloat(distance) : (clearedFields.distance ? null : prefillDistance),
+            custom_values,
+            type: set.type,
+        };
+    }, [weight, reps, rir, duration, distance, unit, set.type, clearedFields, customFields, customInputs,
+        prefillWeight, prefillReps, prefillRir, prefillDuration, prefillDistance, prefillCustom]);
+
+    const handleChangeCustom = useCallback((id: string, text: string) => {
+        setCustomInputs((prev) => ({ ...prev, [id]: text }));
+        setClearedFields((prev) => ({ ...prev, [id]: text === "" }));
+    }, []);
 
     const handleToggleUnit = useCallback(() => {
         const newUnit = unit === "kg" ? "lb" : "kg";
@@ -123,7 +151,7 @@ export default function SetInputRow({
                 <Text style={[styles.setCell, styles.setCol, { color: colors.textTertiary }]}>
                     {typeLabel}{index + 1}
                 </Text>
-                <ScheduledCells set={set} exerciseType={exerciseType} textColor={colors.textTertiary} styles={styles} />
+                <ScheduledCells set={set} exerciseType={exerciseType} customFields={customFields} textColor={colors.textTertiary} styles={styles} />
                 <Pressable style={styles.checkCol} onPress={handleDelete}>
                     <Ionicons name="trash-outline" size={18} color={colors.textTertiary} />
                 </Pressable>
@@ -172,7 +200,7 @@ export default function SetInputRow({
                 </View>
             )}
 
-            {exerciseType !== "cardio" && (
+            {exerciseType !== "cardio" && !useCustom && (
                 <TextInput
                     style={[fieldStyle("reps"), styles.valueCol, { color: textColor }]}
                     value={reps}
@@ -222,7 +250,23 @@ export default function SetInputRow({
                 </>
             )}
 
-            {exerciseType !== "cardio" && (
+            {useCustom && (
+                <CustomEditableCells
+                    fields={customFields}
+                    inputs={customInputs}
+                    cleared={clearedFields}
+                    prefill={prefillCustom}
+                    focusedField={focusedField}
+                    textColor={textColor}
+                    placeholderColor={colors.textTertiary}
+                    onFocusField={setFocusedField}
+                    onChangeField={handleChangeCustom}
+                    onBlurField={handleBlurSave}
+                    styles={styles}
+                />
+            )}
+
+            {exerciseType !== "cardio" && !useCustom && (
                 <TextInput
                     style={[fieldStyle("rir"), styles.rirCol, { color: textColor }]}
                     value={rir}

--- a/src/features/exercise/helpers/customFields.ts
+++ b/src/features/exercise/helpers/customFields.ts
@@ -1,0 +1,71 @@
+// Custom set-tracking fields for "other" type exercises (issue #362).
+// A template defines an ordered list of CustomField; each set stores a
+// { [fieldId]: number } map of values. Both are persisted as JSON text.
+
+export interface CustomField {
+    id: string;
+    name: string;
+    /** Optional unit label shown in the column header, e.g. "s", "cm". */
+    unit: string;
+    /** Progression direction — true if a higher value is an improvement. */
+    higherIsBetter: boolean;
+}
+
+export type CustomValues = Record<string, number | null>;
+
+/** Generate a stable-enough id for a new custom field. */
+export function newCustomFieldId(): string {
+    return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`;
+}
+
+export function parseCustomFields(json: string | null | undefined): CustomField[] {
+    if (!json) return [];
+    try {
+        const parsed = JSON.parse(json);
+        if (!Array.isArray(parsed)) return [];
+        return parsed
+            .filter((f): f is Record<string, unknown> => !!f && typeof f === "object")
+            .map((f) => ({
+                id: typeof f.id === "string" ? f.id : newCustomFieldId(),
+                name: typeof f.name === "string" ? f.name : "",
+                unit: typeof f.unit === "string" ? f.unit : "",
+                higherIsBetter: f.higherIsBetter !== false,
+            }));
+    } catch {
+        return [];
+    }
+}
+
+/** Serialize fields for storage; drops unnamed fields. Returns null when empty. */
+export function serializeCustomFields(fields: CustomField[]): string | null {
+    const cleaned = fields
+        .map((f) => ({ ...f, name: f.name.trim(), unit: f.unit.trim() }))
+        .filter((f) => f.name.length > 0);
+    return cleaned.length > 0 ? JSON.stringify(cleaned) : null;
+}
+
+export function parseCustomValues(json: string | null | undefined): CustomValues {
+    if (!json) return {};
+    try {
+        const parsed = JSON.parse(json);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+        const result: CustomValues = {};
+        for (const [key, value] of Object.entries(parsed)) {
+            result[key] = typeof value === "number" ? value : null;
+        }
+        return result;
+    } catch {
+        return {};
+    }
+}
+
+/** Serialize values for storage, keeping only numeric entries. Null when empty. */
+export function serializeCustomValues(values: CustomValues): string | null {
+    const entries = Object.entries(values).filter(([, v]) => typeof v === "number");
+    return entries.length > 0 ? JSON.stringify(Object.fromEntries(entries)) : null;
+}
+
+/** Whether an "other" exercise should render its custom-field columns. */
+export function hasCustomFields(fields: CustomField[]): boolean {
+    return fields.length > 0;
+}

--- a/src/features/exercise/hooks/useWorkoutActions.ts
+++ b/src/features/exercise/hooks/useWorkoutActions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { Alert } from "react-native";
 import { useTranslation } from "react-i18next";
+import { serializeCustomValues } from "../helpers/customFields";
 import type { SetValues } from "../types";
 import type { UseRestTimerReturn } from "./useRestTimer";
 import type { UseWorkoutReturn } from "./useWorkout";
@@ -38,6 +39,7 @@ export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestT
             rir: values.rir,
             duration_seconds: values.duration_seconds,
             distance_meters: values.distance_meters,
+            custom_values: serializeCustomValues(values.custom_values),
             type: values.type,
         });
         completeSet(setId);
@@ -59,6 +61,7 @@ export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestT
             rir: values.rir,
             duration_seconds: values.duration_seconds,
             distance_meters: values.distance_meters,
+            custom_values: serializeCustomValues(values.custom_values),
             type: values.type,
         });
         workout.reload();

--- a/src/features/exercise/services/exerciseSetDb.ts
+++ b/src/features/exercise/services/exerciseSetDb.ts
@@ -94,6 +94,7 @@ export function copySetsFromLastSession(templateId: number, targetWorkoutExercis
                 duration_seconds: s.duration_seconds,
                 distance_meters: s.distance_meters,
                 rir: s.rir,
+                custom_values: s.custom_values,
                 rest_seconds: s.rest_seconds,
                 is_scheduled: 1,
             })
@@ -122,6 +123,7 @@ export function copySetsFromWorkoutExercise(sourceWorkoutExerciseId: number, tar
                 duration_seconds: s.duration_seconds,
                 distance_meters: s.distance_meters,
                 rir: s.rir,
+                custom_values: s.custom_values,
                 rest_seconds: s.rest_seconds,
                 is_scheduled: 1,
             })

--- a/src/features/exercise/types.ts
+++ b/src/features/exercise/types.ts
@@ -16,5 +16,7 @@ export interface SetValues {
     rir: number | null;
     duration_seconds: number | null;
     distance_meters: number | null;
+    /** Values for an "other" exercise's custom fields, keyed by field id. */
+    custom_values: Record<string, number | null>;
     type: string;
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -418,6 +418,11 @@ const de = {
             defaultUnit: "Standardeinheit",
             none: "Keine",
             nameRequired: "Name ist erforderlich",
+            customFields: "Eigene Felder",
+            customFieldsHint: "Verfolge alles: z. B. Haltezeit, Ringabstand. Der Pfeil legt fest, ob höher oder niedriger besser ist.",
+            customFieldName: "Feldname",
+            customFieldUnit: "Einheit",
+            addCustomField: "Feld hinzufügen",
         },
         workoutSummary: {
             title: "Training",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -417,6 +417,11 @@ const en = {
             defaultUnit: "Default Unit",
             none: "None",
             nameRequired: "Name is required",
+            customFields: "Custom Fields",
+            customFieldsHint: "Track anything: e.g. hold time, ring distance. Arrow sets whether higher or lower is better.",
+            customFieldName: "Field name",
+            customFieldUnit: "Unit",
+            addCustomField: "Add field",
         },
         workoutSummary: {
             title: "Workouts",

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -207,6 +207,8 @@ export function initDB() {
     "ALTER TABLE notification_settings ADD COLUMN snack_enabled INTEGER NOT NULL DEFAULT 1",
     "ALTER TABLE notification_settings ADD COLUMN weight_enabled INTEGER NOT NULL DEFAULT 1",
     "ALTER TABLE entries ADD COLUMN is_scheduled INTEGER NOT NULL DEFAULT 0",
+    "ALTER TABLE exercise_templates ADD COLUMN custom_fields TEXT",
+    "ALTER TABLE exercise_sets ADD COLUMN custom_values TEXT",
   ];
   for (const sql of migrations) {
     try { expoDb.execSync(sql); } catch { /* column already exists */ }

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -128,6 +128,9 @@ export const exerciseTemplates = sqliteTable("exercise_templates", {
     resistance_mode: text("resistance_mode").notNull().default("resistance"),
     default_weight_unit: text("default_weight_unit").notNull().default("kg"),
     notes: text("notes"),
+    // JSON array of custom set-tracking fields for "other" type exercises:
+    // [{ id, name, unit, higherIsBetter }]. Null/empty for standard exercises.
+    custom_fields: text("custom_fields"),
     deleted: integer("deleted").notNull().default(0),
     created_at: integer("created_at").notNull(),
 });
@@ -163,6 +166,8 @@ export const exerciseSets = sqliteTable("exercise_sets", {
     distance_meters: real("distance_meters"),
     rir: integer("rir"),
     rest_seconds: integer("rest_seconds"),
+    // JSON object of values for the template's custom fields: { [fieldId]: number }.
+    custom_values: text("custom_values"),
     completed_at: integer("completed_at"),
     is_scheduled: integer("is_scheduled").notNull().default(0),
 });


### PR DESCRIPTION
Closes #362

## What & why
Some exercises don't fit the standard weight/reps/cardio model — iron-cross progressions (hold duration, ring distance, duration-in-reserve), weighted front lever (duration + weight), farmer's walk (duration, distance, weight). This lets users define arbitrary tracked fields for any **"Other"** type exercise.

## How it works
- In **Create/Edit Exercise**, selecting type **Other** reveals a *Custom Fields* editor. Each field has a **name**, an optional **unit**, and a **higher-/lower-is-better** direction (↑/↓ toggle, stored for future progression logic).
- Custom fields are stored as JSON on the template (`exercise_templates.custom_fields`); per-set values as JSON on the set (`exercise_sets.custom_values`).
- During a workout, an Other exercise with custom fields renders one input column per field (in place of reps/RIR), with the usual prefill-from-last-set behaviour, unit toggle-free labels in the header, and the same confirm/blur-save flow.
- Read-only history cards, scheduled/dim rows, and copy-from-last-session all carry the custom values.

## Data / migrations
Schema evolves by hand per this repo's convention — two replayable `ALTER TABLE ... ADD COLUMN` entries appended to the migrations list in `src/services/db/index.ts`, matching the new columns in `schema.ts`. Existing installs and standard exercises are unaffected (columns are nullable, only read for `type === "other"`).

## Checks
- `npx tsc --noEmit`: no new errors introduced (net −1 vs. `main`; the remaining errors are pre-existing, from the recent AI SDK upgrade).
- `npm run lint`: no new errors in touched/new files (net −1 vs. `main`).
- ⚠️ Not exercised in a running simulator (no device available in this environment) — manual QA of the create-field → log-set → view-history flow is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)