### PR TITLE
Tie nutrition goals to the day they were set (#368)

### DIFF
--- a/src/features/log/hooks/useLogData.ts
+++ b/src/features/log/hooks/useLogData.ts
@@ -1,4 +1,4 @@
-import { getGoals, getNotificationSettings, type Goals } from "@/src/features/settings/services/settingsDb";
+import { getGoals, getGoalsForDate, getNotificationSettings, type Goals } from "@/src/features/settings/services/settingsDb";
 import { cancelWeightReminderIfLogged, syncTodayMealReminders, syncTodayWeightReminder } from "@/src/services/notifications";
 import { useAppStore } from "@/src/shared/store/useAppStore";
 import { type MealType } from "@/src/shared/types";
@@ -34,10 +34,13 @@ export function useLogData() {
     const [grouped, setGrouped] = useState(emptyGrouped);
     const [prevGrouped, setPrevGrouped] = useState(emptyGrouped);
     const [nextGrouped, setNextGrouped] = useState(emptyGrouped);
-    const [dailyGoals, setDailyGoals] = useState<Goals>({
+    const defaultGoals: Goals = {
         id: 1, calories: 2000, protein: 150, carbs: 250, fat: 70,
         unit_system: "metric", language: "en", appearance_mode: "system", keep_awake: 0,
-    });
+    };
+    const [dailyGoals, setDailyGoals] = useState<Goals>(defaultGoals);
+    const [prevGoals, setPrevGoals] = useState<Goals>(defaultGoals);
+    const [nextGoals, setNextGoals] = useState<Goals>(defaultGoals);
 
     const [editingEntry, setEditingEntry] = useState<EntryWithFood | null>(null);
     const [editingRecipeGroup, setEditingRecipeGroup] = useState<{ group: RecipeGroup; multiplier: number } | null>(null);
@@ -54,12 +57,19 @@ export function useLogData() {
     const [workoutRefreshKey, setWorkoutRefreshKey] = useState(0);
 
     function loadAllDays(center: Date) {
+        const prevDate = shiftCalendarDate(center, -1);
+        const nextDate = shiftCalendarDate(center, +1);
         setGrouped(loadGrouped(center));
-        setPrevGrouped(loadGrouped(shiftCalendarDate(center, -1)));
-        setNextGrouped(loadGrouped(shiftCalendarDate(center, +1)));
+        setPrevGrouped(loadGrouped(prevDate));
+        setNextGrouped(loadGrouped(nextDate));
+        const centerGoals = getGoalsForDate(formatDateKey(center));
+        if (centerGoals) setDailyGoals(centerGoals);
+        const prevDayGoals = getGoalsForDate(formatDateKey(prevDate));
+        if (prevDayGoals) setPrevGoals(prevDayGoals);
+        const nextDayGoals = getGoalsForDate(formatDateKey(nextDate));
+        if (nextDayGoals) setNextGoals(nextDayGoals);
         const g = getGoals();
         if (g) {
-            setDailyGoals(g);
             if (g.unit_system === "metric" || g.unit_system === "imperial") {
                 useAppStore.getState().setUnitSystem(g.unit_system as "metric" | "imperial");
             }
@@ -269,7 +279,7 @@ export function useLogData() {
 
     return {
         selectedDate, carouselRef, chatBarVisible, setChatBarVisible,
-        grouped, prevGrouped, nextGrouped, dailyGoals,
+        grouped, prevGrouped, nextGrouped, dailyGoals, prevGoals, nextGoals,
         editingEntry, setEditingEntry, editingRecipeGroup, setEditingRecipeGroup,
         portionInput, setPortionInput,
         selectionMode, selectedEntryIds, moveModalVisible, setMoveModalVisible,

--- a/src/features/log/screens/LogScreen.tsx
+++ b/src/features/log/screens/LogScreen.tsx
@@ -119,7 +119,7 @@ export default function LogScreen() {
                 contentOffset={{ x: SCREEN_WIDTH, y: 0 }}
                 style={styles.carousel} scrollEnabled={!d.selectionMode}
             >
-                <LogDayPage width={SCREEN_WIDTH} grouped={d.prevGrouped} goals={d.dailyGoals} onAdd={d.navigateToAdd}
+                <LogDayPage width={SCREEN_WIDTH} grouped={d.prevGrouped} goals={d.prevGoals} onAdd={d.navigateToAdd}
                     onDelete={d.handleDelete} onEdit={d.handleEdit} onEditRecipeGroup={d.handleEditRecipeGroup}
                     onDeleteRecipeLog={d.handleDeleteRecipeLog} onConfirmEntry={d.handleConfirmEntry}
                     onConfirmRecipeLog={d.handleConfirmRecipeLog}
@@ -138,7 +138,7 @@ export default function LogScreen() {
                     dateKey={formatDateKey(d.selectedDate)}
                     onQuickAdd={() => setShowAddExercise(true)}
                     workoutRefreshKey={d.workoutRefreshKey} />
-                <LogDayPage width={SCREEN_WIDTH} grouped={d.nextGrouped} goals={d.dailyGoals} onAdd={d.navigateToAdd}
+                <LogDayPage width={SCREEN_WIDTH} grouped={d.nextGrouped} goals={d.nextGoals} onAdd={d.navigateToAdd}
                     onDelete={d.handleDelete} onEdit={d.handleEdit} onEditRecipeGroup={d.handleEditRecipeGroup}
                     onDeleteRecipeLog={d.handleDeleteRecipeLog} onConfirmEntry={d.handleConfirmEntry}
                     onConfirmRecipeLog={d.handleConfirmRecipeLog}

--- a/src/features/settings/screens/GoalsScreen.tsx
+++ b/src/features/settings/screens/GoalsScreen.tsx
@@ -8,7 +8,8 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { getGoals, setGoals } from "../services/settingsDb";
+import { formatDateKey } from "@/src/utils/date";
+import { getGoals, setNutritionGoals } from "../services/settingsDb";
 
 export default function GoalsScreen() {
     const { t } = useTranslation();
@@ -43,7 +44,7 @@ export default function GoalsScreen() {
             return;
         }
 
-        setGoals({ calories: cal, protein: p, carbs: c, fat: f });
+        setNutritionGoals({ calories: cal, protein: p, carbs: c, fat: f }, formatDateKey(new Date()));
         Alert.alert(t("settings.saved"), t("settings.goalsUpdated"));
     }
 

--- a/src/features/settings/services/importExport.ts
+++ b/src/features/settings/services/importExport.ts
@@ -7,6 +7,7 @@ import {
     exerciseSets,
     exerciseTemplates,
     foods,
+    goalHistory,
     goals,
     notificationSettings,
     recipeItems,
@@ -29,6 +30,7 @@ interface ExportPayload {
     foods: (typeof foods.$inferSelect)[];
     entries: (typeof entries.$inferSelect)[];
     goals: (typeof goals.$inferSelect)[];
+    goalHistory?: (typeof goalHistory.$inferSelect)[];
     recipes: (typeof recipes.$inferSelect)[];
     recipeItems: (typeof recipeItems.$inferSelect)[];
     recipeLogs?: (typeof recipeLogs.$inferSelect)[];
@@ -53,6 +55,7 @@ export async function exportData(): Promise<void> {
         foods: db.select().from(foods).all(),
         entries: db.select().from(entries).all(),
         goals: db.select().from(goals).all(),
+        goalHistory: db.select().from(goalHistory).all(),
         recipes: db.select().from(recipes).all(),
         recipeItems: db.select().from(recipeItems).all(),
         recipeLogs: db.select().from(recipeLogs).all(),
@@ -116,6 +119,7 @@ export async function importData(): Promise<{ inserted: number }> {
         tx.delete(servingUnits).run();
         tx.delete(foods).run();
         tx.delete(weightLogs).run();
+        tx.delete(goalHistory).run();
         tx.delete(notificationSettings).run();
 
         for (const row of data.foods) {
@@ -158,6 +162,12 @@ export async function importData(): Promise<{ inserted: number }> {
                 tx.insert(goals).values(row).run();
             }
             inserted++;
+        }
+        if (data.goalHistory) {
+            for (const row of data.goalHistory) {
+                tx.insert(goalHistory).values(row).run();
+                inserted++;
+            }
         }
         if (data.notificationSettings) {
             for (const row of data.notificationSettings) {
@@ -226,6 +236,9 @@ function validate(data: unknown): asserts data is ExportPayload {
         if (!Array.isArray(d[key])) {
             throw new Error(`Invalid backup file: missing "${key}" array.`);
         }
+    }
+    if (d.goalHistory !== undefined && !Array.isArray(d.goalHistory)) {
+        throw new Error(`Invalid backup file: "goalHistory" must be an array.`);
     }
     // recipeLogs is optional for backwards compat with older exports
     if (d.recipeLogs !== undefined && !Array.isArray(d.recipeLogs)) {

--- a/src/features/settings/services/settingsDb.ts
+++ b/src/features/settings/services/settingsDb.ts
@@ -1,9 +1,12 @@
 import { db } from "@/src/services/db";
-import { goals, notificationSettings } from "@/src/services/db/schema";
-import { eq } from "drizzle-orm";
+import { goalHistory, goals, notificationSettings } from "@/src/services/db/schema";
+import { desc, eq, lte } from "drizzle-orm";
 
 export type Goals = typeof goals.$inferSelect;
 export type NotificationSettings = typeof notificationSettings.$inferSelect;
+
+/** The macro-nutrition subset of goals that is tracked historically per day. */
+export type NutritionGoals = Pick<Goals, "calories" | "protein" | "carbs" | "fat">;
 
 // ── Goals ──────────────────────────────────────────────────
 
@@ -13,6 +16,37 @@ export function getGoals(): Goals | undefined {
 
 export function setGoals(values: Partial<Omit<Goals, "id">>) {
     db.update(goals).set(values).where(eq(goals.id, 1)).run();
+}
+
+/**
+ * Save nutrition goals and record them in the history as effective from
+ * `dateKey` onward. Changing goals multiple times on one day overwrites that
+ * day's snapshot, so only the last save of the day counts.
+ */
+export function setNutritionGoals(values: NutritionGoals, dateKey: string) {
+    setGoals(values);
+    db.delete(goalHistory).where(eq(goalHistory.date, dateKey)).run();
+    db.insert(goalHistory).values({ ...values, date: dateKey }).run();
+}
+
+/**
+ * Resolve the nutrition goals that were active on a given day: the most recent
+ * history snapshot with date <= `dateKey`. Falls back to the current goals when
+ * no snapshot precedes the day (e.g. days before any goal was ever recorded).
+ */
+export function getGoalsForDate(dateKey: string): Goals | undefined {
+    const current = getGoals();
+    if (!current) return undefined;
+    const snapshot = db
+        .select()
+        .from(goalHistory)
+        .where(lte(goalHistory.date, dateKey))
+        .orderBy(desc(goalHistory.date), desc(goalHistory.id))
+        .limit(1)
+        .get();
+    if (!snapshot) return current;
+    const { calories, protein, carbs, fat } = snapshot;
+    return { ...current, calories, protein, carbs, fat };
 }
 
 // ── Notification Settings ──────────────────────────────────

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -58,6 +58,15 @@ export function initDB() {
       keep_awake INTEGER NOT NULL DEFAULT 0
     );
 
+    CREATE TABLE IF NOT EXISTS goal_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      date TEXT NOT NULL,
+      calories REAL NOT NULL,
+      protein REAL NOT NULL,
+      carbs REAL NOT NULL,
+      fat REAL NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS recipe_items (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       recipe_id INTEGER NOT NULL REFERENCES recipes(id),
@@ -248,5 +257,19 @@ export function initDB() {
       `UPDATE entries SET recipe_log_id = ? WHERE recipe_log_group = ?`,
       [newId, g.recipe_log_group],
     );
+  }
+
+  // Seed goal history for existing installs: without a starting snapshot, past
+  // days would have no goal to resolve to. Backfill the current goals dated at
+  // the epoch so every existing/past day keeps using them, while future goal
+  // changes only affect days from the day they were made onward.
+  const goalHistoryCount = expoDb.getFirstSync<{ count: number }>(
+    `SELECT COUNT(*) as count FROM goal_history`,
+  );
+  if (!goalHistoryCount || goalHistoryCount.count === 0) {
+    expoDb.execSync(`
+      INSERT INTO goal_history (date, calories, protein, carbs, fat)
+      SELECT '1970-01-01', calories, protein, carbs, fat FROM goals WHERE id = 1;
+    `);
   }
 }

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -51,6 +51,18 @@ export const goals = sqliteTable("goals", {
     keep_awake: integer("keep_awake").notNull().default(0),
 });
 
+// Point-in-time snapshots of nutrition goals. `date` is the day the goal
+// became effective; the goal applied to any given day is the most recent row
+// with date <= that day. Only one row per date (latest save of the day wins).
+export const goalHistory = sqliteTable("goal_history", {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    date: text("date").notNull(),
+    calories: real("calories").notNull(),
+    protein: real("protein").notNull(),
+    carbs: real("carbs").notNull(),
+    fat: real("fat").notNull(),
+});
+
 export const recipes = sqliteTable("recipes", {
     id: integer("id").primaryKey({ autoIncrement: true }),
     name: text("name").notNull(),


### PR DESCRIPTION
Closes #368

## Problem

Goals lived in a single mutable row, so changing them rewrote the past too. Coming out of a bulk into a cut made the entire bulk look like the goals were massively exceeded, when in reality the goals were simply different then.

## Solution

Nutrition goals (calories/protein/carbs/fat) are now snapshotted per day in a new `goal_history` table:

- Saving goals records a snapshot against the current date and updates the live `goals` row (still used for the editor and AI meal planning).
- The log screen resolves each day's goal via `getGoalsForDate(dateKey)` — the most recent snapshot on or before that day — so past days keep the goal that was active then. The carousel's prev/current/next pages each resolve their own goal.
- Changing goals several times on one day overwrites that day's snapshot, so only the last save counts (per the issue).

## Migration & compatibility

- `initDB()` creates `goal_history` and, on existing installs, backfills one snapshot from the current goals dated at the epoch. This keeps all past days resolving to the current goals (no visible change to existing history) while future edits only affect days from the edit onward.
- Only the macro subset is historized; app settings on the goals row (unit system, language, appearance, keep-awake) stay global.
- `goal_history` is added to backup export/import.

## Testing

- `npx tsc --noEmit` — no new type errors (24 pre-existing, unchanged).
- `npm run lint` — no new problems (identical count before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)