### PR TITLE
feat: recipe template variants

### DIFF
--- a/src/features/ai/screens/MealPlanScreen.tsx
+++ b/src/features/ai/screens/MealPlanScreen.tsx
@@ -1,5 +1,6 @@
 import { addEntry } from "@/src/features/log/services/logDb";
 import { getGoals } from "@/src/features/settings/services/settingsDb";
+import { formatRecipeName } from "@/src/features/templates/services/recipeVariantsDb";
 import { getAllFoods, getAllRecipes, getRecipeItems } from "@/src/features/templates/services/templateDb";
 import Button from "@/src/shared/atoms/Button";
 import Input from "@/src/shared/atoms/Input";
@@ -89,7 +90,7 @@ export default function MealPlanScreen() {
             const items = getRecipeItems(r.id);
             return {
                 id: r.id,
-                name: r.name,
+                name: formatRecipeName(r),
                 items: items.map((i) => ({
                     food_id: i.recipe_items.food_id,
                     quantity_grams: i.recipe_items.quantity_grams,

--- a/src/features/ai/services/toolExecutors/mealPlanToolExecutors.ts
+++ b/src/features/ai/services/toolExecutors/mealPlanToolExecutors.ts
@@ -1,4 +1,5 @@
 import { getGoals } from "@/src/features/settings/services/settingsDb";
+import { formatRecipeName } from "@/src/features/templates/services/recipeVariantsDb";
 import { getAllFoods, getAllRecipes, getRecipeItems } from "@/src/features/templates/services/templateDb";
 import i18n from "@/src/i18n";
 import type { AiToolResult } from "../../types/toolDefinitionTypes";
@@ -27,7 +28,7 @@ function executeCreateMealPlan(args: Record<string, unknown>): AiToolResult {
     const allRecipes = getAllRecipes();
     const recipePayload: AiRecipePayload[] = allRecipes.map((r) => {
         const items = getRecipeItems(r.id);
-        return { id: r.id, name: r.name, items: items.map((i) => ({ food_id: i.recipe_items.food_id, quantity_grams: i.recipe_items.quantity_grams })) };
+        return { id: r.id, name: formatRecipeName(r), items: items.map((i) => ({ food_id: i.recipe_items.food_id, quantity_grams: i.recipe_items.quantity_grams })) };
     });
 
     const goalsPayload: AiGoalsPayload = { calories: goals.calories, protein: goals.protein, carbs: goals.carbs, fat: goals.fat };

--- a/src/features/ai/services/toolExecutors/templateToolExecutors.ts
+++ b/src/features/ai/services/toolExecutors/templateToolExecutors.ts
@@ -16,6 +16,7 @@ import {
     updateRecipe,
     type NewFood,
 } from "@/src/features/templates/services/templateDb";
+import { formatRecipeName } from "@/src/features/templates/services/recipeVariantsDb";
 import i18n from "@/src/i18n";
 import { resolveQuantityToGrams } from "../unitResolution";
 import type { AiToolResult } from "../../types/toolDefinitionTypes";
@@ -38,7 +39,7 @@ function executeSearchLibrary(args: Record<string, unknown>): AiToolResult {
             serving_units: servingUnits,
         };
     });
-    const matchedRecipes = searchRecipesByName(query).map((r) => ({ type: "recipe" as const, id: r.id, name: r.name }));
+    const matchedRecipes = searchRecipesByName(query).map((r) => ({ type: "recipe" as const, id: r.id, name: formatRecipeName(r) }));
     const results = [...matchedFoods, ...matchedRecipes];
 
     return { success: true, summary: i18n.t("chat.toolResult.searchLibrary", { foodCount: matchedFoods.length, recipeCount: matchedRecipes.length, query }), data: results };

--- a/src/features/log/components/EntryModal.tsx
+++ b/src/features/log/components/EntryModal.tsx
@@ -172,7 +172,7 @@ export default function EntryModal({
                                             style={[styles.recipeGroupName, isSelected && styles.recipeGroupNameActive]}
                                             numberOfLines={1}
                                         >
-                                            {g.recipeName}{g.portion !== 1 ? ` (${g.portion}x)` : ""}
+                                            {g.recipeName}{g.recipeVariant ? ` · ${g.recipeVariant}` : ""}{g.portion !== 1 ? ` (${g.portion}x)` : ""}
                                         </Text>
                                     </Pressable>
                                 );

--- a/src/features/log/components/MealSection.tsx
+++ b/src/features/log/components/MealSection.tsx
@@ -1,3 +1,4 @@
+import { getRecipeDisplayName } from "@/src/features/templates/services/recipeVariantsDb";
 import { getRecipeById } from "@/src/features/templates/services/templateDb";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import type { MealType } from "@/src/shared/types";
@@ -55,10 +56,12 @@ function groupEntries(items: EntryWithFood[]) {
             continue;
         }
         const recipe = getRecipeById(recipeLog.recipe_id);
+        const display = recipe ? getRecipeDisplayName(recipe) : null;
         recipeGroups.push({
             recipeLogId,
             recipeId: recipeLog.recipe_id,
-            recipeName: recipe?.name ?? "Recipe",
+            recipeName: display?.name ?? "Recipe",
+            recipeVariant: display?.variant ?? null,
             portion: recipeLog.portion,
             rows,
         });

--- a/src/features/log/components/MoveCopyModal.tsx
+++ b/src/features/log/components/MoveCopyModal.tsx
@@ -242,7 +242,7 @@ export default function MoveCopyModal({
                                                         disabled && styles.mealOptionTextDisabled,
                                                     ]}
                                                 >
-                                                    {recipe.recipeName}
+                                                    {recipe.recipeName}{recipe.recipeVariant ? ` · ${recipe.recipeVariant}` : ""}
                                                 </Text>
                                             </Pressable>
                                         );

--- a/src/features/log/components/RecipeGroupRow.tsx
+++ b/src/features/log/components/RecipeGroupRow.tsx
@@ -100,9 +100,16 @@ export default function RecipeGroupRow({
                     color={isGroupScheduled ? colors.disabled : (isModified ? colors.textSecondary : colors.primary)}
                     style={{ marginLeft: 4 }}
                 />
-                <Text style={[styles.recipeName, isGroupScheduled && styles.scheduledText]} numberOfLines={1}>
-                    {displayName}
-                </Text>
+                <View style={styles.nameColumn}>
+                    <Text style={[styles.recipeName, isGroupScheduled && styles.scheduledText]} numberOfLines={1}>
+                        {displayName}
+                    </Text>
+                    {group.recipeVariant != null && (
+                        <Text style={[styles.recipeVariant, isGroupScheduled && styles.scheduledText]} numberOfLines={1}>
+                            {group.recipeVariant}
+                        </Text>
+                    )}
+                </View>
                 <Text style={[styles.recipeDetail, isGroupScheduled && styles.scheduledText]}>
                     {t("common.itemCount", { count: group.rows.length })} · {Math.round(totalCals)} {t("common.cal")}
                 </Text>
@@ -183,11 +190,15 @@ function createStyles(colors: ThemeColors) {
             paddingVertical: spacing.sm,
             gap: spacing.xs,
         },
+        nameColumn: { flex: 1 },
         recipeName: {
-            flex: 1,
             fontSize: fontSize.sm,
             fontWeight: "600",
             color: colors.primary,
+        },
+        recipeVariant: {
+            fontSize: fontSize.xs,
+            color: colors.textSecondary,
         },
         recipeDetail: {
             fontSize: fontSize.xs,

--- a/src/features/log/components/RecipeLogModal.tsx
+++ b/src/features/log/components/RecipeLogModal.tsx
@@ -1,3 +1,4 @@
+import { getRecipeDisplayName } from "@/src/features/templates/services/recipeVariantsDb";
 import { getRecipeItems, getServingUnits, type Recipe } from "@/src/features/templates/services/templateDb";
 import { cancelMealReminderIfLogged } from "@/src/services/notifications";
 import Button from "@/src/shared/atoms/Button";
@@ -50,6 +51,8 @@ export default function RecipeLogModal({
     React.useEffect(() => {
         if (recipe) setPortionInput("1");
     }, [recipe]);
+
+    const displayName = React.useMemo(() => (recipe ? getRecipeDisplayName(recipe) : null), [recipe]);
 
     const items = React.useMemo(() => (recipe ? getRecipeItems(recipe.id) : []), [recipe]);
     const servingUnitGramsByFoodId = React.useMemo(() => {
@@ -104,7 +107,10 @@ export default function RecipeLogModal({
                 </View>
 
                 <ScrollView contentContainerStyle={styles.content}>
-                    <Text style={styles.recipeName}>{recipe.name}</Text>
+                    <Text style={styles.recipeName}>{displayName?.name ?? recipe.name}</Text>
+                    {displayName?.variant != null && (
+                        <Text style={styles.recipeVariant}>{displayName.variant}</Text>
+                    )}
                     <Text style={styles.summary}>
                         {t("common.itemCount", { count: items.length })} · {Math.round(totalCals)} {t("common.cal")}
                     </Text>
@@ -206,6 +212,11 @@ function createStyles(colors: ThemeColors, insetsTop = 0) {
             fontSize: fontSize.xl,
             fontWeight: "700",
             color: colors.text,
+            marginBottom: spacing.xs,
+        },
+        recipeVariant: {
+            fontSize: fontSize.md,
+            color: colors.textSecondary,
             marginBottom: spacing.xs,
         },
         summary: {

--- a/src/features/log/hooks/useAddFoodSearch.ts
+++ b/src/features/log/hooks/useAddFoodSearch.ts
@@ -1,9 +1,9 @@
+import { getRecipeGroups, type RecipeGroup } from "@/src/features/templates/services/recipeVariantsDb";
 import {
     addFood,
     getFoodByBarcode,
     getFoodByOpenfoodfactsId,
     searchFoodsByName,
-    searchRecipesByName,
     type Food,
     type Recipe,
 } from "@/src/features/templates/services/templateDb";
@@ -37,14 +37,27 @@ export function useAddFoodSearch() {
     const [showManualForm, setShowManualForm] = useState(false);
     const [showScanner, setShowScanner] = useState(false);
 
-    // ── Recipe search ──────────────────────────────────────
-    const [recipeResults, setRecipeResults] = useState<Recipe[]>([]);
+    // ── Recipe search (variants grouped under their base, collapsed) ──
+    const [recipeResults, setRecipeResults] = useState<RecipeGroup[]>([]);
+    const [expandedRecipeIds, setExpandedRecipeIds] = useState<Set<number>>(new Set());
 
     useEffect(() => {
         if (query.trim().length < 2) { setRecipeResults([]); return; }
-        const timer = setTimeout(() => setRecipeResults(searchRecipesByName(query.trim())), 200);
+        const timer = setTimeout(() => {
+            setExpandedRecipeIds(new Set());
+            setRecipeResults(getRecipeGroups(query.trim()));
+        }, 200);
         return () => clearTimeout(timer);
     }, [query]);
+
+    function toggleRecipeExpanded(recipeId: number) {
+        setExpandedRecipeIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(recipeId)) next.delete(recipeId);
+            else next.add(recipeId);
+            return next;
+        });
+    }
 
     // ── Local search (debounced, search-as-you-type) ──────
     useEffect(() => {
@@ -169,6 +182,8 @@ export function useAddFoodSearch() {
         setQuery,
         localResults,
         recipeResults,
+        expandedRecipeIds,
+        toggleRecipeExpanded,
         offResults: filteredOFF,
         isSearchingOFF,
         offError,

--- a/src/features/log/screens/AddFoodScreen.tsx
+++ b/src/features/log/screens/AddFoodScreen.tsx
@@ -96,17 +96,46 @@ export default function AddFoodScreen() {
                 {search.showLocalSection && search.recipeResults.length > 0 && (
                     <>
                         <Text style={styles.sectionLabel}>{t("log.sectionRecipes")}</Text>
-                        {search.recipeResults.map((r) => (
-                            <Pressable
-                                key={r.id}
-                                style={styles.recipeRow}
-                                onPress={() => search.setSelectedRecipe(r)}
-                            >
-                                <Ionicons name="book-outline" size={18} color={colors.primary} />
-                                <Text style={styles.recipeRowName} numberOfLines={1}>{r.name}</Text>
-                                <Ionicons name="chevron-forward" size={16} color={colors.textTertiary} />
-                            </Pressable>
-                        ))}
+                        {search.recipeResults.map((group) => {
+                            const expanded = search.expandedRecipeIds.has(group.recipe.id);
+                            return (
+                                <View key={group.recipe.id} style={styles.recipeCard}>
+                                    <Pressable
+                                        style={styles.recipeRow}
+                                        onPress={() => search.setSelectedRecipe(group.recipe)}
+                                    >
+                                        <Ionicons name="book-outline" size={18} color={colors.primary} />
+                                        <Text style={styles.recipeRowName} numberOfLines={1}>{group.recipe.name}</Text>
+                                        {group.variants.length > 0 && (
+                                            <Pressable
+                                                onPress={() => search.toggleRecipeExpanded(group.recipe.id)}
+                                                hitSlop={8}
+                                                style={styles.variantToggle}
+                                            >
+                                                <Text style={styles.variantToggleText}>{group.variants.length}</Text>
+                                                <Ionicons
+                                                    name={expanded ? "chevron-up" : "chevron-down"}
+                                                    size={16}
+                                                    color={colors.textTertiary}
+                                                />
+                                            </Pressable>
+                                        )}
+                                        <Ionicons name="chevron-forward" size={16} color={colors.textTertiary} />
+                                    </Pressable>
+                                    {expanded && group.variants.map((variant) => (
+                                        <Pressable
+                                            key={variant.id}
+                                            style={[styles.recipeRow, styles.recipeVariantRow]}
+                                            onPress={() => search.setSelectedRecipe(variant)}
+                                        >
+                                            <Ionicons name="return-down-forward-outline" size={18} color={colors.textTertiary} />
+                                            <Text style={styles.recipeRowName} numberOfLines={1}>{variant.name}</Text>
+                                            <Ionicons name="chevron-forward" size={16} color={colors.textTertiary} />
+                                        </Pressable>
+                                    ))}
+                                </View>
+                            );
+                        })}
                     </>
                 )}
 
@@ -303,20 +332,38 @@ function createStyles(colors: ThemeColors) {
             marginTop: spacing.md,
             maxWidth: 220,
         },
+        recipeCard: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.md,
+            marginBottom: spacing.sm,
+        },
         recipeRow: {
             flexDirection: "row",
             alignItems: "center",
             gap: spacing.sm,
-            backgroundColor: colors.surface,
-            borderRadius: borderRadius.md,
             padding: spacing.md,
-            marginBottom: spacing.sm,
         },
         recipeRowName: {
             flex: 1,
             fontSize: fontSize.sm,
             fontWeight: "500",
             color: colors.text,
+        },
+        recipeVariantRow: {
+            marginHorizontal: spacing.md,
+            paddingHorizontal: spacing.xs,
+            borderTopWidth: StyleSheet.hairlineWidth,
+            borderTopColor: colors.border,
+        },
+        variantToggle: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 2,
+            paddingHorizontal: spacing.xs,
+        },
+        variantToggleText: {
+            fontSize: fontSize.xs,
+            color: colors.textTertiary,
         },
     });
 }

--- a/src/features/log/screens/LogScreen.tsx
+++ b/src/features/log/screens/LogScreen.tsx
@@ -106,6 +106,8 @@ export default function LogScreen() {
         setWeightInput("");
     }
 
+    const editingGroup = d.editingRecipeGroup?.group;
+
     return (
         <View style={[styles.screen, { paddingTop: insets.top }]}>
             <View style={styles.dateSelectorWrapper}>
@@ -224,7 +226,7 @@ export default function LogScreen() {
                 <Pressable style={styles.overlay} onPress={() => d.setEditingRecipeGroup(null)}>
                     <Pressable style={styles.portionModal} onPress={() => { }}>
                         <Text style={styles.portionModalTitle}>{t("log.adjustPortions")}</Text>
-                        <Text style={styles.portionModalSubtitle}>{d.editingRecipeGroup?.group.recipeName}</Text>
+                        <Text style={styles.portionModalSubtitle}>{[editingGroup?.recipeName, editingGroup?.recipeVariant].filter(Boolean).join(" · ")}</Text>
                         <View style={styles.portionRow}>
                             <Pressable
                                 onPress={() => { const v = Math.max(0.25, (parseFloat(d.portionInput) || 1) - 0.25); d.setPortionInput(String(Math.round(v * 100) / 100)); }}

--- a/src/features/log/services/logDb.ts
+++ b/src/features/log/services/logDb.ts
@@ -1,3 +1,4 @@
+import { getRecipeDisplayName } from "@/src/features/templates/services/recipeVariantsDb";
 import { getRecipeById, getRecipeItems, type Food } from "@/src/features/templates/services/templateDb";
 import { db } from "@/src/services/db";
 import { entries, foods, recipeItems, recipeLogs, recipes, weightLogs } from "@/src/services/db/schema";
@@ -16,6 +17,7 @@ export interface RecipeGroup {
     recipeLogId: number;
     recipeId: number;
     recipeName: string;
+    recipeVariant: string | null;
     portion: number;
     rows: EntryWithFood[];
 }
@@ -129,6 +131,7 @@ export interface LoggedRecipeGroup {
     recipeLogId: number;
     recipeId: number;
     recipeName: string;
+    recipeVariant: string | null;
     portion: number;
     isScheduled: boolean;
 }
@@ -151,6 +154,7 @@ export function getLoggedRecipeGroups(date: string, mealType: string): LoggedRec
 
     return rows.map((row) => {
         const recipe = getRecipeById(row.recipeId);
+        const display = recipe ? getRecipeDisplayName(recipe) : null;
         const groupEntries = db
             .select({ is_scheduled: entries.is_scheduled })
             .from(entries)
@@ -160,7 +164,8 @@ export function getLoggedRecipeGroups(date: string, mealType: string): LoggedRec
         return {
             recipeLogId: row.recipeLogId,
             recipeId: row.recipeId,
-            recipeName: recipe?.name ?? "Recipe",
+            recipeName: display?.name ?? "Recipe",
+            recipeVariant: display?.variant ?? null,
             portion: row.portion,
             isScheduled,
         };

--- a/src/features/templates/components/ForkRecipeModal.tsx
+++ b/src/features/templates/components/ForkRecipeModal.tsx
@@ -1,0 +1,96 @@
+import Button from "@/src/shared/atoms/Button";
+import Input from "@/src/shared/atoms/Input";
+import ModalHeader from "@/src/shared/atoms/ModalHeader";
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+    KeyboardAvoidingView,
+    Modal,
+    Platform,
+    ScrollView,
+    StyleSheet,
+    Text,
+} from "react-native";
+import type { ForkTarget } from "../hooks/useTemplateList";
+import { getRecipeDisplayName } from "../services/recipeVariantsDb";
+
+interface ForkRecipeModalProps {
+    target: ForkTarget | null;
+    onClose: () => void;
+    onSubmit: (variantName: string) => void;
+}
+
+export default function ForkRecipeModal({ target, onClose, onSubmit }: ForkRecipeModalProps) {
+    const { t } = useTranslation();
+    const colors = useThemeColors();
+    const styles = React.useMemo(() => createStyles(colors), [colors]);
+
+    const [variantName, setVariantName] = useState("");
+
+    // Reset the field whenever the modal is opened for a different recipe.
+    const [prevTarget, setPrevTarget] = useState(target);
+    if (target !== prevTarget) {
+        setPrevTarget(target);
+        setVariantName("");
+    }
+
+    function handleCreate() {
+        if (!variantName.trim()) return;
+        onSubmit(variantName.trim());
+    }
+
+    const baseName = target ? getRecipeDisplayName(target.recipe).name : "";
+
+    return (
+        <Modal
+            visible={!!target}
+            animationType="slide"
+            presentationStyle="pageSheet"
+            onRequestClose={onClose}
+        >
+            <KeyboardAvoidingView
+                behavior={Platform.OS === "ios" ? "padding" : undefined}
+                style={styles.flex}
+            >
+                <ModalHeader title={t("templates.createVariant")} onClose={onClose} />
+
+                <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+                    <Text style={styles.description}>
+                        {t("templates.forkDescription", { name: baseName })}
+                    </Text>
+
+                    <Input
+                        label={t("templates.variantName")}
+                        placeholder={t("templates.variantNamePlaceholder")}
+                        value={variantName}
+                        onChangeText={setVariantName}
+                        containerStyle={styles.input}
+                    />
+
+                    <Button
+                        title={t("common.create")}
+                        onPress={handleCreate}
+                        disabled={!variantName.trim()}
+                        style={styles.createButton}
+                    />
+                </ScrollView>
+            </KeyboardAvoidingView>
+        </Modal>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        flex: { flex: 1, backgroundColor: colors.background },
+        content: { padding: spacing.lg },
+        description: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            marginBottom: spacing.md,
+        },
+        input: { marginTop: spacing.sm },
+        createButton: { marginTop: spacing.lg },
+    });
+}

--- a/src/features/templates/components/TemplateCard.tsx
+++ b/src/features/templates/components/TemplateCard.tsx
@@ -12,9 +12,29 @@ interface TemplateCardProps {
     data: Recipe | Food | ExerciseTemplate;
     subtitle: string;
     onDelete: () => void;
+    // Recipe-only: variant group support
+    onFork?: () => void;
+    variants?: Recipe[];
+    variantSubtitle?: (variant: Recipe) => string;
+    expanded?: boolean;
+    onToggleExpand?: () => void;
+    onForkVariant?: (variant: Recipe) => void;
+    onDeleteVariant?: (variant: Recipe) => void;
 }
 
-export default function TemplateCard({ kind, data, subtitle, onDelete }: TemplateCardProps) {
+export default function TemplateCard({
+    kind,
+    data,
+    subtitle,
+    onDelete,
+    onFork,
+    variants = [],
+    variantSubtitle,
+    expanded = false,
+    onToggleExpand,
+    onForkVariant,
+    onDeleteVariant,
+}: TemplateCardProps) {
     const colors = useThemeColors();
     const styles = useMemo(() => createStyles(colors), [colors]);
 
@@ -24,9 +44,13 @@ export default function TemplateCard({ kind, data, subtitle, onDelete }: Templat
         exercise: { icon: "barbell-outline" as const, color: colors.exercise },
     }[kind];
 
+    function openRecipe(id: number) {
+        router.push({ pathname: "/templates/edit", params: { recipeId: String(id) } } as unknown as Href);
+    }
+
     function handlePress() {
         if (kind === "recipe") {
-            router.push({ pathname: "/templates/edit", params: { recipeId: String(data.id) } } as unknown as Href);
+            openRecipe(data.id);
         } else if (kind === "food") {
             router.push({ pathname: "/templates/food-edit", params: { foodId: String(data.id) } } as unknown as Href);
         } else {
@@ -35,16 +59,59 @@ export default function TemplateCard({ kind, data, subtitle, onDelete }: Templat
     }
 
     return (
-        <Pressable style={styles.card} onPress={handlePress}>
-            <Ionicons name={config.icon} size={22} color={config.color} style={styles.cardIcon} />
-            <View style={styles.cardInfo}>
-                <Text style={styles.cardName} numberOfLines={1}>{data.name}</Text>
-                <Text style={styles.cardSub}>{subtitle}</Text>
-            </View>
-            <Pressable onPress={onDelete} hitSlop={8}>
-                <Ionicons name="trash-outline" size={20} color={colors.danger} />
+        <View style={styles.card}>
+            <Pressable style={styles.row} onPress={handlePress}>
+                <Ionicons name={config.icon} size={22} color={config.color} style={styles.cardIcon} />
+                <View style={styles.cardInfo}>
+                    <Text style={styles.cardName} numberOfLines={1}>{data.name}</Text>
+                    <Text style={styles.cardSub}>{subtitle}</Text>
+                </View>
+                {variants.length > 0 && onToggleExpand && (
+                    <Pressable onPress={onToggleExpand} hitSlop={8} style={styles.actionIcon}>
+                        <Ionicons
+                            name={expanded ? "chevron-up" : "chevron-down"}
+                            size={20}
+                            color={colors.textSecondary}
+                        />
+                    </Pressable>
+                )}
+                {onFork && (
+                    <Pressable onPress={onFork} hitSlop={8} style={styles.actionIcon}>
+                        <Ionicons name="git-branch-outline" size={20} color={colors.textSecondary} />
+                    </Pressable>
+                )}
+                <Pressable onPress={onDelete} hitSlop={8}>
+                    <Ionicons name="trash-outline" size={20} color={colors.danger} />
+                </Pressable>
             </Pressable>
-        </Pressable>
+
+            {expanded && variants.map((variant) => (
+                <View key={variant.id} style={styles.variantRow}>
+                    <Pressable style={styles.variantInfo} onPress={() => openRecipe(variant.id)}>
+                        <Ionicons
+                            name="return-down-forward-outline"
+                            size={18}
+                            color={colors.textTertiary}
+                            style={styles.cardIcon}
+                        />
+                        <View style={styles.cardInfo}>
+                            <Text style={styles.cardName} numberOfLines={1}>{variant.name}</Text>
+                            {variantSubtitle && <Text style={styles.cardSub}>{variantSubtitle(variant)}</Text>}
+                        </View>
+                    </Pressable>
+                    {onForkVariant && (
+                        <Pressable onPress={() => onForkVariant(variant)} hitSlop={8} style={styles.actionIcon}>
+                            <Ionicons name="git-branch-outline" size={18} color={colors.textSecondary} />
+                        </Pressable>
+                    )}
+                    {onDeleteVariant && (
+                        <Pressable onPress={() => onDeleteVariant(variant)} hitSlop={8}>
+                            <Ionicons name="trash-outline" size={18} color={colors.danger} />
+                        </Pressable>
+                    )}
+                </View>
+            ))}
+        </View>
     );
 }
 
@@ -55,10 +122,27 @@ function createStyles(colors: ThemeColors) {
             borderRadius: borderRadius.lg,
             padding: spacing.md,
             marginBottom: spacing.sm,
+        },
+        row: {
+            flexDirection: "row",
+            alignItems: "center",
+        },
+        variantRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            marginTop: spacing.sm,
+            paddingTop: spacing.sm,
+            paddingLeft: spacing.sm,
+            borderTopWidth: StyleSheet.hairlineWidth,
+            borderTopColor: colors.border,
+        },
+        variantInfo: {
+            flex: 1,
             flexDirection: "row",
             alignItems: "center",
         },
         cardIcon: { marginRight: spacing.sm },
+        actionIcon: { marginRight: spacing.md },
         cardInfo: { flex: 1, marginRight: spacing.sm },
         cardName: { fontSize: fontSize.md, fontWeight: "600", color: colors.text },
         cardSub: { fontSize: fontSize.xs, color: colors.textSecondary, marginTop: 2 },

--- a/src/features/templates/hooks/useRecipeEditor.ts
+++ b/src/features/templates/hooks/useRecipeEditor.ts
@@ -37,6 +37,9 @@ export function useRecipeEditor() {
     recipeIdRef.current = recipeId;
 
     const [name, setName] = useState("");
+    // Base recipe name when editing a variant (whose own name is just the
+    // specification, e.g. "with sprinkles").
+    const [baseName, setBaseName] = useState<string | null>(null);
     const [items, setItems] = useState<ItemWithFood[]>([]);
 
     // food search
@@ -56,7 +59,11 @@ export function useRecipeEditor() {
     useEffect(() => {
         if (!recipeId) return;
         const recipe = getRecipeById(Number(recipeId));
-        if (recipe) setName(recipe.name);
+        if (recipe) {
+            setName(recipe.name);
+            const base = recipe.parent_recipe_id != null ? getRecipeById(recipe.parent_recipe_id) : undefined;
+            setBaseName(base?.name ?? null);
+        }
         loadItems(Number(recipeId));
     }, [recipeId]);
 
@@ -223,6 +230,7 @@ export function useRecipeEditor() {
         isEditing,
         name,
         setName,
+        baseName,
         items,
         totalCals,
         foodQuery,

--- a/src/features/templates/hooks/useTemplateList.ts
+++ b/src/features/templates/hooks/useTemplateList.ts
@@ -10,14 +10,13 @@ import { useFocusEffect } from "expo-router";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert } from "react-native";
+import { forkRecipe, getRecipeGroups } from "../services/recipeVariantsDb";
 import {
     deleteFood,
     deleteRecipe,
     getAllFoods,
-    getAllRecipes,
     getRecipeItems,
     searchFoodsByName,
-    searchRecipesByName,
     softDeleteFood,
     softDeleteRecipe,
     type Food,
@@ -28,8 +27,12 @@ type FilterType = "all" | "recipes" | "foods" | "exercises";
 
 export type TemplateItem =
     | { kind: "food"; data: Food }
-    | { kind: "recipe"; data: Recipe }
+    | { kind: "recipe"; data: Recipe; variants: Recipe[] }
     | { kind: "exercise"; data: ExerciseTemplate };
+
+export interface ForkTarget {
+    recipe: Recipe;
+}
 
 export function useTemplateList() {
     const { t } = useTranslation();
@@ -38,6 +41,8 @@ export function useTemplateList() {
     const [filter, setFilter] = useState<FilterType>("all");
     const [filterExpanded, setFilterExpanded] = useState(false);
     const [fabExpanded, setFabExpanded] = useState(false);
+    const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+    const [forkTarget, setForkTarget] = useState<ForkTarget | null>(null);
 
     const load = useCallback(() => {
         const q = query.trim();
@@ -45,8 +50,9 @@ export function useTemplateList() {
         const result: TemplateItem[] = [];
 
         if (filter === "all" || filter === "recipes") {
-            const recipeList = hasQuery ? searchRecipesByName(q) : getAllRecipes();
-            for (const r of recipeList) result.push({ kind: "recipe", data: r });
+            for (const group of getRecipeGroups(hasQuery ? q : undefined)) {
+                result.push({ kind: "recipe", data: group.recipe, variants: group.variants });
+            }
         }
         if (filter === "all" || filter === "foods") {
             const foodList = hasQuery ? searchFoodsByName(q) : getAllFoods();
@@ -62,6 +68,27 @@ export function useTemplateList() {
     }, [filter, query]);
 
     useFocusEffect(load);
+
+    function toggleExpanded(recipeId: number) {
+        setExpandedIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(recipeId)) next.delete(recipeId);
+            else next.add(recipeId);
+            return next;
+        });
+    }
+
+    function handleForkSubmit(variantName: string) {
+        if (!forkTarget) return;
+        const variant = forkRecipe(forkTarget.recipe.id, variantName);
+        logger.info("[DB] Forked recipe", { source: forkTarget.recipe.id, variant: variant.id });
+        setForkTarget(null);
+        if (variant.parent_recipe_id != null) {
+            // Expand the group so the new variant is visible.
+            setExpandedIds((prev) => new Set(prev).add(variant.parent_recipe_id!));
+        }
+        load();
+    }
 
     function handleDeleteRecipe(recipe: Recipe) {
         Alert.alert(t("templates.deleteRecipe"), t("templates.deleteTitle"), [
@@ -178,6 +205,11 @@ export function useTemplateList() {
         setFilterExpanded,
         fabExpanded,
         setFabExpanded,
+        expandedIds,
+        toggleExpanded,
+        forkTarget,
+        setForkTarget,
+        handleForkSubmit,
         handleDeleteRecipe,
         handleDeleteFood,
         handleDeleteExercise,

--- a/src/features/templates/screens/RecipeEditorScreen.tsx
+++ b/src/features/templates/screens/RecipeEditorScreen.tsx
@@ -71,9 +71,18 @@ export default function RecipeEditorScreen() {
                 contentContainerStyle={styles.content}
                 keyboardShouldPersistTaps="handled"
             >
+                {recipe.baseName != null && (
+                    <Text style={styles.variantOf}>
+                        {t("templates.variantOf", { name: recipe.baseName })}
+                    </Text>
+                )}
                 <Input
-                    label={t("templates.recipeName")}
-                    placeholder={t("templates.recipeNamePlaceholder")}
+                    label={recipe.baseName != null ? t("templates.variantName") : t("templates.recipeName")}
+                    placeholder={
+                        recipe.baseName != null
+                            ? t("templates.variantNamePlaceholder")
+                            : t("templates.recipeNamePlaceholder")
+                    }
                     value={recipe.name}
                     onChangeText={recipe.setName}
                     containerStyle={styles.nameInput}
@@ -252,6 +261,11 @@ function createStyles(colors: ThemeColors) {
     return StyleSheet.create({
         screen: { flex: 1, backgroundColor: colors.background },
         content: { padding: spacing.lg, paddingBottom: SHEET_COLLAPSED + spacing.lg },
+        variantOf: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            marginBottom: spacing.sm,
+        },
         nameInput: { marginBottom: spacing.md },
         summary: {
             fontSize: fontSize.sm,

--- a/src/features/templates/screens/TemplatesScreen.tsx
+++ b/src/features/templates/screens/TemplatesScreen.tsx
@@ -14,6 +14,7 @@ import {
     View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import ForkRecipeModal from "../components/ForkRecipeModal";
 import TemplateCard from "../components/TemplateCard";
 import { useTemplateList, type TemplateItem } from "../hooks/useTemplateList";
 import type { Food, Recipe } from "../services/templateDb";
@@ -27,15 +28,38 @@ export default function TemplatesScreen() {
     const list = useTemplateList();
 
     function renderItem({ item }: { item: TemplateItem }) {
-        const subtitle =
-            item.kind === "recipe" ? list.recipeSummary((item.data as Recipe).id) :
-            item.kind === "exercise" ? list.exerciseSummary(item.data as ExerciseTemplate) :
-            list.foodSummary(item.data as Food);
-
         const handleDelete =
             item.kind === "recipe" ? () => list.handleDeleteRecipe(item.data as Recipe) :
             item.kind === "exercise" ? () => list.handleDeleteExercise(item.data as ExerciseTemplate) :
             () => list.handleDeleteFood(item.data as Food);
+
+        if (item.kind === "recipe") {
+            const recipe = item.data as Recipe;
+            const subtitleParts = [list.recipeSummary(recipe.id)];
+            if (item.variants.length > 0) {
+                subtitleParts.push(t("templates.variantCount", { count: item.variants.length }));
+            }
+            return (
+                <TemplateCard
+                    kind="recipe"
+                    data={recipe}
+                    subtitle={subtitleParts.join(" · ")}
+                    onDelete={handleDelete}
+                    onFork={() => list.setForkTarget({ recipe })}
+                    variants={item.variants}
+                    variantSubtitle={(v) => list.recipeSummary(v.id)}
+                    expanded={list.expandedIds.has(recipe.id)}
+                    onToggleExpand={() => list.toggleExpanded(recipe.id)}
+                    onForkVariant={(v) => list.setForkTarget({ recipe: v })}
+                    onDeleteVariant={(v) => list.handleDeleteRecipe(v)}
+                />
+            );
+        }
+
+        const subtitle =
+            item.kind === "exercise"
+                ? list.exerciseSummary(item.data as ExerciseTemplate)
+                : list.foodSummary(item.data as Food);
 
         return (
             <TemplateCard
@@ -181,6 +205,12 @@ export default function TemplatesScreen() {
                     </Pressable>
                 </>
             )}
+
+            <ForkRecipeModal
+                target={list.forkTarget}
+                onClose={() => list.setForkTarget(null)}
+                onSubmit={list.handleForkSubmit}
+            />
         </View>
     );
 }

--- a/src/features/templates/services/recipeVariantsDb.ts
+++ b/src/features/templates/services/recipeVariantsDb.ts
@@ -1,0 +1,89 @@
+import { db } from "@/src/services/db";
+import { recipeItems, recipes } from "@/src/services/db/schema";
+import { eq } from "drizzle-orm";
+import { getAllRecipes, getRecipeById, type Recipe } from "./templateDb";
+
+export interface RecipeGroup {
+    recipe: Recipe;
+    variants: Recipe[];
+}
+
+// A variant's `name` is only the specification (e.g. "with sprinkles");
+// the full display name is resolved against the base recipe.
+export interface RecipeDisplayName {
+    name: string;
+    variant: string | null;
+}
+
+export function getRecipeDisplayName(recipe: Recipe): RecipeDisplayName {
+    if (recipe.parent_recipe_id == null) return { name: recipe.name, variant: null };
+    const base = getRecipeById(recipe.parent_recipe_id);
+    if (!base) return { name: recipe.name, variant: null };
+    return { name: base.name, variant: recipe.name };
+}
+
+/** One-line form, e.g. "Cupcakes · with sprinkles", for flat lists. */
+export function formatRecipeName(recipe: Recipe): string {
+    const display = getRecipeDisplayName(recipe);
+    return display.variant ? `${display.name} · ${display.variant}` : display.name;
+}
+
+/**
+ * Non-deleted recipes grouped into base recipes with their variants.
+ * A group matches `query` if the base or any of its variants matches,
+ * so searching for a variant still surfaces the (collapsed) base.
+ */
+export function getRecipeGroups(query?: string): RecipeGroup[] {
+    const all = getAllRecipes();
+    const ids = new Set(all.map((r) => r.id));
+    const byParent = new Map<number, Recipe[]>();
+    const topLevel: Recipe[] = [];
+    for (const r of all) {
+        // A variant whose base was deleted is shown as a top-level recipe.
+        if (r.parent_recipe_id != null && ids.has(r.parent_recipe_id)) {
+            const siblings = byParent.get(r.parent_recipe_id);
+            if (siblings) siblings.push(r);
+            else byParent.set(r.parent_recipe_id, [r]);
+        } else {
+            topLevel.push(r);
+        }
+    }
+    const groups = topLevel.map((r) => ({ recipe: r, variants: byParent.get(r.id) ?? [] }));
+    const q = query?.trim().toLowerCase();
+    if (!q) return groups;
+    return groups.filter(
+        (g) =>
+            g.recipe.name.toLowerCase().includes(q) ||
+            g.variants.some((v) => v.name.toLowerCase().includes(q)),
+    );
+}
+
+function copyRecipe(source: Recipe, name: string, parentId: number | null): Recipe {
+    const created = db.insert(recipes).values({ name, parent_recipe_id: parentId }).returning().get();
+    const items = db.select().from(recipeItems).where(eq(recipeItems.recipe_id, source.id)).all();
+    for (const item of items) {
+        db.insert(recipeItems).values({
+            recipe_id: created.id,
+            food_id: item.food_id,
+            quantity_grams: item.quantity_grams,
+            quantity_unit: item.quantity_unit,
+        }).run();
+    }
+    return created;
+}
+
+/**
+ * Fork a recipe into a new variant (a copy of the recipe and its items).
+ *
+ * - Forking a variant adds a sibling variant under the same base.
+ * - Forking a base or standalone recipe adds a new variant under it — the
+ *   recipe being forked always stays put and becomes/remains the base, so
+ *   nothing gets duplicated except the new variant itself.
+ */
+export function forkRecipe(recipeId: number, variantName: string): Recipe {
+    const original = getRecipeById(recipeId);
+    if (!original) throw new Error(`Recipe ${recipeId} not found`);
+
+    const baseId = original.parent_recipe_id ?? original.id;
+    return copyRecipe(original, variantName, baseId);
+}

--- a/src/features/templates/services/templateDb.ts
+++ b/src/features/templates/services/templateDb.ts
@@ -155,12 +155,19 @@ export function updateRecipe(id: number, name: string) {
     db.update(recipes).set({ name }).where(eq(recipes.id, id)).run();
 }
 
+// Deleting a base recipe promotes its variants to standalone recipes.
+function promoteVariants(baseId: number) {
+    db.update(recipes).set({ parent_recipe_id: null }).where(eq(recipes.parent_recipe_id, baseId)).run();
+}
+
 export function deleteRecipe(id: number) {
+    promoteVariants(id);
     db.delete(recipeItems).where(eq(recipeItems.recipe_id, id)).run();
     db.delete(recipes).where(eq(recipes.id, id)).run();
 }
 
 export function softDeleteRecipe(id: number) {
+    promoteVariants(id);
     db.update(recipes).set({ deleted: 1 }).where(eq(recipes.id, id)).run();
 }
 

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -267,6 +267,13 @@ const de = {
         editRewriteHistory: "Alle Einträge aktualisieren",
         removeFoodSoft: '"{{name}}" aus der Suche ausblenden? Vergangene Protokolleinträge bleiben erhalten.',
         removeRecipeSoft: '"{{name}}" aus der Suche ausblenden? Vergangene Protokolleinträge bleiben erhalten.',
+        createVariant: "Variante erstellen",
+        forkDescription: 'Erstellt eine neue Variante von "{{name}}" mit einer Kopie ihrer Zutaten zum Anpassen. Benenne sie nur nach der Spezifikation, z. B. "mit Streuseln".',
+        variantName: "Name der Variante",
+        variantNamePlaceholder: "z. B. mit Streuseln",
+        variantOf: 'Variante von "{{name}}"',
+        variantCount_one: "{{count}} Variante",
+        variantCount_other: "{{count}} Varianten",
     },
     analytics: {
         title: "Analyse",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -267,6 +267,13 @@ const en = {
         editRewriteHistory: "Update all entries",
         removeFoodSoft: 'Hide "{{name}}" from searches? Past log entries will be preserved.',
         removeRecipeSoft: 'Hide "{{name}}" from searches? Past log entries will be preserved.',
+        createVariant: "Create variant",
+        forkDescription: 'Creates a new variant of "{{name}}" with a copy of its items to customize. Name it after just the specification, e.g. "with sprinkles".',
+        variantName: "Variant name",
+        variantNamePlaceholder: "e.g. with sprinkles",
+        variantOf: 'Variant of "{{name}}"',
+        variantCount_one: "{{count}} variant",
+        variantCount_other: "{{count}} variants",
     },
     analytics: {
         title: "Analytics",

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -218,6 +218,7 @@ export function initDB() {
     "ALTER TABLE entries ADD COLUMN is_scheduled INTEGER NOT NULL DEFAULT 0",
     "ALTER TABLE exercise_templates ADD COLUMN custom_fields TEXT",
     "ALTER TABLE exercise_sets ADD COLUMN custom_values TEXT",
+    "ALTER TABLE recipes ADD COLUMN parent_recipe_id INTEGER REFERENCES recipes(id)",
   ];
   for (const sql of migrations) {
     try { expoDb.execSync(sql); } catch { /* column already exists */ }

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -1,4 +1,4 @@
-import { integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { integer, real, sqliteTable, text, type AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 
 export const foods = sqliteTable("foods", {
     id: integer("id").primaryKey({ autoIncrement: true }),
@@ -67,6 +67,8 @@ export const recipes = sqliteTable("recipes", {
     id: integer("id").primaryKey({ autoIncrement: true }),
     name: text("name").notNull(),
     deleted: integer("deleted").notNull().default(0),
+    // Set on variant recipes; points at the base recipe of the variant group.
+    parent_recipe_id: integer("parent_recipe_id").references((): AnySQLiteColumn => recipes.id),
 });
 
 export const recipeItems = sqliteTable("recipe_items", {


### PR DESCRIPTION
Closes #358

Lets you fork a recipe template into variants (e.g. Cupcakes → "with sprinkles", "vegan") that are grouped under the base recipe instead of cluttering the template list and search.

## What's included

**Data model**
- New `parent_recipe_id` column on `recipes` (self-referencing, nullable) with an `ALTER TABLE` migration entry. Variants point at their base recipe; a single level of nesting.

**Forking** (`src/features/templates/services/recipeVariantsDb.ts`)
- Forking a recipe copies it into a new variant under its base — the recipe you fork stays exactly where it is (it just gains a child), so nothing is ever duplicated except the new variant.
- Forking a **variant** adds a sibling under the same base; forking a **base or standalone** recipe adds a variant under it, and the standalone recipe becomes the base the moment it has a child.
- Variant names are just the specification (e.g. "with sprinkles"), not the full name — `getRecipeDisplayName`/`formatRecipeName` resolve the base name wherever a variant is displayed.
- Recipe items are copied onto every new variant so it starts as an editable copy of what it was forked from.

**Templates screen**
- Recipe cards get a fork (git-branch) icon that opens a modal asking for the variant's specification.
- Variants live inside the base recipe's own card as collapsible rows (not separate cards) with their own fork/delete actions, and a variant count in the subtitle.
- Search matches a group if the base **or any variant** matches, and shows the collapsed base.
- Deleting a base recipe promotes its variants back to standalone recipes (both soft and hard delete).
- The recipe editor shows "Variant of X" when editing a variant.

**Log screen**
- Logged recipe groups show the base name with the variant specification underneath it.
- One-line contexts (portion-adjust modal, entry modal's recipe picker, move/copy modal, AI meal-plan/search payloads) use the combined "Base · variant" form.
- Add-food search: recipe groups render as a single card, base collapsed by default with an inline expander revealing variant rows.

**i18n**: new `templates.*` keys added to both `en.ts` and `de.ts`.

## Verification
- `npx tsc --noEmit` and `npm run lint`: no new errors in any touched file; lint total is actually below the main baseline.
- Fork/delete SQL flow (base creation via first fork, sibling variants, base deletion promoting variants) validated against a real SQLite database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)