### PR TITLE
feat: delete selected logs

### DIFF
--- a/src/features/log/hooks/useLogData.ts
+++ b/src/features/log/hooks/useLogData.ts
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Dimensions, type NativeScrollEvent, type NativeSyntheticEvent, type ScrollView } from "react-native";
 import { computeWeightTrend, loadGrouped, type EntryWithFood } from "../helpers/logHelpers";
-import { addWeightLog, confirmEntry, confirmRecipeLog, copyEntriesToDate, copyEntriesToRecipeLog, createRecipeFromEntries, deleteEntry, deleteRecipeLog, deleteWeightLog, formatDateKey, getEntriesByDate, getWeightLogsForDate, getWeightLogsForRange, moveEntriesToDate, moveEntriesToRecipeLog, updateRecipeLogPortion, type RecipeGroup, type WeightLog } from "../services/logDb";
+import { addWeightLog, confirmEntry, confirmRecipeLog, copyEntriesToDate, copyEntriesToRecipeLog, createRecipeFromEntries, deleteEntriesAndRecipeLogs, deleteEntry, deleteRecipeLog, deleteWeightLog, formatDateKey, getEntriesByDate, getWeightLogsForDate, getWeightLogsForRange, moveEntriesToDate, moveEntriesToRecipeLog, updateRecipeLogPortion, type RecipeGroup, type WeightLog } from "../services/logDb";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 
@@ -204,12 +204,37 @@ export function useLogData() {
     const handleActivateSelection = (entryId: number) => { setSelectionMode(true); setSelectedEntryIds(new Set([entryId])); };
     const handleActivateSelectionMultiple = (entryIds: number[]) => { setSelectionMode(true); setSelectedEntryIds(new Set(entryIds)); };
 
-    function handleMoveCopy(targetDate: Date, targetMealType: string | null, action: "move" | "copy", targetRecipeLogId: number | null) {
+    // Splits the current selection into standalone entry ids and recipe log ids
+    // that are selected in full (every entry belonging to that recipe log is selected).
+    function partitionSelection() {
         const allEntries = Object.values(grouped).flat();
+        const recipeLogEntryMap = new Map<number, number[]>();
+        for (const row of allEntries) {
+            const rlId = row.entries.recipe_log_id;
+            if (rlId) {
+                const list = recipeLogEntryMap.get(rlId) ?? [];
+                list.push(row.entries.id);
+                recipeLogEntryMap.set(rlId, list);
+            }
+        }
+        const fullySelectedRecipeLogIds: number[] = [];
+        const standaloneEntryIds: number[] = [];
+        for (const [rlId, entryIds] of recipeLogEntryMap) {
+            if (entryIds.every((id) => selectedEntryIds.has(id))) fullySelectedRecipeLogIds.push(rlId);
+            else entryIds.filter((id) => selectedEntryIds.has(id)).forEach((id) => standaloneEntryIds.push(id));
+        }
+        for (const row of allEntries) {
+            if (!row.entries.recipe_log_id && selectedEntryIds.has(row.entries.id)) standaloneEntryIds.push(row.entries.id);
+        }
+        return { standaloneEntryIds, fullySelectedRecipeLogIds };
+    }
+
+    function handleMoveCopy(targetDate: Date, targetMealType: string | null, action: "move" | "copy", targetRecipeLogId: number | null) {
         const dateKey = formatDateKey(targetDate);
 
         if (targetRecipeLogId !== null) {
             // Move/copy all selected entries into the target recipe log
+            const allEntries = Object.values(grouped).flat();
             const allSelectedEntryIds = allEntries
                 .filter((row) => selectedEntryIds.has(row.entries.id))
                 .map((row) => row.entries.id);
@@ -222,24 +247,7 @@ export function useLogData() {
                 copyEntriesToRecipeLog(allSelectedEntryIds, targetRecipeLogId, dateKey, recipeMealType);
             }
         } else {
-            const recipeLogEntryMap = new Map<number, number[]>();
-            for (const row of allEntries) {
-                const rlId = row.entries.recipe_log_id;
-                if (rlId) {
-                    const list = recipeLogEntryMap.get(rlId) ?? [];
-                    list.push(row.entries.id);
-                    recipeLogEntryMap.set(rlId, list);
-                }
-            }
-            const fullySelectedRecipeLogIds: number[] = [];
-            const standaloneEntryIds: number[] = [];
-            for (const [rlId, entryIds] of recipeLogEntryMap) {
-                if (entryIds.every((id) => selectedEntryIds.has(id))) fullySelectedRecipeLogIds.push(rlId);
-                else entryIds.filter((id) => selectedEntryIds.has(id)).forEach((id) => standaloneEntryIds.push(id));
-            }
-            for (const row of allEntries) {
-                if (!row.entries.recipe_log_id && selectedEntryIds.has(row.entries.id)) standaloneEntryIds.push(row.entries.id);
-            }
+            const { standaloneEntryIds, fullySelectedRecipeLogIds } = partitionSelection();
             if (action === "move") moveEntriesToDate(standaloneEntryIds, fullySelectedRecipeLogIds, dateKey, targetMealType);
             else copyEntriesToDate(standaloneEntryIds, fullySelectedRecipeLogIds, dateKey, targetMealType);
         }
@@ -247,6 +255,17 @@ export function useLogData() {
         setMoveModalVisible(false);
         loadAllDays(targetDate);
         setSelectedDate(targetDate);
+    }
+
+    function handleDeleteSelection() {
+        const { standaloneEntryIds, fullySelectedRecipeLogIds } = partitionSelection();
+        deleteEntriesAndRecipeLogs(standaloneEntryIds, fullySelectedRecipeLogIds);
+        logger.info("[DB] Deleted selected entries", { entryCount: standaloneEntryIds.length, recipeLogCount: fullySelectedRecipeLogIds.length });
+        const settings = getNotificationSettings() ?? null;
+        const loggedMealTypes = new Set(getEntriesByDate(new Date()).map(e => e.entries.meal_type as MealType));
+        syncTodayMealReminders(settings, loggedMealTypes);
+        exitSelectionMode();
+        loadAllDays(selectedDate);
     }
 
     function handleCreateRecipeFromSelection() {
@@ -291,7 +310,7 @@ export function useLogData() {
         handleEdit, handleEditRecipeGroup, handleSavePortionMultiplier,
         navigateToAdd, exitSelectionMode,
         handleToggleEntries, handleActivateSelection, handleActivateSelectionMultiple,
-        handleMoveCopy, handleCreateRecipeFromSelection, handleDateChange,
+        handleMoveCopy, handleDeleteSelection, handleCreateRecipeFromSelection, handleDateChange,
         loadAllDays, SCREEN_WIDTH,
     };
 }

--- a/src/features/log/screens/LogScreen.tsx
+++ b/src/features/log/screens/LogScreen.tsx
@@ -17,7 +17,7 @@ import { useBottomTabBarHeight } from "expo-router/js-tabs";
 import { router } from "expo-router";
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Dimensions, Modal, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Alert, Dimensions, Modal, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import DateSelectorBar from "../components/DateSelectorBar";
 import EntryModal from "../components/EntryModal";
@@ -97,6 +97,17 @@ export default function LogScreen() {
         router.push({ pathname: "/photos/photos", params: { dateKey: selectedDateKey } });
     }
 
+    function handleDeleteSelection() {
+        Alert.alert(
+            t("log.deleteSelectedTitle", { count: d.selectedEntryIds.size }),
+            t("log.deleteSelectedMessage"),
+            [
+                { text: t("common.cancel"), style: "cancel" },
+                { text: t("common.delete"), style: "destructive", onPress: d.handleDeleteSelection },
+            ],
+        );
+    }
+
     function handleSaveWeight() {
         const value = parseFloat(weightInput);
         if (!value || value <= 0) return;
@@ -154,12 +165,20 @@ export default function LogScreen() {
                 onSaved={() => { d.setEditingEntry(null); d.loadAllDays(d.selectedDate); }} />
 
             {d.selectionMode && (
-                <Pressable
-                    style={({ pressed }) => [styles.secondaryFab, { bottom: fabBottom + 68 }, pressed && styles.secondaryFabPressed]}
-                    onPress={d.handleCreateRecipeFromSelection}
-                >
-                    <Ionicons name="book-outline" size={24} color={colors.primary} />
-                </Pressable>
+                <>
+                    <Pressable
+                        style={({ pressed }) => [styles.secondaryFab, { bottom: fabBottom + 68 + 62 }, pressed && styles.secondaryFabPressed]}
+                        onPress={handleDeleteSelection}
+                    >
+                        <Ionicons name="trash-outline" size={24} color={colors.danger} />
+                    </Pressable>
+                    <Pressable
+                        style={({ pressed }) => [styles.secondaryFab, { bottom: fabBottom + 68 }, pressed && styles.secondaryFabPressed]}
+                        onPress={d.handleCreateRecipeFromSelection}
+                    >
+                        <Ionicons name="book-outline" size={24} color={colors.primary} />
+                    </Pressable>
+                </>
             )}
 
             {!d.selectionMode && showQuickActions && (

--- a/src/features/log/services/logDb.ts
+++ b/src/features/log/services/logDb.ts
@@ -248,6 +248,16 @@ export function deleteRecipeLog(recipeLogId: number) {
     db.delete(recipeLogs).where(eq(recipeLogs.id, recipeLogId)).run();
 }
 
+export function deleteEntriesAndRecipeLogs(standaloneEntryIds: number[], recipeLogIds: number[]) {
+    if (standaloneEntryIds.length > 0) {
+        db.delete(entries).where(inArray(entries.id, standaloneEntryIds)).run();
+    }
+    for (const rlId of recipeLogIds) {
+        db.delete(entries).where(eq(entries.recipe_log_id, rlId)).run();
+        db.delete(recipeLogs).where(eq(recipeLogs.id, rlId)).run();
+    }
+}
+
 // ── Move / Copy entries ────────────────────────────────────
 
 export function moveEntriesToDate(

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -168,6 +168,8 @@ const de = {
         newRecipeFromSelection: "Rezept {{date}}",
         move: "Verschieben",
         copy: "Kopieren",
+        deleteSelectedTitle: "{{count}} ausgewählte Einträge löschen?",
+        deleteSelectedMessage: "Dies kann nicht rückgängig gemacht werden.",
         logWeight: "Gewicht erfassen",
         weight: "Gewicht",
         noWeightsLogged: "Noch kein Gewicht erfasst",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -169,6 +169,8 @@ const en = {
         newRecipeFromSelection: "Recipe {{date}}",
         move: "Move",
         copy: "Copy",
+        deleteSelectedTitle: "Delete {{count}} selected entries?",
+        deleteSelectedMessage: "This can't be undone.",
         logWeight: "Log Weight",
         weight: "Weight",
         noWeightsLogged: "No weight logged yet",


### PR DESCRIPTION
## Summary
- Add a delete option to the log selection FAB, alongside the existing move/copy and create-recipe actions
- Deleting removes standalone selected entries outright, and removes fully-selected recipe logs (and their entries) entirely — matches the same standalone/recipe-log partitioning already used for move/copy
- Confirms via a native Alert before deleting (consistent with other destructive actions in the app)

Closes #365

## Test plan
- [ ] `npx tsc --noEmit` — no new errors introduced by this change
- [ ] `npm run lint` — no new errors introduced by this change (pre-existing `react-hooks/refs` false positives on this file are unchanged in count)
- [ ] Manually verify in the app: select entries in the log screen, tap the new trash FAB, confirm the delete, verify entries and fully-selected recipe logs are removed and partially-selected recipe logs are left intact with only the selected entries removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)