### PR TITLE
feat: display median in analytics statistics

### DIFF
--- a/src/features/analytics/helpers/analyticsHelpers.ts
+++ b/src/features/analytics/helpers/analyticsHelpers.ts
@@ -68,12 +68,15 @@ export function computeStats(values: number[]) {
     const max = Math.max(...values);
     const sum = values.reduce((a, b) => a + b, 0);
     const avg = sum / values.length;
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    const median = sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
     const variance = values.reduce((a, v) => a + (v - avg) ** 2, 0) / values.length;
     const stdDev = Math.sqrt(variance);
     const first = values[0];
     const last = values[values.length - 1];
     const trend = last > first ? "up" : last < first ? "down" : "flat";
-    return { min, max, avg, stdDev, variance, trend };
+    return { min, max, avg, median, stdDev, variance, trend };
 }
 
 export function formatNum(v: number, decimals = 1): string {

--- a/src/features/analytics/screens/AnalyticsScreen.tsx
+++ b/src/features/analytics/screens/AnalyticsScreen.tsx
@@ -115,6 +115,7 @@ export default function AnalyticsScreen() {
                         <View style={styles.statsRow}>
                             <StatCell label={t("analytics.min")} value={`${a.formatNum(a.stats.min)} ${a.statsUnit}`} colors={colors} />
                             <StatCell label={t("analytics.avg")} value={`${a.formatNum(a.stats.avg)} ${a.statsUnit}`} colors={colors} />
+                            <StatCell label={t("analytics.median")} value={`${a.formatNum(a.stats.median)} ${a.statsUnit}`} colors={colors} />
                             <StatCell label={t("analytics.max")} value={`${a.formatNum(a.stats.max)} ${a.statsUnit}`} colors={colors} />
                         </View>
                         {a.statsOpen && (

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -300,6 +300,7 @@ const de = {
         statistics: "Statistik",
         min: "Min",
         avg: "Ø",
+        median: "Median",
         max: "Max",
         stdDev: "Std Abw",
         variance: "Varianz",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -300,6 +300,7 @@ const en = {
         statistics: "Statistics",
         min: "Min",
         avg: "Avg",
+        median: "Median",
         max: "Max",
         stdDev: "Std Dev",
         variance: "Variance",


### PR DESCRIPTION
## Summary
- Days without a food log artificially pull down the average shown in Analytics, per #375
- Added `median` to `computeStats` in `analyticsHelpers.ts` and display it in the stats row alongside Min/Avg/Max
- Added `analytics.median` translation key to `en.ts` and `de.ts`

Closes #375

## Test plan
- [ ] Open Analytics screen, confirm stats row shows Min, Avg, Median, Max
- [ ] Verify median value is sensible for a range that includes a gap day (e.g. a day with 0 logged calories)
- [ ] Check layout doesn't overflow with the 4th cell in the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)