### PR TITLE
Per-minute OpenFoodFacts search rate limit (closes #383)

### DIFF
--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -5,9 +5,12 @@ import type { FoodUnit } from "@/src/utils/units";
 const BASE_URL = "https://world.openfoodfacts.org";
 const USER_AGENT = "MacroFlow/1.0 (React Native; open-source nutrient tracker)";
 
-// Client-side rate limiter for search (10 req/min ≈ 1 per 6 s)
-const SEARCH_MIN_INTERVAL_MS = 6_000;
-let lastSearchTimestamp = 0;
+// Client-side rate limiter for search: OpenFoodFacts allows 10 req/min/IP.
+// Track request timestamps in a sliding 60 s window so users can burst a few
+// requests quickly (or space them out) as long as the window stays under the cap.
+const SEARCH_WINDOW_MS = 60_000;
+const SEARCH_MAX_PER_WINDOW = 10;
+const searchTimestamps: number[] = [];
 
 export interface OFFProduct {
     code: string;
@@ -83,14 +86,17 @@ export async function searchProducts(
     page = 1,
 ): Promise<OFFProduct[]> {
     const now = Date.now();
-    const elapsed = now - lastSearchTimestamp;
-    if (elapsed < SEARCH_MIN_INTERVAL_MS) {
+    // Drop timestamps that have aged out of the sliding window.
+    while (searchTimestamps.length && now - searchTimestamps[0] >= SEARCH_WINDOW_MS) {
+        searchTimestamps.shift();
+    }
+    if (searchTimestamps.length >= SEARCH_MAX_PER_WINDOW) {
         const waitSec = Math.ceil(
-            (SEARCH_MIN_INTERVAL_MS - elapsed) / 1000,
+            (SEARCH_WINDOW_MS - (now - searchTimestamps[0])) / 1000,
         );
         throw new Error(i18n.t("common.rateLimitedWait", { seconds: waitSec }));
     }
-    lastSearchTimestamp = now;
+    searchTimestamps.push(now);
 
     logger.info("[API] Searching products", { query, page });
 


### PR DESCRIPTION
## Summary

Closes #383. Replaces the fixed 6s-between-requests throttle on OpenFoodFacts search with a proper sliding-window limiter.

OpenFoodFacts enforces **10 req/min/IP** for search. The old code forced a 6s gap after *every* search, which doesn't match how people actually use the app (a burst of a few searches, then nothing for a long while).

## Change

`src/services/openfoodfacts.ts` now tracks search timestamps in a sliding 60s window (`searchTimestamps`), pruning aged-out entries on each call. A request is allowed while fewer than 10 sit in the window; at the cap it throws the existing `common.rateLimitedWait` error with the seconds until the oldest request expires.

Users can now burst several searches quickly, or space them out — whatever they like — as long as they stay under 10/min.

## Notes

- No i18n changes; reuses the existing `rateLimitedWait` key.
- Only search is limited (unchanged); barcode lookups have a separate, higher OFF limit.
- `npx tsc --noEmit` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)