### PR TITLE
chore(release): v0.1.0-alpha

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "MacroFlow",
     "slug": "MacroFlow",
-    "version": "0.0.3-alpha",
+    "version": "0.1.0-alpha",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "macroflow",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "macroflow",
   "main": "expo-router/entry",
-  "version": "0.0.3-alpha",
+  "version": "0.1.0-alpha",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
Bump version to 0.1.0-alpha for the v0.1.0-alpha release.

Minor bump reflecting major additions since v0.0.3-alpha:
- Full exercise/workout tracking feature (logging, templates, history, 1RM charts, rest timer, progress photos)
- Multi-device sync via self-hosted sync server
- Quick-add food flow, recipe template variants, daily nutrition goals
- Expo SDK 54 → 57 upgrade
- Numerous fixes and refinements