### PR TITLE
Show sync storage usage on the Account screen (closes #388)

### DIFF
--- a/src/features/settings/screens/AccountScreen.tsx
+++ b/src/features/settings/screens/AccountScreen.tsx
@@ -4,7 +4,7 @@ import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
     Alert,
@@ -17,7 +17,7 @@ import {
     View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { login, register } from "../services/syncClient";
+import { getUsage, login, register, type UsageInfo } from "../services/syncClient";
 import {
     clearSyncSettings,
     loadSyncSettings,
@@ -25,6 +25,19 @@ import {
 } from "../services/syncSettings";
 
 const MIN_PASSWORD_LENGTH = 8;
+
+/** Formats a byte count as a short human-readable size, e.g. "4.9 MB". */
+function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    const units = ["KB", "MB", "GB", "TB"];
+    let value = bytes / 1024;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit++;
+    }
+    return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
 
 type Mode = "signIn" | "signUp";
 
@@ -37,6 +50,7 @@ export default function AccountScreen() {
 
     // Signed-in state, loaded once on mount.
     const [signedInAs, setSignedInAs] = useState<{ username: string; url: string } | null>(null);
+    const [usage, setUsage] = useState<UsageInfo | null>(null);
     const [signingOut, setSigningOut] = useState(false);
 
     // Form state.
@@ -47,6 +61,18 @@ export default function AccountScreen() {
     const [confirm, setConfirm] = useState("");
     const [submitting, setSubmitting] = useState(false);
 
+    // Loads storage usage for the saved account. Usage is informational, so a
+    // failure just leaves it hidden rather than surfacing an error.
+    const refreshUsage = useCallback(async () => {
+        const settings = await loadSyncSettings();
+        if (!settings) return;
+        try {
+            setUsage(await getUsage(settings));
+        } catch {
+            setUsage(null);
+        }
+    }, []);
+
     useEffect(() => {
         let cancelled = false;
         (async () => {
@@ -55,11 +81,12 @@ export default function AccountScreen() {
             setSignedInAs({ username: settings.username, url: settings.url });
             // Pre-fill the URL so a re-sign-in on the same server is one tap.
             setUrl(settings.url);
+            refreshUsage();
         })();
         return () => {
             cancelled = true;
         };
-    }, []);
+    }, [refreshUsage]);
 
     function goBack() {
         router.navigate("/(tabs)/more" as any);
@@ -98,6 +125,7 @@ export default function AccountScreen() {
             setSignedInAs({ username: creds.username, url: url.trim().replace(/\/+$/, "") });
             setPassword("");
             setConfirm("");
+            refreshUsage();
             Alert.alert(
                 t("account.title"),
                 mode === "signUp" ? t("account.signUpSuccess") : t("account.signInSuccess"),
@@ -123,6 +151,7 @@ export default function AccountScreen() {
                         setSigningOut(true);
                         await clearSyncSettings();
                         setSignedInAs(null);
+                        setUsage(null);
                         setPassword("");
                         setConfirm("");
                     } finally {
@@ -156,6 +185,36 @@ export default function AccountScreen() {
                             {t("account.signedInAs", { username: signedInAs.username })}
                         </Text>
                         <Text style={styles.signedInServer}>{signedInAs.url}</Text>
+
+                        {usage && (
+                            <View style={styles.usageBlock}>
+                                <Text style={styles.usageText}>
+                                    {usage.quota > 0
+                                        ? t("account.storageUsedOf", {
+                                              used: formatBytes(usage.bytes),
+                                              total: formatBytes(usage.quota),
+                                          })
+                                        : t("account.storageUsed", { used: formatBytes(usage.bytes) })}
+                                </Text>
+                                {usage.quota > 0 &&
+                                    (() => {
+                                        const ratio = Math.min(1, usage.bytes / usage.quota);
+                                        return (
+                                            <View style={styles.usageBarTrack}>
+                                                <View
+                                                    style={[
+                                                        styles.usageBarFill,
+                                                        { flex: ratio },
+                                                        ratio >= 0.9 && { backgroundColor: colors.danger },
+                                                    ]}
+                                                />
+                                                {ratio < 1 && <View style={{ flex: 1 - ratio }} />}
+                                            </View>
+                                        );
+                                    })()}
+                            </View>
+                        )}
+
                         <Text style={styles.signedInHint}>{t("account.signedInHint")}</Text>
                         <Button
                             title={t("account.signOut")}
@@ -326,6 +385,27 @@ function createStyles(colors: ThemeColors) {
             fontSize: fontSize.sm,
             color: colors.textSecondary,
             textAlign: "center",
+        },
+        usageBlock: {
+            alignSelf: "stretch",
+            marginTop: spacing.sm,
+            gap: spacing.xs,
+        },
+        usageText: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            textAlign: "center",
+        },
+        usageBarTrack: {
+            flexDirection: "row",
+            height: 6,
+            borderRadius: 3,
+            backgroundColor: colors.border,
+            overflow: "hidden",
+        },
+        usageBarFill: {
+            backgroundColor: colors.primary,
+            borderRadius: 3,
         },
         signedInHint: {
             fontSize: fontSize.sm,

--- a/src/features/settings/services/syncClient.ts
+++ b/src/features/settings/services/syncClient.ts
@@ -33,6 +33,16 @@ export interface PullResult {
     hasMore: boolean;
 }
 
+/** Storage usage for the authenticated user, as returned by /usage. */
+export interface UsageInfo {
+    /** Logical bytes the user's stored change log occupies. */
+    bytes: number;
+    /** Number of stored rows. */
+    rows: number;
+    /** Per-user cap in bytes, or 0 when the server sets no limit. */
+    quota: number;
+}
+
 const REQUEST_TIMEOUT_MS = 30_000;
 
 /** Credentials without the server URL, used by the account endpoints. */
@@ -67,6 +77,16 @@ export async function login(url: string, account: Account): Promise<void> {
 
 export async function testConnection(creds: SyncCredentials): Promise<void> {
     await request(creds, "/api/v1/sync/ping");
+}
+
+/** Fetches the signed-in user's storage usage and quota. */
+export async function getUsage(creds: SyncCredentials): Promise<UsageInfo> {
+    const body = await request(creds, "/api/v1/sync/usage");
+    return {
+        bytes: Number(body?.bytes ?? 0),
+        rows: Number(body?.rows ?? 0),
+        quota: Number(body?.quota ?? 0),
+    };
 }
 
 export async function pullChanges(
@@ -171,6 +191,11 @@ async function request(
         });
         if (res.status === 401 || res.status === 403) {
             throw new Error("Sync server rejected the credentials.");
+        }
+        if (res.status === 507) {
+            throw new Error(
+                "Your account is out of storage on the sync server. Free up space or ask the server owner to raise your limit.",
+            );
         }
         if (!res.ok) {
             throw new Error(`Sync server error (HTTP ${res.status}).`);

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -372,6 +372,8 @@ const de = {
         errorPasswordTooShort: "Das Passwort muss mindestens {{count}} Zeichen haben.",
         errorPasswordMismatch: "Die Passwörter stimmen nicht überein.",
         signedInAs: "Angemeldet als {{username}}",
+        storageUsed: "{{used}} Speicher belegt",
+        storageUsedOf: "{{used}} von {{total}} belegt",
         signedInHint: "Die Synchronisierung verwaltest du unter Einstellungen → Synchronisierung. Beim Abmelden wird die Synchronisierung gestoppt, deine Daten bleiben aber auf diesem Gerät.",
         signOut: "Abmelden",
         signOutConfirmTitle: "Abmelden?",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -370,6 +370,8 @@ const en = {
         errorPasswordTooShort: "Password must be at least {{count}} characters.",
         errorPasswordMismatch: "The passwords don't match.",
         signedInAs: "Signed in as {{username}}",
+        storageUsed: "{{used}} of storage used",
+        storageUsedOf: "{{used}} of {{total}} used",
         signedInHint: "Manage syncing from Settings → Sync. Signing out stops syncing but keeps your data on this device.",
         signOut: "Sign Out",
         signOutConfirmTitle: "Sign out?",


### PR DESCRIPTION
Closes #388. Pairs with MacroFlow-Backend #4 (the `/usage` endpoint and `MAX_USER_BYTES`).

## What

Surfaces how much sync storage the signed-in user has used — and their cap, when the server sets one — on the Account screen.

## Changes

- **`getUsage()`** in the sync client → `GET /api/v1/sync/usage`, returning `{ bytes, rows, quota }`.
- **Account screen** (signed-in state) shows storage used:
  - No server cap → "4.9 MB of storage used".
  - Server cap set → "4.9 MB of 50 MB used" with a slim **progress bar** that turns red at ≥90%.
  - Usage is **informational**: if the fetch fails it's simply hidden, never an error. Loaded on open and refreshed after each sign-in / sign-up; cleared on sign-out.
- **Friendlier push error**: when a sync push is rejected because the account hit the server-side per-user cap (`507`), the message explains it instead of showing a raw HTTP code.
- `formatBytes()` helper for human-readable sizes; new i18n (`account.storageUsed` / `storageUsedOf`) in **both** `en.ts` and `de.ts`.

## Testing

- `npx tsc --noEmit` and `npm run lint` both clean.
- The `/usage` contract this consumes is verified end-to-end on the backend PR. As before, the RN screen wasn't driven on a device/simulator in this environment; the progress bar uses a flex-ratio fill (no percentage-string typing pitfalls) and reuses existing theme tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)