### PR TITLE
feat: share foods, recipes and logged items via QR code/link

### DIFF
--- a/app/share/[token].tsx
+++ b/app/share/[token].tsx
@@ -1,0 +1,1 @@
+export { default } from "@/src/features/share/screens/ImportScreen";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "macroflow",
-  "version": "0.0.3-alpha",
+  "version": "0.1.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "macroflow",
-      "version": "0.0.3-alpha",
+      "version": "0.1.0-alpha",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.41",
         "@expo/vector-icons": "^15.0.3",
@@ -49,6 +49,7 @@
         "react-native-gesture-handler": "~2.32.0",
         "react-native-gifted-charts": "^1.4.76",
         "react-native-markdown-display": "^7.0.2",
+        "react-native-qrcode-svg": "^6.3.21",
         "react-native-reanimated": "4.5.0",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
@@ -5698,6 +5699,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -5812,6 +5822,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
     "node_modules/dnssd-advertise": {
@@ -10851,6 +10867,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10889,7 +10914,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11125,6 +11149,159 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -11409,6 +11586,22 @@
       "peerDependencies": {
         "react": ">=16.2.0",
         "react-native": ">=0.50.4"
+      }
+    },
+    "node_modules/react-native-qrcode-svg": {
+      "version": "6.3.21",
+      "resolved": "https://registry.npmjs.org/react-native-qrcode-svg/-/react-native-qrcode-svg-6.3.21.tgz",
+      "integrity": "sha512-6vcj4rcdpWedvphDR+NSJcudJykNuLgNGFwm2p4xYjR8RdyTzlrELKI5LkO4ANS9cQUbqsfkpippPv64Q2tUtA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.0",
+        "qrcode": "^1.5.4",
+        "text-encoding": "^0.7.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">=0.63.4",
+        "react-native-svg": ">=14.0.0"
       }
     },
     "node_modules/react-native-reanimated": {
@@ -11771,6 +11964,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -12041,6 +12240,12 @@
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "license": "MIT"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -12709,6 +12914,13 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
+    },
+    "node_modules/text-encoding": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
+      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==",
+      "deprecated": "no longer maintained",
+      "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/throat": {
       "version": "5.0.0",
@@ -13412,6 +13624,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-native-gesture-handler": "~2.32.0",
     "react-native-gifted-charts": "^1.4.76",
     "react-native-markdown-display": "^7.0.2",
+    "react-native-qrcode-svg": "^6.3.21",
     "react-native-reanimated": "4.5.0",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",

--- a/src/features/log/screens/LogScreen.tsx
+++ b/src/features/log/screens/LogScreen.tsx
@@ -6,16 +6,18 @@ import AiChatOverlay, { CHAT_BAR_TOTAL_HEIGHT } from "@/src/features/ai/componen
 // eslint-disable-next-line boundaries/dependencies
 import AddExerciseModal from "@/src/features/exercise/components/AddExerciseModal";
 import { addExerciseToWorkout, copySetsFromLastSession, createWorkout, finishWorkout, getExercisesForWorkout, getWorkoutsByDate, type ExerciseTemplate } from "@/src/features/exercise/services/exerciseDb";
+import { isShareConfigured, shareLogSelection } from "@/src/features/share/services/shareService";
 import Button from "@/src/shared/atoms/Button";
 import Input from "@/src/shared/atoms/Input";
+import ShareModal from "@/src/shared/components/ShareModal";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { useAppStore } from "@/src/shared/store/useAppStore";
 import { formatDateKey, shiftCalendarDate } from "@/src/utils/date";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { Ionicons } from "@expo/vector-icons";
 import { useBottomTabBarHeight } from "expo-router/js-tabs";
-import { router } from "expo-router";
-import React, { useMemo, useRef, useState } from "react";
+import { router, useFocusEffect } from "expo-router";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, Dimensions, Modal, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -47,7 +49,31 @@ export default function LogScreen() {
     const [showQuickActions, setShowQuickActions] = useState(false);
     const [showWeightModal, setShowWeightModal] = useState(false);
     const [weightInput, setWeightInput] = useState("");
+    const [shareAvailable, setShareAvailable] = useState(false);
+    const [shareVisible, setShareVisible] = useState(false);
     const selectedDateKey = formatDateKey(d.selectedDate);
+
+    // Re-checked on focus so signing in under Account and coming back
+    // immediately enables the share action.
+    useFocusEffect(
+        useCallback(() => {
+            let cancelled = false;
+            isShareConfigured().then((available) => {
+                if (!cancelled) setShareAvailable(available);
+            });
+            return () => {
+                cancelled = true;
+            };
+        }, []),
+    );
+
+    function handleShareSelection() {
+        if (!shareAvailable) {
+            Alert.alert(t("share.notConfiguredTitle"), t("share.notConfiguredMessage"));
+            return;
+        }
+        setShareVisible(true);
+    }
 
     function handleQuickAddExercise(template: ExerciseTemplate, copyFromLast: boolean) {
         const now = Date.now();
@@ -168,10 +194,21 @@ export default function LogScreen() {
             {d.selectionMode && (
                 <>
                     <Pressable
-                        style={({ pressed }) => [styles.secondaryFab, { bottom: fabBottom + 68 + 62 }, pressed && styles.secondaryFabPressed]}
+                        style={({ pressed }) => [styles.secondaryFab, { bottom: fabBottom + 68 + 124 }, pressed && styles.secondaryFabPressed]}
                         onPress={handleDeleteSelection}
                     >
                         <Ionicons name="trash-outline" size={24} color={colors.danger} />
+                    </Pressable>
+                    <Pressable
+                        style={({ pressed }) => [
+                            styles.secondaryFab,
+                            { bottom: fabBottom + 68 + 62 },
+                            !shareAvailable && styles.secondaryFabDisabled,
+                            pressed && styles.secondaryFabPressed,
+                        ]}
+                        onPress={handleShareSelection}
+                    >
+                        <Ionicons name="share-outline" size={24} color={colors.primary} />
                     </Pressable>
                     <Pressable
                         style={({ pressed }) => [styles.secondaryFab, { bottom: fabBottom + 68 }, pressed && styles.secondaryFabPressed]}
@@ -272,6 +309,12 @@ export default function LogScreen() {
                 onConfirm={d.handleMoveCopy} initialDate={d.selectedDate}
                 selectedEntries={Object.values(d.grouped).flat().filter(e => d.selectedEntryIds.has(e.entries.id))} />
 
+            <ShareModal
+                visible={shareVisible}
+                onClose={() => setShareVisible(false)}
+                fetchUrl={() => shareLogSelection(Object.values(d.grouped).flat(), d.selectedEntryIds)}
+            />
+
             <AiChatOverlay tabBarHeight={tabBarHeight} onVisibilityChange={d.setChatBarVisible}
                 onDataChanged={() => d.loadAllDays(d.selectedDate)} />
 
@@ -313,6 +356,7 @@ function createStyles(colors: ThemeColors) {
             right: 28,
         },
         secondaryFabPressed: { opacity: 0.85, transform: [{ scale: 0.95 }] },
+        secondaryFabDisabled: { opacity: 0.4 },
         overlay: { flex: 1, backgroundColor: "rgba(0,0,0,0.5)", justifyContent: "center", alignItems: "center", padding: spacing.lg },
         portionModal: { backgroundColor: colors.surface, borderRadius: borderRadius.lg, padding: spacing.lg, width: "100%", maxWidth: 340 },
         portionModalTitle: { fontSize: fontSize.lg, fontWeight: "700", color: colors.text, marginBottom: spacing.xs },

--- a/src/features/settings/services/syncClient.ts
+++ b/src/features/settings/services/syncClient.ts
@@ -208,9 +208,11 @@ async function request(
 }
 
 // Hermes does not reliably provide btoa, so encode Basic-auth ourselves.
+// Exported for other features that authenticate against the same server
+// (e.g. share).
 const B64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-function base64Encode(input: string): string {
+export function base64Encode(input: string): string {
     const bytes = utf8Bytes(input);
     let out = "";
     for (let i = 0; i < bytes.length; i += 3) {

--- a/src/features/share/components/SharePreview.tsx
+++ b/src/features/share/components/SharePreview.tsx
@@ -1,0 +1,136 @@
+// Compact "what's inside this share" summary rendered in the import screen.
+
+import { fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { StyleSheet, Text, View } from "react-native";
+import type { FetchedShare } from "../services/shareClient";
+import type {
+    FoodSharePayload,
+    LogSharePayload,
+    RecipeSharePayload,
+} from "../services/sharePayloads";
+
+interface SharePreviewProps {
+    share: FetchedShare;
+    colors: ThemeColors;
+}
+
+const KIND_ICONS = {
+    food: "fast-food-outline",
+    recipe: "book-outline",
+    log: "list-outline",
+} as const;
+
+export default function SharePreview({ share, colors }: SharePreviewProps) {
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+
+    const { title, lines } = useMemo(() => summarize(share, t), [share, t]);
+
+    return (
+        <View style={styles.card}>
+            <View style={styles.titleRow}>
+                <Ionicons
+                    name={KIND_ICONS[share.kind] ?? "help-circle-outline"}
+                    size={20}
+                    color={colors.primary}
+                />
+                <Text style={styles.kindLabel}>{t(`share.kind_${share.kind}`)}</Text>
+            </View>
+            <Text style={styles.title} numberOfLines={2}>
+                {title}
+            </Text>
+            {lines.map((line, i) => (
+                <Text key={i} style={styles.line} numberOfLines={1}>
+                    {line}
+                </Text>
+            ))}
+        </View>
+    );
+}
+
+function summarize(
+    share: FetchedShare,
+    t: (key: string, opts?: any) => string,
+): { title: string; lines: string[] } {
+    switch (share.kind) {
+        case "food": {
+            const p = share.payload as FoodSharePayload;
+            return {
+                title: p?.food?.name ?? t("common.unknown"),
+                lines: [
+                    t("templates.calPer100g", { cal: Math.round(Number(p?.food?.calories_per_100g ?? 0)) }),
+                ],
+            };
+        }
+        case "recipe": {
+            const p = share.payload as RecipeSharePayload;
+            const items = Array.isArray(p?.items) ? p.items : [];
+            return {
+                title: p?.name ?? t("common.unknown"),
+                lines: [
+                    t("common.itemCount", { count: items.length }),
+                    ...items.slice(0, 4).map((item) => `· ${item?.food?.name ?? t("common.unknown")}`),
+                    ...(items.length > 4 ? [t("share.moreItems", { count: items.length - 4 })] : []),
+                ],
+            };
+        }
+        case "log": {
+            const p = share.payload as LogSharePayload;
+            const items = Array.isArray(p?.items) ? p.items : [];
+            const names = items.map((item) =>
+                item?.type === "recipe"
+                    ? (item.recipe?.name ?? t("common.unknown"))
+                    : (item?.food?.name ?? t("common.unknown")),
+            );
+            return {
+                title: t("common.itemCount", { count: items.length }),
+                lines: [
+                    ...names.slice(0, 5).map((name) => `· ${name}`),
+                    ...(names.length > 5 ? [t("share.moreItems", { count: names.length - 5 })] : []),
+                ],
+            };
+        }
+        default:
+            return { title: t("common.unknown"), lines: [] };
+    }
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        card: {
+            backgroundColor: colors.background,
+            borderRadius: spacing.sm,
+            borderWidth: 1,
+            borderColor: colors.border,
+            padding: spacing.md,
+            marginBottom: spacing.md,
+        },
+        titleRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            marginBottom: spacing.xs,
+        },
+        kindLabel: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            textTransform: "uppercase",
+            letterSpacing: 0.5,
+        },
+        title: {
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+            color: colors.text,
+            marginBottom: spacing.xs,
+        },
+        line: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            marginTop: 2,
+        },
+    });
+}

--- a/src/features/share/screens/ImportScreen.tsx
+++ b/src/features/share/screens/ImportScreen.tsx
@@ -1,0 +1,333 @@
+// Landing screen for share deep links (macroflow://share/<token>?origin=…).
+// Fetches the shared payload and offers Cancel / Save to library / Save and
+// add to log. Rendered as a floating card so it reads as a modal even though
+// it is a pushed route (deep links may open the app cold, with no screen
+// underneath to overlay).
+
+import Button from "@/src/shared/atoms/Button";
+import CalendarPicker from "@/src/shared/components/CalendarPicker";
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { MEAL_TYPES, type MealType } from "@/src/shared/types";
+import { formatDateKey } from "@/src/utils/date";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import SharePreview from "../components/SharePreview";
+import type { FetchedShare } from "../services/shareClient";
+import {
+    importFoodPayload,
+    importLogPayloadToLibrary,
+    importLogPayloadToLog,
+    importRecipePayload,
+    logImportedFood,
+    logImportedRecipe,
+    type FoodSharePayload,
+    type LogSharePayload,
+    type RecipeSharePayload,
+} from "../services/sharePayloads";
+import { fetchSharedContent } from "../services/shareService";
+
+type LoadState =
+    | { status: "loading" }
+    | { status: "ready"; share: FetchedShare }
+    | { status: "error"; message: string };
+
+export default function ImportScreen() {
+    const { token, origin } = useLocalSearchParams<{ token: string; origin?: string }>();
+    const { t } = useTranslation();
+    const colors = useThemeColors();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const insets = useSafeAreaInsets();
+    const router = useRouter();
+
+    const [state, setState] = useState<LoadState>({ status: "loading" });
+    const [saving, setSaving] = useState(false);
+    const [targetDate, setTargetDate] = useState(new Date());
+    const [mealType, setMealType] = useState<MealType>("snack");
+    const [calendarVisible, setCalendarVisible] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        queueMicrotask(() => {
+            if (!cancelled) setState({ status: "loading" });
+        });
+        fetchSharedContent(String(token ?? ""), origin)
+            .then((share) => {
+                if (cancelled) return;
+                if (share.kind !== "food" && share.kind !== "recipe" && share.kind !== "log") {
+                    setState({ status: "error", message: t("share.importUnsupported") });
+                    return;
+                }
+                setState({ status: "ready", share });
+            })
+            .catch((e: any) => {
+                if (!cancelled) {
+                    setState({ status: "error", message: e?.message ?? t("common.unknownError") });
+                }
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [token, origin, t]);
+
+    function close() {
+        if (router.canGoBack()) router.back();
+        else router.replace("/(tabs)" as any);
+    }
+
+    function finish(message: string) {
+        Alert.alert(t("share.importTitle"), message, [{ text: t("common.ok"), onPress: close }]);
+    }
+
+    function handleSaveToLibrary() {
+        if (state.status !== "ready") return;
+        try {
+            setSaving(true);
+            const { kind, payload } = state.share;
+            if (kind === "food") importFoodPayload(payload as FoodSharePayload);
+            else if (kind === "recipe") importRecipePayload(payload as RecipeSharePayload);
+            else importLogPayloadToLibrary(payload as LogSharePayload);
+            finish(t("share.importSavedToLibrary"));
+        } catch (e: any) {
+            Alert.alert(t("share.importFailed"), e?.message ?? t("common.unknownError"));
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    function handleSaveAndLog() {
+        if (state.status !== "ready") return;
+        try {
+            setSaving(true);
+            const { kind, payload } = state.share;
+            const dateKey = formatDateKey(targetDate);
+            if (kind === "food") {
+                logImportedFood(importFoodPayload(payload as FoodSharePayload), dateKey, mealType);
+            } else if (kind === "recipe") {
+                logImportedRecipe(importRecipePayload(payload as RecipeSharePayload), dateKey, mealType);
+            } else {
+                importLogPayloadToLog(payload as LogSharePayload, dateKey);
+            }
+            finish(t("share.importSavedAndLogged"));
+        } catch (e: any) {
+            Alert.alert(t("share.importFailed"), e?.message ?? t("common.unknownError"));
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    return (
+        <View style={[styles.screen, { paddingTop: insets.top + spacing.lg }]}>
+            <View style={styles.card}>
+                <View style={styles.header}>
+                    <Text style={styles.title}>{t("share.importTitle")}</Text>
+                    <Pressable onPress={close} hitSlop={8}>
+                        <Ionicons name="close" size={22} color={colors.textSecondary} />
+                    </Pressable>
+                </View>
+
+                {state.status === "loading" && (
+                    <View style={styles.center}>
+                        <ActivityIndicator size="large" color={colors.primary} />
+                        <Text style={styles.statusText}>{t("share.importLoading")}</Text>
+                    </View>
+                )}
+
+                {state.status === "error" && (
+                    <View style={styles.center}>
+                        <Ionicons name="cloud-offline-outline" size={40} color={colors.danger} />
+                        <Text style={styles.errorText}>{state.message}</Text>
+                        <Button title={t("common.cancel")} variant="outline" onPress={close} style={styles.errorBtn} />
+                    </View>
+                )}
+
+                {state.status === "ready" && (
+                    <ScrollView showsVerticalScrollIndicator={false}>
+                        <SharePreview share={state.share} colors={colors} />
+
+                        {/* Date (all kinds) + meal (templates only; log items keep their own meals). */}
+                        <Text style={styles.sectionLabel}>{t("share.logOnDate")}</Text>
+                        <Pressable style={styles.dateRow} onPress={() => setCalendarVisible(true)}>
+                            <Text style={styles.dateText}>
+                                {targetDate.toLocaleDateString(undefined, {
+                                    weekday: "short",
+                                    month: "short",
+                                    day: "numeric",
+                                })}
+                            </Text>
+                            <Ionicons name="calendar-outline" size={18} color={colors.primary} />
+                        </Pressable>
+
+                        {state.share.kind !== "log" && (
+                            <>
+                                <Text style={styles.sectionLabel}>{t("share.logToMeal")}</Text>
+                                <View style={styles.mealOptions}>
+                                    {MEAL_TYPES.map((meal) => (
+                                        <Pressable
+                                            key={meal.key}
+                                            style={[
+                                                styles.mealOption,
+                                                mealType === meal.key && styles.mealOptionSelected,
+                                            ]}
+                                            onPress={() => setMealType(meal.key)}
+                                        >
+                                            <Ionicons
+                                                name={meal.icon as never}
+                                                size={16}
+                                                color={mealType === meal.key ? "#fff" : colors.text}
+                                            />
+                                            <Text
+                                                style={[
+                                                    styles.mealOptionText,
+                                                    mealType === meal.key && styles.mealOptionTextSelected,
+                                                ]}
+                                            >
+                                                {t(`meal.${meal.key}`)}
+                                            </Text>
+                                        </Pressable>
+                                    ))}
+                                </View>
+                            </>
+                        )}
+
+                        <Button
+                            title={t("share.saveAndLog")}
+                            onPress={handleSaveAndLog}
+                            loading={saving}
+                            style={styles.actionBtn}
+                        />
+                        <Button
+                            title={t("share.saveToLibrary")}
+                            variant="outline"
+                            onPress={handleSaveToLibrary}
+                            disabled={saving}
+                            style={styles.actionBtn}
+                        />
+                        <Button
+                            title={t("common.cancel")}
+                            variant="ghost"
+                            onPress={close}
+                            disabled={saving}
+                            style={styles.actionBtn}
+                        />
+                    </ScrollView>
+                )}
+            </View>
+
+            <CalendarPicker
+                visible={calendarVisible}
+                selectedDate={targetDate}
+                onSelect={(date) => {
+                    setTargetDate(date);
+                    setCalendarVisible(false);
+                }}
+                onClose={() => setCalendarVisible(false)}
+            />
+        </View>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        screen: {
+            flex: 1,
+            backgroundColor: colors.background,
+            padding: spacing.lg,
+        },
+        card: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            borderWidth: 1,
+            borderColor: colors.border,
+            padding: spacing.lg,
+            maxHeight: "90%",
+        },
+        header: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: spacing.md,
+        },
+        title: {
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        center: {
+            alignItems: "center",
+            paddingVertical: spacing.xl,
+        },
+        statusText: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            marginTop: spacing.md,
+            textAlign: "center",
+        },
+        errorText: {
+            fontSize: fontSize.sm,
+            color: colors.danger,
+            marginTop: spacing.md,
+            textAlign: "center",
+        },
+        errorBtn: { marginTop: spacing.md },
+        sectionLabel: {
+            fontSize: fontSize.xs,
+            fontWeight: "600",
+            color: colors.textSecondary,
+            letterSpacing: 0.5,
+            marginBottom: spacing.sm,
+            marginTop: spacing.sm,
+        },
+        dateRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            backgroundColor: colors.background,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+            marginBottom: spacing.sm,
+        },
+        dateText: {
+            fontSize: fontSize.md,
+            color: colors.text,
+            fontWeight: "500",
+        },
+        mealOptions: {
+            flexDirection: "row",
+            flexWrap: "wrap",
+            gap: spacing.sm,
+            marginBottom: spacing.sm,
+        },
+        mealOption: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.xs,
+            paddingHorizontal: spacing.md,
+            paddingVertical: spacing.sm,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.background,
+        },
+        mealOptionSelected: {
+            backgroundColor: colors.primary,
+            borderColor: colors.primary,
+        },
+        mealOptionText: {
+            fontSize: fontSize.sm,
+            color: colors.text,
+        },
+        mealOptionTextSelected: {
+            color: "#fff",
+            fontWeight: "600",
+        },
+        actionBtn: { marginTop: spacing.sm },
+    });
+}

--- a/src/features/share/services/shareClient.ts
+++ b/src/features/share/services/shareClient.ts
@@ -1,0 +1,107 @@
+// HTTP transport for the share feature. Creating a share reuses the sync
+// account's Basic auth; fetching one back is unauthenticated, since the
+// recipient may have no account on the sharing server. The endpoint contract
+// lives in the MacroFlow-Backend README.
+
+import { base64Encode, type SyncCredentials } from "@/src/features/settings/services/syncClient";
+
+export type ShareKind = "food" | "recipe" | "log";
+
+/** Bump together with the backend's accepted version when the shape changes. */
+export const SHARE_PAYLOAD_VERSION = 1;
+
+export interface ShareCreateResult {
+    token: string;
+    /** Human-facing https link (redirects into the app); what the QR encodes. */
+    url: string;
+}
+
+export interface FetchedShare {
+    kind: ShareKind;
+    version: number;
+    payload: unknown;
+    createdAt: number;
+}
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+/** Uploads a payload to the sync server and returns its share token + URL. */
+export async function createShare(
+    creds: SyncCredentials,
+    kind: ShareKind,
+    payload: object,
+): Promise<ShareCreateResult> {
+    const body = await request(`${trimBase(creds.url)}/api/v1/share`, {
+        method: "POST",
+        body: JSON.stringify({ kind, version: SHARE_PAYLOAD_VERSION, payload }),
+        authorization: `Basic ${base64Encode(`${creds.username}:${creds.password}`)}`,
+    });
+    if (!body?.token || !body?.url) {
+        throw new Error("Share server returned an invalid response.");
+    }
+    return { token: String(body.token), url: String(body.url) };
+}
+
+/** Fetches a shared payload back from the server it was created on. */
+export async function fetchShare(baseUrl: string, token: string): Promise<FetchedShare> {
+    const body = await request(
+        `${trimBase(baseUrl)}/api/v1/share/${encodeURIComponent(token)}`,
+    );
+    if (!body?.kind || typeof body.payload !== "object" || body.payload === null) {
+        throw new Error("Share server returned an invalid response.");
+    }
+    return {
+        kind: body.kind as ShareKind,
+        version: Number(body.version ?? 0),
+        payload: body.payload,
+        createdAt: Number(body.createdAt ?? 0),
+    };
+}
+
+// ── Plumbing ───────────────────────────────────────────────
+
+function trimBase(url: string): string {
+    return url.trim().replace(/\/+$/, "");
+}
+
+async function request(
+    url: string,
+    init?: { method?: string; body?: string; authorization?: string },
+): Promise<any> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    let res: Response;
+    try {
+        res = await fetch(url, {
+            method: init?.method ?? "GET",
+            body: init?.body,
+            headers: {
+                "Content-Type": "application/json",
+                ...(init?.authorization ? { Authorization: init.authorization } : {}),
+            },
+            signal: controller.signal,
+        });
+    } catch {
+        throw new Error("Could not reach the share server. Check your connection.");
+    } finally {
+        clearTimeout(timeout);
+    }
+
+    if (res.status === 401 || res.status === 403) {
+        throw new Error("The share server rejected the sync account's credentials.");
+    }
+    if (res.status === 404) {
+        throw new Error("This share does not exist or has expired.");
+    }
+    if (res.status === 413) {
+        throw new Error("This item is too large to share.");
+    }
+    if (res.status === 429) {
+        throw new Error("Too many share requests — please try again later.");
+    }
+    if (!res.ok) {
+        throw new Error(`Share server error (HTTP ${res.status}).`);
+    }
+    const text = await res.text();
+    return text ? JSON.parse(text) : null;
+}

--- a/src/features/share/services/sharePayloads.ts
+++ b/src/features/share/services/sharePayloads.ts
@@ -1,0 +1,314 @@
+// Portable payload shapes for shared foods, recipes, and log selections
+// (version 1), plus the builders that produce them from local rows and the
+// importers that write them back into the local DB. Foods travel embedded in
+// full (macros + serving units) because the recipient likely doesn't have
+// them; on import an existing food is reused only when a stable identifier
+// (OpenFoodFacts id or barcode) matches, otherwise a new row is created —
+// imports never overwrite existing data.
+
+import {
+    addEntry,
+    getRecipeLogById,
+    logRecipeToMeal,
+    type EntryWithFood,
+} from "@/src/features/log/services/logDb";
+import {
+    addFood,
+    addRecipe,
+    addRecipeItem,
+    addServingUnit,
+    getFoodByBarcode,
+    getFoodByOpenfoodfactsId,
+    getRecipeById,
+    getRecipeItems,
+    getServingUnits,
+    type Food,
+    type ServingUnit,
+} from "@/src/features/templates/services/templateDb";
+
+// ── Payload shapes (version 1) ─────────────────────────────
+
+export interface SharedServingUnit {
+    name: string;
+    grams: number;
+}
+
+export interface SharedFood {
+    name: string;
+    calories_per_100g: number;
+    protein_per_100g: number;
+    carbs_per_100g: number;
+    fat_per_100g: number;
+    barcode?: string | null;
+    openfoodfacts_id?: string | null;
+    default_unit?: string;
+    serving_size?: number;
+    serving_units?: SharedServingUnit[];
+}
+
+export interface FoodSharePayload {
+    food: SharedFood;
+}
+
+export interface SharedRecipeItem {
+    food: SharedFood;
+    quantity_grams: number;
+    quantity_unit: string;
+}
+
+export interface RecipeSharePayload {
+    name: string;
+    items: SharedRecipeItem[];
+}
+
+export type SharedLogItem =
+    | {
+          type: "food";
+          food: SharedFood;
+          quantity_grams: number;
+          quantity_unit: string;
+          meal_type: string;
+      }
+    | {
+          type: "recipe";
+          recipe: RecipeSharePayload;
+          portion: number;
+          meal_type: string;
+      };
+
+export interface LogSharePayload {
+    items: SharedLogItem[];
+}
+
+// ── Builders ───────────────────────────────────────────────
+
+function toSharedFood(food: Food, units: ServingUnit[]): SharedFood {
+    return {
+        name: food.name,
+        calories_per_100g: food.calories_per_100g,
+        protein_per_100g: food.protein_per_100g,
+        carbs_per_100g: food.carbs_per_100g,
+        fat_per_100g: food.fat_per_100g,
+        barcode: food.barcode,
+        openfoodfacts_id: food.openfoodfacts_id,
+        default_unit: food.default_unit,
+        serving_size: food.serving_size,
+        serving_units: units.map((u) => ({ name: u.name, grams: u.grams })),
+    };
+}
+
+export function buildFoodPayload(food: Food): FoodSharePayload {
+    return { food: toSharedFood(food, getServingUnits(food.id)) };
+}
+
+export function buildRecipePayload(recipeId: number): RecipeSharePayload | null {
+    const recipe = getRecipeById(recipeId);
+    if (!recipe) return null;
+    const rows = getRecipeItems(recipeId);
+    return {
+        name: recipe.name,
+        items: rows
+            .filter((row) => row.foods)
+            .map((row) => ({
+                food: toSharedFood(row.foods!, getServingUnits(row.foods!.id)),
+                quantity_grams: row.recipe_items.quantity_grams,
+                quantity_unit: row.recipe_items.quantity_unit ?? "g",
+            })),
+    };
+}
+
+/**
+ * Bundles the log screen's selection. A recipe log whose entries are all
+ * selected travels as a recipe (template + portion) so the recipient can
+ * re-log or save it; partially-selected recipe entries and standalone entries
+ * travel as plain food items.
+ */
+export function buildLogSelectionPayload(
+    allRows: EntryWithFood[],
+    selectedIds: Set<number>,
+): LogSharePayload {
+    const items: SharedLogItem[] = [];
+    const foodRows: EntryWithFood[] = [];
+
+    const byRecipeLog = new Map<number, EntryWithFood[]>();
+    for (const row of allRows) {
+        const rlId = row.entries.recipe_log_id;
+        if (!rlId) continue;
+        const list = byRecipeLog.get(rlId) ?? [];
+        list.push(row);
+        byRecipeLog.set(rlId, list);
+    }
+
+    for (const [rlId, rows] of byRecipeLog) {
+        const selected = rows.filter((r) => selectedIds.has(r.entries.id));
+        if (selected.length === 0) continue;
+        if (selected.length === rows.length) {
+            const recipeLog = getRecipeLogById(rlId);
+            const recipe = recipeLog ? buildRecipePayload(recipeLog.recipe_id) : null;
+            if (recipeLog && recipe) {
+                items.push({
+                    type: "recipe",
+                    recipe,
+                    portion: recipeLog.portion,
+                    meal_type: recipeLog.meal_type,
+                });
+                continue;
+            }
+        }
+        foodRows.push(...selected);
+    }
+
+    for (const row of allRows) {
+        if (!row.entries.recipe_log_id && selectedIds.has(row.entries.id)) {
+            foodRows.push(row);
+        }
+    }
+
+    for (const row of foodRows) {
+        if (!row.foods) continue;
+        items.push({
+            type: "food",
+            food: toSharedFood(row.foods, getServingUnits(row.foods.id)),
+            quantity_grams: row.entries.quantity_grams,
+            quantity_unit: row.entries.quantity_unit,
+            meal_type: row.entries.meal_type,
+        });
+    }
+
+    return { items };
+}
+
+// ── Importers ──────────────────────────────────────────────
+
+/**
+ * Reuses an existing food when a stable identifier matches, otherwise creates
+ * one from the shared values (with numeric coercion so a malformed payload
+ * cannot write NaN into the DB).
+ */
+export function findOrCreateFood(shared: SharedFood): Food {
+    if (shared.openfoodfacts_id) {
+        const existing = getFoodByOpenfoodfactsId(String(shared.openfoodfacts_id));
+        if (existing && !existing.deleted) return existing;
+    }
+    if (shared.barcode) {
+        const existing = getFoodByBarcode(String(shared.barcode));
+        if (existing && !existing.deleted) return existing;
+    }
+
+    const num = (v: unknown, fallback = 0) => {
+        const n = Number(v);
+        return Number.isFinite(n) ? n : fallback;
+    };
+    const created = addFood({
+        name: String(shared.name ?? "").trim() || "Shared food",
+        calories_per_100g: num(shared.calories_per_100g),
+        protein_per_100g: num(shared.protein_per_100g),
+        carbs_per_100g: num(shared.carbs_per_100g),
+        fat_per_100g: num(shared.fat_per_100g),
+        barcode: shared.barcode ? String(shared.barcode) : null,
+        openfoodfacts_id: shared.openfoodfacts_id ? String(shared.openfoodfacts_id) : null,
+        source: "manual",
+        default_unit: shared.default_unit ? String(shared.default_unit) : "g",
+        serving_size: num(shared.serving_size, 100) || 100,
+    });
+    for (const unit of shared.serving_units ?? []) {
+        const grams = num(unit.grams);
+        const name = String(unit.name ?? "").trim();
+        if (!name || grams <= 0) continue;
+        addServingUnit({ food_id: created.id, name, grams });
+    }
+    return created;
+}
+
+export function importFoodPayload(payload: FoodSharePayload): Food {
+    if (!payload?.food) throw new Error("Invalid shared food.");
+    return findOrCreateFood(payload.food);
+}
+
+/** Creates a new recipe (never merges into an existing one) and returns its id. */
+export function importRecipePayload(payload: RecipeSharePayload): number {
+    if (!payload?.name || !Array.isArray(payload.items)) {
+        throw new Error("Invalid shared recipe.");
+    }
+    const recipe = addRecipe(String(payload.name));
+    for (const item of payload.items) {
+        if (!item?.food) continue;
+        const food = findOrCreateFood(item.food);
+        const grams = Number(item.quantity_grams);
+        addRecipeItem({
+            recipe_id: recipe.id,
+            food_id: food.id,
+            quantity_grams: Number.isFinite(grams) && grams > 0 ? grams : 0,
+            quantity_unit: item.quantity_unit ? String(item.quantity_unit) : "g",
+        });
+    }
+    return recipe.id;
+}
+
+/** Saves everything a log share contains into the library, without logging. */
+export function importLogPayloadToLibrary(payload: LogSharePayload): void {
+    for (const item of validLogItems(payload)) {
+        if (item.type === "food") findOrCreateFood(item.food);
+        else importRecipePayload(item.recipe);
+    }
+}
+
+/**
+ * Saves a log share into the library and logs each item to `dateKey`, keeping
+ * every item's original meal.
+ */
+export function importLogPayloadToLog(payload: LogSharePayload, dateKey: string): void {
+    for (const item of validLogItems(payload)) {
+        if (item.type === "food") {
+            const food = findOrCreateFood(item.food);
+            const grams = Number(item.quantity_grams);
+            addEntry({
+                food_id: food.id,
+                quantity_grams: Number.isFinite(grams) && grams > 0 ? grams : 0,
+                quantity_unit: item.quantity_unit ? String(item.quantity_unit) : "g",
+                timestamp: Date.now(),
+                date: dateKey,
+                meal_type: normalizeMeal(item.meal_type),
+            });
+        } else {
+            const recipeId = importRecipePayload(item.recipe);
+            const portion = Number(item.portion);
+            logRecipeToMeal(
+                recipeId,
+                normalizeMeal(item.meal_type),
+                dateKey,
+                Number.isFinite(portion) && portion > 0 ? portion : 1,
+            );
+        }
+    }
+}
+
+/** Logs an already-imported food as one serving of its default size. */
+export function logImportedFood(food: Food, dateKey: string, mealType: string): void {
+    addEntry({
+        food_id: food.id,
+        quantity_grams: food.serving_size > 0 ? food.serving_size : 100,
+        quantity_unit: "g",
+        timestamp: Date.now(),
+        date: dateKey,
+        meal_type: mealType,
+    });
+}
+
+/** Logs an already-imported recipe at portion 1. */
+export function logImportedRecipe(recipeId: number, dateKey: string, mealType: string): void {
+    logRecipeToMeal(recipeId, mealType, dateKey, 1);
+}
+
+function validLogItems(payload: LogSharePayload): SharedLogItem[] {
+    if (!Array.isArray(payload?.items)) throw new Error("Invalid shared log.");
+    return payload.items.filter(
+        (item) => (item?.type === "food" && item.food) || (item?.type === "recipe" && item.recipe),
+    );
+}
+
+const MEALS = new Set(["breakfast", "lunch", "dinner", "snack"]);
+
+function normalizeMeal(meal: unknown): string {
+    return MEALS.has(String(meal)) ? String(meal) : "snack";
+}

--- a/src/features/share/services/sharePayloads.ts
+++ b/src/features/share/services/sharePayloads.ts
@@ -181,11 +181,63 @@ export function buildLogSelectionPayload(
 // ── Importers ──────────────────────────────────────────────
 
 /**
+ * Per-import dedupe caches. A payload embeds a food once per item that uses
+ * it, so the same food (or the same recipe logged for two meals) appears
+ * multiple times; without the cache each occurrence would create its own
+ * template row.
+ */
+interface ImportCache {
+    foods: Map<string, Food>;
+    recipes: Map<string, number>;
+}
+
+function newImportCache(): ImportCache {
+    return { foods: new Map(), recipes: new Map() };
+}
+
+/** Identity of a shared food within one import: stable id, else full content. */
+function foodKey(shared: SharedFood): string {
+    if (shared.openfoodfacts_id) return `off:${shared.openfoodfacts_id}`;
+    if (shared.barcode) return `bc:${shared.barcode}`;
+    return (
+        "c:" +
+        JSON.stringify([
+            shared.name,
+            shared.calories_per_100g,
+            shared.protein_per_100g,
+            shared.carbs_per_100g,
+            shared.fat_per_100g,
+            shared.default_unit,
+            shared.serving_size,
+            (shared.serving_units ?? []).map((u) => [u.name, u.grams]),
+        ])
+    );
+}
+
+function recipeKey(payload: RecipeSharePayload): string {
+    return JSON.stringify([
+        payload.name,
+        payload.items.map((item) => [foodKey(item.food), item.quantity_grams, item.quantity_unit]),
+    ]);
+}
+
+/**
  * Reuses an existing food when a stable identifier matches, otherwise creates
  * one from the shared values (with numeric coercion so a malformed payload
- * cannot write NaN into the DB).
+ * cannot write NaN into the DB). Within one import, identical foods are
+ * created once and reused via `cache`.
  */
-export function findOrCreateFood(shared: SharedFood): Food {
+export function findOrCreateFood(shared: SharedFood, cache: ImportCache = newImportCache()): Food {
+    const key = foodKey(shared);
+    const cached = cache.foods.get(key);
+    if (cached) return cached;
+
+    const found = lookupOrCreateFood(shared);
+    cache.foods.set(key, found);
+    return found;
+}
+
+function lookupOrCreateFood(shared: SharedFood): Food {
     if (shared.openfoodfacts_id) {
         const existing = getFoodByOpenfoodfactsId(String(shared.openfoodfacts_id));
         if (existing && !existing.deleted) return existing;
@@ -225,15 +277,26 @@ export function importFoodPayload(payload: FoodSharePayload): Food {
     return findOrCreateFood(payload.food);
 }
 
-/** Creates a new recipe (never merges into an existing one) and returns its id. */
-export function importRecipePayload(payload: RecipeSharePayload): number {
+/**
+ * Creates a new recipe (never merges into an existing one) and returns its
+ * id. Within one import, identical recipes are created once and reused via
+ * `cache`.
+ */
+export function importRecipePayload(
+    payload: RecipeSharePayload,
+    cache: ImportCache = newImportCache(),
+): number {
     if (!payload?.name || !Array.isArray(payload.items)) {
         throw new Error("Invalid shared recipe.");
     }
+    const key = recipeKey(payload);
+    const cached = cache.recipes.get(key);
+    if (cached !== undefined) return cached;
+
     const recipe = addRecipe(String(payload.name));
     for (const item of payload.items) {
         if (!item?.food) continue;
-        const food = findOrCreateFood(item.food);
+        const food = findOrCreateFood(item.food, cache);
         const grams = Number(item.quantity_grams);
         addRecipeItem({
             recipe_id: recipe.id,
@@ -242,14 +305,16 @@ export function importRecipePayload(payload: RecipeSharePayload): number {
             quantity_unit: item.quantity_unit ? String(item.quantity_unit) : "g",
         });
     }
+    cache.recipes.set(key, recipe.id);
     return recipe.id;
 }
 
 /** Saves everything a log share contains into the library, without logging. */
 export function importLogPayloadToLibrary(payload: LogSharePayload): void {
+    const cache = newImportCache();
     for (const item of validLogItems(payload)) {
-        if (item.type === "food") findOrCreateFood(item.food);
-        else importRecipePayload(item.recipe);
+        if (item.type === "food") findOrCreateFood(item.food, cache);
+        else importRecipePayload(item.recipe, cache);
     }
 }
 
@@ -258,9 +323,10 @@ export function importLogPayloadToLibrary(payload: LogSharePayload): void {
  * every item's original meal.
  */
 export function importLogPayloadToLog(payload: LogSharePayload, dateKey: string): void {
+    const cache = newImportCache();
     for (const item of validLogItems(payload)) {
         if (item.type === "food") {
-            const food = findOrCreateFood(item.food);
+            const food = findOrCreateFood(item.food, cache);
             const grams = Number(item.quantity_grams);
             addEntry({
                 food_id: food.id,
@@ -271,7 +337,7 @@ export function importLogPayloadToLog(payload: LogSharePayload, dateKey: string)
                 meal_type: normalizeMeal(item.meal_type),
             });
         } else {
-            const recipeId = importRecipePayload(item.recipe);
+            const recipeId = importRecipePayload(item.recipe, cache);
             const portion = Number(item.portion);
             logRecipeToMeal(
                 recipeId,

--- a/src/features/share/services/shareService.ts
+++ b/src/features/share/services/shareService.ts
@@ -1,0 +1,69 @@
+// High-level share operations the entry-point screens call: check whether
+// sharing is possible (a sync account doubles as the share credential), turn
+// a local food/recipe/log selection into an uploaded share URL, and fetch a
+// shared payload back when importing.
+
+import { loadSyncSettings } from "@/src/features/settings/services/syncSettings";
+import { type EntryWithFood } from "@/src/features/log/services/logDb";
+import { getFoodById } from "@/src/features/templates/services/templateDb";
+import { createShare, fetchShare, type FetchedShare } from "./shareClient";
+import {
+    buildFoodPayload,
+    buildLogSelectionPayload,
+    buildRecipePayload,
+} from "./sharePayloads";
+
+/** Sharing rides on the sync account; without one there is nowhere to POST. */
+export async function isShareConfigured(): Promise<boolean> {
+    return (await loadSyncSettings()) !== null;
+}
+
+export async function shareFood(foodId: number): Promise<string> {
+    const creds = await requireCreds();
+    const food = getFoodById(foodId);
+    if (!food) throw new Error("Food not found.");
+    const { url } = await createShare(creds, "food", buildFoodPayload(food));
+    return url;
+}
+
+export async function shareRecipe(recipeId: number): Promise<string> {
+    const creds = await requireCreds();
+    const payload = buildRecipePayload(recipeId);
+    if (!payload) throw new Error("Recipe not found.");
+    const { url } = await createShare(creds, "recipe", payload);
+    return url;
+}
+
+export async function shareLogSelection(
+    allRows: EntryWithFood[],
+    selectedIds: Set<number>,
+): Promise<string> {
+    const creds = await requireCreds();
+    const payload = buildLogSelectionPayload(allRows, selectedIds);
+    if (payload.items.length === 0) throw new Error("Nothing selected to share.");
+    const { url } = await createShare(creds, "log", payload);
+    return url;
+}
+
+/**
+ * Fetches a shared payload for import. `origin` comes from the share link's
+ * query parameter and names the server the token lives on; when absent (e.g.
+ * a hand-typed link) the user's own sync server is tried instead.
+ */
+export async function fetchSharedContent(token: string, origin?: string): Promise<FetchedShare> {
+    let base = origin?.trim();
+    if (base && !/^https?:\/\//i.test(base)) base = undefined;
+    if (!base) base = (await loadSyncSettings())?.url;
+    if (!base) {
+        throw new Error(
+            "This link does not say which server it lives on, and no sync account is configured.",
+        );
+    }
+    return fetchShare(base, token);
+}
+
+async function requireCreds() {
+    const creds = await loadSyncSettings();
+    if (!creds) throw new Error("Sharing needs a sync account. Sign in first.");
+    return creds;
+}

--- a/src/features/templates/screens/FoodEditorScreen.tsx
+++ b/src/features/templates/screens/FoodEditorScreen.tsx
@@ -1,16 +1,44 @@
 import FoodForm from "@/src/features/templates/components/FoodForm";
+import { isShareConfigured, shareFood } from "@/src/features/share/services/shareService";
+import ShareModal from "@/src/shared/components/ShareModal";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { Ionicons } from "@expo/vector-icons";
 import { useHeaderHeight } from "expo-router/react-navigation";
-import { router, Stack, useLocalSearchParams } from "expo-router";
-import React from "react";
+import { router, Stack, useFocusEffect, useLocalSearchParams } from "expo-router";
+import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { KeyboardAvoidingView, Platform, StyleSheet } from "react-native";
+import { Alert, KeyboardAvoidingView, Platform, Pressable, StyleSheet } from "react-native";
 
 export default function FoodEditorScreen() {
     const { foodId } = useLocalSearchParams<{ foodId?: string }>();
     const { t } = useTranslation();
     const colors = useThemeColors();
     const headerHeight = useHeaderHeight();
+
+    const [shareAvailable, setShareAvailable] = useState(false);
+    const [shareVisible, setShareVisible] = useState(false);
+
+    // Re-checked on focus so signing in under Account and coming back
+    // immediately enables the share button.
+    useFocusEffect(
+        useCallback(() => {
+            let cancelled = false;
+            isShareConfigured().then((available) => {
+                if (!cancelled) setShareAvailable(available);
+            });
+            return () => {
+                cancelled = true;
+            };
+        }, []),
+    );
+
+    function handleSharePress() {
+        if (!shareAvailable) {
+            Alert.alert(t("share.notConfiguredTitle"), t("share.notConfiguredMessage"));
+            return;
+        }
+        setShareVisible(true);
+    }
 
     return (
         <KeyboardAvoidingView
@@ -27,12 +55,31 @@ export default function FoodEditorScreen() {
                     title: foodId
                         ? t("templates.foodEditorTitle")
                         : t("templates.newFoodTitle"),
+                    // Only an already-saved food can be shared.
+                    headerRight: foodId
+                        ? () => (
+                              <Pressable
+                                  onPress={handleSharePress}
+                                  hitSlop={8}
+                                  style={{ opacity: shareAvailable ? 1 : 0.4 }}
+                              >
+                                  <Ionicons name="share-outline" size={22} color={colors.text} />
+                              </Pressable>
+                          )
+                        : undefined,
                 }}
             />
             <FoodForm
                 foodId={foodId ? Number(foodId) : undefined}
                 onSaved={() => router.back()}
             />
+            {foodId && (
+                <ShareModal
+                    visible={shareVisible}
+                    onClose={() => setShareVisible(false)}
+                    fetchUrl={() => shareFood(Number(foodId))}
+                />
+            )}
         </KeyboardAvoidingView>
     );
 }

--- a/src/features/templates/screens/RecipeEditorScreen.tsx
+++ b/src/features/templates/screens/RecipeEditorScreen.tsx
@@ -1,16 +1,19 @@
 import BarcodeScannerView from "@/src/shared/components/BarcodeScannerView";
 import ManualFoodForm from "../components/ManualFoodForm";
+import { isShareConfigured, shareRecipe } from "@/src/features/share/services/shareService";
 import Button from "@/src/shared/atoms/Button";
 import Input from "@/src/shared/atoms/Input";
 import BottomSheet, { type BottomSheetRef } from "@/src/shared/components/BottomSheet";
+import ShareModal from "@/src/shared/components/ShareModal";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { fromGrams, unitLabel, type FoodUnit } from "@/src/utils/units";
 import { Ionicons } from "@expo/vector-icons";
-import { Stack } from "expo-router";
-import React, { useCallback, useMemo, useRef } from "react";
+import { Stack, useFocusEffect, useLocalSearchParams } from "expo-router";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+    Alert,
     Keyboard,
     Pressable,
     ScrollView,
@@ -32,8 +35,34 @@ export default function RecipeEditorScreen() {
     const { height: screenHeight } = useWindowDimensions();
     const sheetRef = useRef<BottomSheetRef>(null);
     const snapPoints = useMemo(() => [SHEET_COLLAPSED, Math.round(screenHeight * 0.8)], [screenHeight]);
+    const { recipeId } = useLocalSearchParams<{ recipeId?: string }>();
 
     const recipe = useRecipeEditor();
+
+    const [shareAvailable, setShareAvailable] = useState(false);
+    const [shareVisible, setShareVisible] = useState(false);
+
+    // Re-checked on focus so signing in under Account and coming back
+    // immediately enables the share button.
+    useFocusEffect(
+        useCallback(() => {
+            let cancelled = false;
+            isShareConfigured().then((available) => {
+                if (!cancelled) setShareAvailable(available);
+            });
+            return () => {
+                cancelled = true;
+            };
+        }, []),
+    );
+
+    const handleSharePress = useCallback(() => {
+        if (!shareAvailable) {
+            Alert.alert(t("share.notConfiguredTitle"), t("share.notConfiguredMessage"));
+            return;
+        }
+        setShareVisible(true);
+    }, [shareAvailable, t]);
 
     const handleSearchFocus = useCallback(() => {
         sheetRef.current?.snapTo(1);
@@ -65,6 +94,18 @@ export default function RecipeEditorScreen() {
                     title: recipe.isEditing
                         ? t("templates.recipeEditorTitle")
                         : t("templates.newRecipeTitle"),
+                    // Only an already-saved recipe can be shared.
+                    headerRight: recipe.isEditing
+                        ? () => (
+                              <Pressable
+                                  onPress={handleSharePress}
+                                  hitSlop={8}
+                                  style={{ opacity: shareAvailable ? 1 : 0.4 }}
+                              >
+                                  <Ionicons name="share-outline" size={22} color={colors.text} />
+                              </Pressable>
+                          )
+                        : undefined,
                 }}
             />
             <ScrollView
@@ -253,6 +294,14 @@ export default function RecipeEditorScreen() {
                 onFoodFound={recipe.handleBarcodeFound}
                 onNotFound={recipe.handleBarcodeNotFound}
             />
+
+            {recipeId && (
+                <ShareModal
+                    visible={shareVisible}
+                    onClose={() => setShareVisible(false)}
+                    fetchUrl={() => shareRecipe(Number(recipeId))}
+                />
+            )}
         </View>
     );
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -698,6 +698,31 @@ const de = {
             mealPlanGenerated_other: "Essensplan mit {{count}} Einträgen generiert.",
         },
     },
+    share: {
+        title: "Teilen",
+        creating: "Freigabe-Link wird erstellt…",
+        hint: "Scanne diesen QR-Code mit der Kamera des anderen Geräts oder verschicke den Link.",
+        copy: "Link kopieren",
+        copied: "Kopiert!",
+        shareLink: "Teilen…",
+        notConfiguredTitle: "Teilen nicht verfügbar",
+        notConfiguredMessage:
+            "Zum Teilen wird das Element auf deinen Sync-Server hochgeladen, aber es ist kein Sync-Konto eingerichtet. Lege zuerst unter Mehr → Konto die Server-URL fest und melde dich an.",
+        importTitle: "Geteiltes Element importieren",
+        importLoading: "Geteilte Inhalte werden geladen…",
+        importFailed: "Import fehlgeschlagen",
+        importUnsupported: "Diese Freigabe stammt aus einer neueren App-Version und kann nicht importiert werden.",
+        importSavedToLibrary: "In deiner Bibliothek gespeichert.",
+        importSavedAndLogged: "In deiner Bibliothek gespeichert und zum Log hinzugefügt.",
+        kind_food: "Geteiltes Lebensmittel",
+        kind_recipe: "Geteiltes Rezept",
+        kind_log: "Geteilte Log-Einträge",
+        moreItems: "…und {{count}} weitere",
+        logOnDate: "Loggen am",
+        logToMeal: "Mahlzeit",
+        saveToLibrary: "In Bibliothek speichern",
+        saveAndLog: "Speichern und zum Log hinzufügen",
+    },
 } as const;
 
 export default de;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -695,6 +695,31 @@ const en = {
             mealPlanGenerated_other: "Meal plan generated with {{count}} entries.",
         },
     },
+    share: {
+        title: "Share",
+        creating: "Creating share link…",
+        hint: "Scan this QR code with the other device's camera, or send the link.",
+        copy: "Copy link",
+        copied: "Copied!",
+        shareLink: "Share…",
+        notConfiguredTitle: "Sharing unavailable",
+        notConfiguredMessage:
+            "Sharing uploads the item to your sync server, but no sync account is configured. Set the server URL and sign in under More → Account first.",
+        importTitle: "Import shared item",
+        importLoading: "Fetching shared content…",
+        importFailed: "Import failed",
+        importUnsupported: "This share was created by a newer app version and cannot be imported.",
+        importSavedToLibrary: "Saved to your library.",
+        importSavedAndLogged: "Saved to your library and added to your log.",
+        kind_food: "Shared food",
+        kind_recipe: "Shared recipe",
+        kind_log: "Shared log items",
+        moreItems: "…and {{count}} more",
+        logOnDate: "Log on",
+        logToMeal: "Meal",
+        saveToLibrary: "Save to library",
+        saveAndLog: "Save and add to log",
+    },
 } as const;
 
 export default en;

--- a/src/shared/components/ShareModal.tsx
+++ b/src/shared/components/ShareModal.tsx
@@ -1,0 +1,240 @@
+// Floating modal that turns a "make me a share URL" callback into a QR code
+// plus copy / native-share actions. It is deliberately dumb about where the
+// URL comes from — the calling screen closes over the right share service
+// call — so it can be reused by any feature without importing feature code.
+
+import Button from "@/src/shared/atoms/Button";
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import * as Clipboard from "expo-clipboard";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+    ActivityIndicator,
+    Modal,
+    Pressable,
+    Share,
+    StyleSheet,
+    Text,
+    View,
+} from "react-native";
+import QRCode from "react-native-qrcode-svg";
+
+interface ShareModalProps {
+    visible: boolean;
+    onClose: () => void;
+    /** Uploads the shared item and resolves to its share URL. Called each time the modal opens. */
+    fetchUrl: () => Promise<string>;
+}
+
+type ShareState =
+    | { status: "loading" }
+    | { status: "ready"; url: string }
+    | { status: "error"; message: string };
+
+export default function ShareModal({ visible, onClose, fetchUrl }: ShareModalProps) {
+    const { t } = useTranslation();
+    const colors = useThemeColors();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const [state, setState] = useState<ShareState>({ status: "loading" });
+    const [copied, setCopied] = useState(false);
+
+    // The callback is typically an inline closure; keep the latest one in a
+    // ref so the fetch effect only re-runs when the modal opens.
+    const fetchUrlRef = useRef(fetchUrl);
+    useEffect(() => {
+        fetchUrlRef.current = fetchUrl;
+    });
+
+    useEffect(() => {
+        if (!visible) return;
+        let cancelled = false;
+        queueMicrotask(() => {
+            if (cancelled) return;
+            setState({ status: "loading" });
+            setCopied(false);
+        });
+        fetchUrlRef
+            .current()
+            .then((url) => {
+                if (!cancelled) setState({ status: "ready", url });
+            })
+            .catch((e: any) => {
+                if (!cancelled) {
+                    setState({ status: "error", message: e?.message ?? t("common.unknownError") });
+                }
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [visible, t]);
+
+    useEffect(() => {
+        if (!copied) return;
+        const timer = setTimeout(() => setCopied(false), 2000);
+        return () => clearTimeout(timer);
+    }, [copied]);
+
+    async function handleCopy() {
+        if (state.status !== "ready") return;
+        await Clipboard.setStringAsync(state.url);
+        setCopied(true);
+    }
+
+    async function handleShare() {
+        if (state.status !== "ready") return;
+        await Share.share({ message: state.url });
+    }
+
+    function handleRetry() {
+        setState({ status: "loading" });
+        fetchUrlRef
+            .current()
+            .then((url) => setState({ status: "ready", url }))
+            .catch((e: any) =>
+                setState({ status: "error", message: e?.message ?? t("common.unknownError") }),
+            );
+    }
+
+    return (
+        <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+            <Pressable style={styles.overlay} onPress={onClose}>
+                <Pressable style={styles.modal} onPress={() => {}}>
+                    <View style={styles.header}>
+                        <Text style={styles.title}>{t("share.title")}</Text>
+                        <Pressable onPress={onClose} hitSlop={8}>
+                            <Ionicons name="close" size={22} color={colors.textSecondary} />
+                        </Pressable>
+                    </View>
+
+                    {state.status === "loading" && (
+                        <View style={styles.center}>
+                            <ActivityIndicator size="large" color={colors.primary} />
+                            <Text style={styles.statusText}>{t("share.creating")}</Text>
+                        </View>
+                    )}
+
+                    {state.status === "error" && (
+                        <View style={styles.center}>
+                            <Ionicons name="cloud-offline-outline" size={40} color={colors.danger} />
+                            <Text style={styles.errorText}>{state.message}</Text>
+                            <Button
+                                title={t("common.retry")}
+                                variant="outline"
+                                onPress={handleRetry}
+                                style={styles.retryBtn}
+                            />
+                        </View>
+                    )}
+
+                    {state.status === "ready" && (
+                        <>
+                            {/* Always white so the QR stays scannable in dark mode. */}
+                            <View style={styles.qrBox}>
+                                <QRCode value={state.url} size={200} backgroundColor="#FFFFFF" color="#000000" />
+                            </View>
+                            <Text style={styles.hint}>{t("share.hint")}</Text>
+                            <Text style={styles.url} numberOfLines={2} selectable>
+                                {state.url}
+                            </Text>
+                            <View style={styles.actionRow}>
+                                <Button
+                                    title={copied ? t("share.copied") : t("share.copy")}
+                                    variant="outline"
+                                    icon={
+                                        <Ionicons
+                                            name={copied ? "checkmark-outline" : "copy-outline"}
+                                            size={18}
+                                            color={colors.text}
+                                        />
+                                    }
+                                    onPress={handleCopy}
+                                    style={styles.actionBtn}
+                                />
+                                <Button
+                                    title={t("share.shareLink")}
+                                    icon={<Ionicons name="share-social-outline" size={18} color="#fff" />}
+                                    onPress={handleShare}
+                                    style={styles.actionBtn}
+                                />
+                            </View>
+                        </>
+                    )}
+                </Pressable>
+            </Pressable>
+        </Modal>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        overlay: {
+            flex: 1,
+            backgroundColor: "rgba(0,0,0,0.5)",
+            justifyContent: "center",
+            alignItems: "center",
+            padding: spacing.lg,
+        },
+        modal: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.lg,
+            width: "100%",
+            maxWidth: 340,
+            alignItems: "stretch",
+        },
+        header: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            marginBottom: spacing.md,
+        },
+        title: {
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+            color: colors.text,
+        },
+        center: {
+            alignItems: "center",
+            paddingVertical: spacing.xl,
+        },
+        statusText: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            marginTop: spacing.md,
+            textAlign: "center",
+        },
+        errorText: {
+            fontSize: fontSize.sm,
+            color: colors.danger,
+            marginTop: spacing.md,
+            textAlign: "center",
+        },
+        retryBtn: { marginTop: spacing.md },
+        qrBox: {
+            alignSelf: "center",
+            backgroundColor: "#FFFFFF",
+            borderRadius: borderRadius.md,
+            padding: spacing.md,
+        },
+        hint: {
+            fontSize: fontSize.sm,
+            color: colors.textSecondary,
+            textAlign: "center",
+            marginTop: spacing.md,
+        },
+        url: {
+            fontSize: fontSize.xs,
+            color: colors.textTertiary,
+            textAlign: "center",
+            marginTop: spacing.sm,
+        },
+        actionRow: {
+            flexDirection: "row",
+            gap: spacing.sm,
+            marginTop: spacing.md,
+        },
+        actionBtn: { flex: 1 },
+    });
+}


### PR DESCRIPTION
## Summary
- **New share entry points**: a share icon in the Edit Food and Edit Recipe headers, and a share FAB in the Log screen's selection mode (between the create-recipe and delete actions). Sharing uploads the item to the configured sync server via the new share endpoint (herrderkekse/MacroFlow-Backend#10, reusing the sync account's Basic auth) and opens a floating modal showing the returned URL as a QR code, with copy and native-share actions.
- **No sync account configured** → the share buttons render greyed out, and tapping them explains that sharing needs a sync account (Settings → Account).
- **Import flow**: opening a share link (`https://<server>/s/<token>`, e.g. by scanning the QR with the stock camera) redirects into `macroflow://share/<token>?origin=<server>`, which Expo Router resolves to a new import screen. It fetches the payload (unauthenticated — the recipient needs no account) and offers **Cancel**, **Save to library**, and **Save and add to log** (with a date picker, plus a meal picker for template shares; shared log selections keep their original meals).
- **Payloads** (`version: 1`): foods travel with macros + serving units; recipes embed their ingredient foods in full; log selections bundle standalone entries as food items and fully-selected recipe logs as recipes with their logged portion. On import, an existing food is reused only when a stable identifier (OpenFoodFacts id or barcode) matches — imports never overwrite existing data.
- New dependency: `react-native-qrcode-svg` (pure JS on top of the already-present `react-native-svg`).

Closes #390. Relates to #75 (this is the backend-relay path; the fully offline QR-payload approach described there stays open).

## Test plan
- [x] `npx tsc --noEmit` and `npm run lint` pass.
- [ ] Against a locally-running backend (MacroFlow-Backend PR #10): sign in, share a food / a recipe / a multi-item log selection, confirm the QR + copy + share sheet work.
- [ ] Open the share URL on a second device: browser hands off to the app, import preview shows the right content, and all three actions behave (Cancel / Save to library / Save and add to log).
- [ ] Signed-out state: share buttons greyed, tapping shows the explanation alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)