### PR TITLE
Supersets: alternate two exercises with one shared rest timer (closes #394)

### DIFF
--- a/src/features/exercise/components/ExerciseCard.tsx
+++ b/src/features/exercise/components/ExerciseCard.tsx
@@ -27,6 +27,7 @@ interface ExerciseCardProps {
     onAddSet: (workoutExerciseId: number) => void;
     onCopyFromLast: (workoutExerciseId: number, templateId: number) => void;
     onReorderSets: (workoutExerciseId: number, from: number, to: number) => void;
+    onSuperset: (baseWorkoutExerciseId: number) => void;
     restTimerActive: boolean;
     restTimerElapsed: number;
     restTimerTarget: number;
@@ -39,6 +40,7 @@ export default function ExerciseCard({
     item, index, isFinished, isExpanded, onExpand, onDragStart, lastWorkoutSets,
     onRemove, onNoteChange,
     onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast, onReorderSets,
+    onSuperset,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
     onRestTimerChangeDuration,
 }: ExerciseCardProps) {
@@ -88,10 +90,12 @@ export default function ExerciseCard({
                     onEditNote={() => { setMenuOpen(false); setNoteDraft(item.workoutExercise.notes ?? ""); setNoteOpen(true); }}
                     onCopyFromLast={() => { onCopyFromLast(item.workoutExercise.id, template!.id); setMenuOpen(false); }}
                     onRemove={handleRemove}
+                    onSuperset={template ? () => { setMenuOpen(false); onSuperset(item.workoutExercise.id); } : undefined}
                     labels={{
                         editNote: t("exercise.exerciseCard.editNote"),
                         addNote: t("exercise.exerciseCard.addNote"),
                         copyFromLast: t("exercise.exerciseCard.copyFromLast"),
+                        superset: t("exercise.exerciseCard.superset"),
                         remove: t("exercise.exerciseCard.remove"),
                     }}
                 />
@@ -136,6 +140,7 @@ export default function ExerciseCard({
             onAddSet={onAddSet}
             onCopyFromLast={onCopyFromLast}
             onReorderSets={onReorderSets}
+            onSuperset={onSuperset}
             restTimerActive={restTimerActive}
             restTimerElapsed={restTimerElapsed}
             restTimerTarget={restTimerTarget}

--- a/src/features/exercise/components/ExerciseCardModals.tsx
+++ b/src/features/exercise/components/ExerciseCardModals.tsx
@@ -35,10 +35,13 @@ interface ExerciseCardMenuProps {
     onEditNote: () => void;
     onCopyFromLast: () => void;
     onRemove: () => void;
+    /** When provided (and not finished), shows a "Superset with…" action. */
+    onSuperset?: () => void;
     labels: {
         editNote: string;
         addNote: string;
         copyFromLast: string;
+        superset?: string;
         remove: string;
     };
 }
@@ -46,7 +49,7 @@ interface ExerciseCardMenuProps {
 export function ExerciseCardMenu({
     visible, onClose, isFinished,
     hasNote, hasTemplate,
-    onEditNote, onCopyFromLast, onRemove,
+    onEditNote, onCopyFromLast, onRemove, onSuperset,
     labels,
 }: ExerciseCardMenuProps) {
     const colors = useThemeColors();
@@ -63,6 +66,9 @@ export function ExerciseCardMenu({
                     />
                     {hasTemplate && (
                         <MenuItem label={labels.copyFromLast} icon="copy-outline" onPress={onCopyFromLast} colors={colors} />
+                    )}
+                    {!isFinished && onSuperset && labels.superset && (
+                        <MenuItem label={labels.superset} icon="git-merge-outline" onPress={onSuperset} colors={colors} />
                     )}
                     <MenuItem label={labels.remove} icon="trash-outline" onPress={onRemove} colors={colors} destructive />
                 </View>

--- a/src/features/exercise/components/ExpandedExerciseCard.tsx
+++ b/src/features/exercise/components/ExpandedExerciseCard.tsx
@@ -37,6 +37,7 @@ interface ExpandedExerciseCardProps {
     onAddSet: (workoutExerciseId: number) => void;
     onCopyFromLast: (workoutExerciseId: number, templateId: number) => void;
     onReorderSets: (workoutExerciseId: number, from: number, to: number) => void;
+    onSuperset: (baseWorkoutExerciseId: number) => void;
     restTimerActive: boolean;
     restTimerElapsed: number;
     restTimerTarget: number;
@@ -51,7 +52,7 @@ export function ExpandedExerciseCard({
     menuOpen, setMenuOpen, onDragStart, noteOpen, setNoteOpen, noteDraft, setNoteDraft,
     onRemove, onNoteChange,
     onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast,
-    onReorderSets,
+    onReorderSets, onSuperset,
     restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip,
     onRestTimerChangeDuration,
 }: ExpandedExerciseCardProps) {
@@ -205,10 +206,12 @@ export function ExpandedExerciseCard({
                 onEditNote={() => { setMenuOpen(false); setNoteDraft(item.workoutExercise.notes ?? ""); setNoteOpen(true); }}
                 onCopyFromLast={() => { onCopyFromLast(item.workoutExercise.id, template!.id); setMenuOpen(false); }}
                 onRemove={handleRemove}
+                onSuperset={template ? () => { setMenuOpen(false); onSuperset(item.workoutExercise.id); } : undefined}
                 labels={{
                     editNote: t("exercise.exerciseCard.editNote"),
                     addNote: t("exercise.exerciseCard.addNote"),
                     copyFromLast: t("exercise.exerciseCard.copyFromLast"),
+                    superset: t("exercise.exerciseCard.superset"),
                     remove: t("exercise.exerciseCard.remove"),
                 }}
             />

--- a/src/features/exercise/components/SupersetCard.tsx
+++ b/src/features/exercise/components/SupersetCard.tsx
@@ -1,0 +1,402 @@
+import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import React, { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert, Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import DraggableFlatList, { type RenderItemParams } from "react-native-draggable-flatlist";
+import { parseCustomFields } from "../helpers/customFields";
+import { activeRowIndex, nextAddTarget, orderSupersetRows, type SupersetRow, type WorkoutCard } from "../helpers/supersets";
+import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
+import type { ExerciseType } from "../types";
+import { createExerciseCardStyles, getPrefillForSet } from "./ExerciseCardHelpers";
+import { ExerciseNoteModal, MenuItem } from "./ExerciseCardModals";
+import RestTimer from "./RestTimer";
+import SetInputRow, { type SetValues } from "./SetInputRow";
+
+// Distinct, theme-aware accent per member so each set row can be tied to its exercise.
+function memberColor(colors: ThemeColors, memberIndex: number): string {
+    return memberIndex === 0 ? colors.primary : colors.exercise;
+}
+
+interface SupersetCardProps {
+    card: WorkoutCard;
+    index: number;
+    isFinished: boolean;
+    isExpanded: boolean;
+    onExpand: () => void;
+    onDragStart: () => void;
+    getLastSets: (templateId: number | null) => ExerciseSet[];
+    onRemove: (workoutExerciseId: number) => void;
+    onNoteChange: (workoutExerciseId: number, note: string) => void;
+    onConfirmSet: (setId: number, values: SetValues) => void;
+    onUpdateSet: (setId: number, values: SetValues) => void;
+    onDeleteSet: (setId: number) => void;
+    onSetTypeChange: (setId: number, type: string) => void;
+    onAddSet: (workoutExerciseId: number) => void;
+    onCopyFromLast: (workoutExerciseId: number, templateId: number) => void;
+    onReorderSet: (setId: number, toIndex: number) => void;
+    restTimerActive: boolean;
+    restTimerElapsed: number;
+    restTimerTarget: number;
+    restTimerReached: boolean;
+    onRestTimerSkip: () => void;
+    onRestTimerChangeDuration: (seconds: number) => void;
+}
+
+export default function SupersetCard(props: SupersetCardProps) {
+    const { card, isExpanded, onExpand, onDragStart } = props;
+    if (!isExpanded) {
+        return <CollapsedSupersetCard card={card} index={props.index} onExpand={onExpand} onLongPress={onDragStart} />;
+    }
+    return <ExpandedSupersetCard {...props} />;
+}
+
+// ── Collapsed ────────────────────────────────────────────────────────────────
+
+function CollapsedSupersetCard({ card, index, onExpand, onLongPress }: {
+    card: WorkoutCard; index: number; onExpand: () => void; onLongPress: () => void;
+}) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+
+    const allSets = card.members.flatMap((m) => m.sets);
+    const completed = allSets.filter((s) => !!s.completed_at).length;
+    const isAllDone = allSets.length > 0 && completed === allSets.length;
+
+    return (
+        <Pressable style={styles.collapsedCard} onPress={onExpand} onLongPress={onLongPress}>
+            <Text style={styles.collapsedOrderNum}>{index + 1}.</Text>
+            <Text style={styles.collapsedName} numberOfLines={1}>
+                {card.members.map((m) => m.exerciseTemplate?.name ?? "?").join("  +  ")}
+            </Text>
+            <View style={[styles.progressBadge, isAllDone && styles.progressBadgeComplete]}>
+                {isAllDone && <Ionicons name="checkmark-circle" size={12} color={colors.success} />}
+                <Text style={[styles.progressText, isAllDone && styles.progressTextComplete]}>
+                    {allSets.length === 0
+                        ? t("exercise.exerciseCard.noSetsYet")
+                        : t("exercise.exerciseCard.setsProgress", { completed, total: allSets.length })}
+                </Text>
+            </View>
+            <Ionicons name="chevron-forward" size={16} color={colors.textTertiary} />
+        </Pressable>
+    );
+}
+
+// ── Expanded ─────────────────────────────────────────────────────────────────
+
+function ExpandedSupersetCard({
+    card, index, isFinished, onDragStart, getLastSets,
+    onRemove, onNoteChange, onConfirmSet, onUpdateSet, onDeleteSet, onSetTypeChange, onAddSet, onCopyFromLast, onReorderSet,
+    restTimerActive, restTimerElapsed, restTimerTarget, restTimerReached, onRestTimerSkip, onRestTimerChangeDuration,
+}: SupersetCardProps) {
+    const colors = useThemeColors();
+    const { t } = useTranslation();
+    const router = useRouter();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+    const cardStyles = useMemo(() => createExerciseCardStyles(colors), [colors]);
+
+    const [menuOpen, setMenuOpen] = useState(false);
+    const [noteOpen, setNoteOpen] = useState(false);
+    const [noteDraft, setNoteDraft] = useState("");
+
+    const members = card.members;
+    // A superset carries a single, shared note — kept on the base (first) member.
+    const noteHost = members[0];
+    const rows = useMemo(() => orderSupersetRows(members), [members]);
+    const activeIdx = isFinished ? -1 : activeRowIndex(rows);
+
+    function renderRow({ item: row, drag, getIndex }: RenderItemParams<SupersetRow>) {
+        const i = getIndex() ?? 0;
+        const member = members[row.memberIndex];
+        const template = member.exerciseTemplate;
+        const exerciseType = (template?.type as ExerciseType) ?? "weight";
+        const customFields = parseCustomFields(template?.custom_fields);
+        const prefill = getPrefillForSet(row.withinIndex, member.sets, getLastSets(template?.id ?? null));
+        const active = i === activeIdx;
+        return (
+            <React.Fragment key={row.set.id}>
+                {active && restTimerActive && (
+                    <RestTimer
+                        elapsedSeconds={restTimerElapsed}
+                        targetSeconds={restTimerTarget}
+                        isTargetReached={restTimerReached}
+                        onSkip={onRestTimerSkip}
+                        onChangeDuration={onRestTimerChangeDuration}
+                    />
+                )}
+                <View style={styles.rowWrap}>
+                    <View style={styles.chipCol}>
+                        <View style={[styles.rowBar, { backgroundColor: memberColor(colors, row.memberIndex) }]} />
+                    </View>
+                    <View style={styles.rowInput}>
+                        <SetInputRow
+                            set={row.set}
+                            index={row.withinIndex}
+                            exerciseType={exerciseType}
+                            customFields={customFields}
+                            isActive={active}
+                            isFinished={isFinished}
+                            prefillWeight={prefill.weight}
+                            prefillReps={prefill.reps}
+                            prefillRir={prefill.rir}
+                            prefillDuration={prefill.duration}
+                            prefillDistance={prefill.distance}
+                            prefillCustom={prefill.custom}
+                            onConfirm={onConfirmSet}
+                            onUpdate={onUpdateSet}
+                            onDelete={onDeleteSet}
+                            onTypeChange={onSetTypeChange}
+                            onDragStart={drag}
+                        />
+                    </View>
+                </View>
+            </React.Fragment>
+        );
+    }
+
+    const sameType = members.every((m) => m.exerciseTemplate?.type === members[0].exerciseTemplate?.type);
+    const headerType = (members[0].exerciseTemplate?.type as ExerciseType) ?? "weight";
+    const headerCustomFields = parseCustomFields(members[0].exerciseTemplate?.custom_fields);
+
+    function handleRemove(member: WorkoutExerciseWithSets) {
+        setMenuOpen(false);
+        Alert.alert(
+            t("exercise.superset.removeMember", { name: member.exerciseTemplate?.name ?? "" }),
+            t("exercise.superset.removeMemberConfirm"),
+            [
+                { text: t("common.cancel"), style: "cancel" },
+                { text: t("common.delete"), style: "destructive", onPress: () => onRemove(member.workoutExercise.id) },
+            ],
+        );
+    }
+
+    function handleHistory() {
+        const valid = members.filter((m) => m.exerciseTemplate);
+        if (valid.length === 0) return;
+        router.push({
+            pathname: "/workout/exercise-history",
+            params: {
+                templateId: String(valid[0].exerciseTemplate!.id),
+                name: valid[0].exerciseTemplate!.name,
+                workoutExerciseId: String(valid[0].workoutExercise.id),
+                templateIds: valid.map((m) => m.exerciseTemplate!.id).join(","),
+                workoutExerciseIds: valid.map((m) => m.workoutExercise.id).join(","),
+            },
+        });
+    }
+
+    function handleAddSet() {
+        onAddSet(members[nextAddTarget(members)].workoutExercise.id);
+    }
+
+    return (
+        <Pressable style={[cardStyles.card, styles.supersetCardBorder]} onLongPress={onDragStart} delayLongPress={180}>
+            {/* Title row: order number, colored "A + B" title, history + menu */}
+            <View style={styles.titleRow}>
+                <Text style={cardStyles.orderNum}>{index + 1}.</Text>
+                <Text style={styles.titleText} numberOfLines={2}>
+                    {members.map((m, i) => (
+                        <Text key={m.workoutExercise.id} style={{ color: memberColor(colors, i) }}>
+                            {i > 0 ? "  +  " : ""}{m.exerciseTemplate?.name ?? "?"}
+                        </Text>
+                    ))}
+                </Text>
+                <Pressable onPress={handleHistory} hitSlop={8}>
+                    <Ionicons name="bar-chart-outline" size={18} color={colors.textSecondary} />
+                </Pressable>
+                <Pressable onPress={() => setMenuOpen(true)} hitSlop={8}>
+                    <Ionicons name="ellipsis-vertical" size={18} color={colors.textSecondary} />
+                </Pressable>
+            </View>
+
+            {/* Shared note */}
+            {noteHost.workoutExercise.notes ? (
+                <Text style={cardStyles.noteText} numberOfLines={2}>{noteHost.workoutExercise.notes}</Text>
+            ) : null}
+
+            {/* Column headers (only when both members share a type) */}
+            {sameType && (
+                <View style={cardStyles.headerRow}>
+                    <View style={styles.chipCol} />
+                    <View style={cardStyles.handleCol} />
+                    <Text style={[cardStyles.headerCell, cardStyles.setCol]}>{t("exercise.exerciseCard.set")}</Text>
+                    {headerType === "weight" && (
+                        <Text style={[cardStyles.headerCell, cardStyles.valueCol]}>{t("exercise.exerciseCard.weight")}</Text>
+                    )}
+                    {headerType !== "cardio" && !(headerType === "other" && headerCustomFields.length > 0) && (
+                        <Text style={[cardStyles.headerCell, cardStyles.valueCol]}>{t("exercise.exerciseCard.reps")}</Text>
+                    )}
+                    {headerType === "cardio" && (
+                        <>
+                            <Text style={[cardStyles.headerCell, cardStyles.valueCol]}>{t("exercise.exerciseCard.duration")}</Text>
+                            <Text style={[cardStyles.headerCell, cardStyles.valueCol]}>{t("exercise.exerciseCard.distance")}</Text>
+                        </>
+                    )}
+                    {headerType !== "cardio" && !(headerType === "other" && headerCustomFields.length > 0) && (
+                        <Text style={[cardStyles.headerCell, cardStyles.rirCol]}>{t("exercise.exerciseCard.rir")}</Text>
+                    )}
+                    <Text style={[cardStyles.headerCell, cardStyles.emptyCol]}></Text>
+                </View>
+            )}
+
+            {/* Combined set rows (draggable; a colored bar ties each set to its exercise) */}
+            <DraggableFlatList
+                data={rows}
+                keyExtractor={(row) => String(row.set.id)}
+                scrollEnabled={false}
+                activationDistance={0}
+                onDragEnd={({ from, to }) => { if (from !== to) onReorderSet(rows[from].set.id, to); }}
+                renderItem={renderRow}
+            />
+
+            {rows.length === 0 && (
+                <Text style={cardStyles.emptyText}>{t("exercise.workout.emptyState")}</Text>
+            )}
+
+            {!isFinished && (
+                <Pressable style={cardStyles.addSetBtn} onPress={handleAddSet}>
+                    <Text style={cardStyles.addSetText}>{t("exercise.exerciseCard.addSet")}</Text>
+                </Pressable>
+            )}
+
+            {/* Unified menu: one shared note, then per-member copy and remove */}
+            <Modal visible={menuOpen} transparent animationType="fade" onRequestClose={() => setMenuOpen(false)}>
+                <Pressable style={styles.menuOverlay} onPress={() => setMenuOpen(false)}>
+                    <View style={styles.menu}>
+                        <MenuItem
+                            label={noteHost.workoutExercise.notes ? t("exercise.exerciseCard.editNote") : t("exercise.exerciseCard.addNote")}
+                            icon="create-outline"
+                            colors={colors}
+                            onPress={() => { setMenuOpen(false); setNoteDraft(noteHost.workoutExercise.notes ?? ""); setNoteOpen(true); }}
+                        />
+                        {members.map((member, i) => member.exerciseTemplate && (
+                            <MenuItem
+                                key={`copy-${member.workoutExercise.id}`}
+                                label={t("exercise.superset.copyMember", { name: member.exerciseTemplate.name })}
+                                icon="copy-outline"
+                                colors={colors}
+                                onPress={() => { setMenuOpen(false); onCopyFromLast(member.workoutExercise.id, member.exerciseTemplate!.id); }}
+                            />
+                        ))}
+                        {members.map((member) => (
+                            <MenuItem
+                                key={`remove-${member.workoutExercise.id}`}
+                                label={t("exercise.superset.removeMember", { name: member.exerciseTemplate?.name ?? "" })}
+                                icon="trash-outline"
+                                colors={colors}
+                                destructive
+                                onPress={() => handleRemove(member)}
+                            />
+                        ))}
+                    </View>
+                </Pressable>
+            </Modal>
+
+            <ExerciseNoteModal
+                visible={noteOpen}
+                onClose={() => setNoteOpen(false)}
+                value={noteDraft}
+                onChangeText={setNoteDraft}
+                onSave={() => { onNoteChange(noteHost.workoutExercise.id, noteDraft.trim()); setNoteOpen(false); }}
+                labels={{
+                    title: t("exercise.exerciseCard.note"),
+                    placeholder: t("exercise.exerciseCard.notePlaceholder"),
+                    save: t("common.save"),
+                }}
+            />
+        </Pressable>
+    );
+}
+
+const CHIP_COL_WIDTH = 12;
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        // Collapsed
+        collapsedCard: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            paddingVertical: spacing.sm + 2,
+            paddingHorizontal: spacing.md,
+            marginBottom: spacing.sm,
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+        },
+        collapsedOrderNum: {
+            fontSize: fontSize.sm,
+            fontWeight: "700",
+            color: colors.textTertiary,
+            width: 22,
+        },
+        collapsedName: {
+            flex: 1,
+            fontSize: fontSize.sm,
+            fontWeight: "500",
+            color: colors.text,
+        },
+        progressBadge: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 4,
+            backgroundColor: colors.primaryLight,
+            paddingHorizontal: spacing.sm,
+            paddingVertical: 3,
+            borderRadius: borderRadius.sm,
+        },
+        progressBadgeComplete: { backgroundColor: colors.success + "22" },
+        progressText: { fontSize: fontSize.xs, fontWeight: "600", color: colors.primary },
+        progressTextComplete: { color: colors.success },
+
+        // Expanded
+        supersetCardBorder: {
+            borderColor: colors.exercise,
+        },
+        titleRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: spacing.sm,
+            marginBottom: spacing.sm,
+        },
+        titleText: {
+            flex: 1,
+            fontSize: fontSize.lg,
+            fontWeight: "700",
+        },
+        chipCol: {
+            width: CHIP_COL_WIDTH,
+            alignItems: "center",
+            paddingVertical: 4,
+        },
+        rowWrap: {
+            flexDirection: "row",
+            alignItems: "stretch",
+        },
+        // flex:1 fills the (stretched) chipCol's full height, so the bar spans the row.
+        rowBar: {
+            flex: 1,
+            width: 3,
+            borderRadius: 2,
+        },
+        rowInput: {
+            flex: 1,
+        },
+        menuOverlay: {
+            flex: 1,
+            backgroundColor: "rgba(0,0,0,0.5)",
+            justifyContent: "center",
+            alignItems: "center",
+            padding: spacing.lg,
+        },
+        menu: {
+            backgroundColor: colors.surface,
+            borderRadius: borderRadius.lg,
+            padding: spacing.md,
+            width: "100%",
+            maxWidth: 300,
+        },
+    });
+}

--- a/src/features/exercise/helpers/__tests__/supersets.test.ts
+++ b/src/features/exercise/helpers/__tests__/supersets.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "@jest/globals";
+import type { ExerciseSet, WorkoutExerciseWithSets } from "../../services/exerciseDb";
+import {
+    activeRowIndex,
+    groupIntoCards,
+    nextAddTarget,
+    orderSupersetRows,
+} from "../supersets";
+
+// Minimal fixtures — only the fields the pure helpers read are populated.
+// `orders` overrides each set's set_order (defaults to 1..n, i.e. a fresh superset).
+function ex(id: number, group: string | null, setCount: number, completed = 0, orders?: number[]): WorkoutExerciseWithSets {
+    const sets = Array.from({ length: setCount }, (_, i) => ({
+        id: id * 100 + i,
+        set_order: orders?.[i] ?? i + 1,
+        completed_at: i < completed ? Date.now() : null,
+    })) as ExerciseSet[];
+    return {
+        workoutExercise: { id, superset_group: group } as WorkoutExerciseWithSets["workoutExercise"],
+        workout: {} as WorkoutExerciseWithSets["workout"],
+        exerciseTemplate: null,
+        sets,
+    };
+}
+
+describe("groupIntoCards", () => {
+    it("keeps standalone exercises as single cards", () => {
+        const cards = groupIntoCards([ex(1, null, 2), ex(2, null, 1)]);
+        expect(cards.map((c) => c.isSuperset)).toEqual([false, false]);
+        expect(cards).toHaveLength(2);
+    });
+
+    it("collapses two exercises sharing a group into one superset card", () => {
+        const cards = groupIntoCards([ex(1, "g1", 3), ex(2, "g1", 2), ex(3, null, 1)]);
+        expect(cards).toHaveLength(2);
+        expect(cards[0].isSuperset).toBe(true);
+        expect(cards[0].members.map((m) => m.workoutExercise.id)).toEqual([1, 2]);
+        expect(cards[1].isSuperset).toBe(false);
+    });
+
+    it("groups by first appearance even when members are not adjacent", () => {
+        const cards = groupIntoCards([ex(1, "g1", 1), ex(3, null, 1), ex(2, "g1", 1)]);
+        expect(cards).toHaveLength(2);
+        expect(cards[0].isSuperset).toBe(true);
+        expect(cards[0].members.map((m) => m.workoutExercise.id)).toEqual([1, 2]);
+    });
+
+    it("demotes a group left with a single member back to a normal card", () => {
+        const cards = groupIntoCards([ex(1, "g1", 2)]);
+        expect(cards[0].isSuperset).toBe(false);
+    });
+});
+
+describe("orderSupersetRows", () => {
+    it("reads as A1, B1, A2, … for a fresh superset (equal set_orders)", () => {
+        const rows = orderSupersetRows([ex(1, "g1", 3), ex(2, "g1", 2)]);
+        expect(rows.map((r) => [r.memberIndex, r.withinIndex])).toEqual([
+            [0, 0], [1, 0],
+            [0, 1], [1, 1],
+            [0, 2],
+        ]);
+    });
+
+    it("respects a custom global set_order after reordering", () => {
+        // A sets at order 1,4; B sets at 2,3 → A1, B1, B2, A2
+        const rows = orderSupersetRows([ex(1, "g1", 2, 0, [1, 4]), ex(2, "g1", 2, 0, [2, 3])]);
+        expect(rows.map((r) => [r.memberIndex, r.withinIndex])).toEqual([
+            [0, 0], [1, 0], [1, 1], [0, 1],
+        ]);
+    });
+
+    it("handles an empty superset without throwing", () => {
+        expect(orderSupersetRows([ex(1, "g1", 0), ex(2, "g1", 0)])).toEqual([]);
+    });
+});
+
+describe("nextAddTarget", () => {
+    it("targets the member with fewer sets, ties going to the base", () => {
+        expect(nextAddTarget([ex(1, "g1", 2), ex(2, "g1", 2)])).toBe(0);
+        expect(nextAddTarget([ex(1, "g1", 3), ex(2, "g1", 2)])).toBe(1);
+        expect(nextAddTarget([ex(1, "g1", 1), ex(2, "g1", 3)])).toBe(0);
+    });
+});
+
+describe("activeRowIndex", () => {
+    it("finds the first uncompleted row in interleaved order", () => {
+        const rows = orderSupersetRows([ex(1, "g1", 2, 2), ex(2, "g1", 2, 1)]);
+        // A0✓ B0✓ A1✓ B1 → first uncompleted is index 3
+        expect(activeRowIndex(rows)).toBe(3);
+    });
+
+    it("returns -1 when everything is done", () => {
+        const rows = orderSupersetRows([ex(1, "g1", 1, 1), ex(2, "g1", 1, 1)]);
+        expect(activeRowIndex(rows)).toBe(-1);
+    });
+});

--- a/src/features/exercise/helpers/supersets.ts
+++ b/src/features/exercise/helpers/supersets.ts
@@ -1,0 +1,93 @@
+import type { ExerciseSet, WorkoutExerciseWithSets } from "../services/exerciseDb";
+
+/**
+ * A rendered unit on the workout screen: either a single exercise or a superset
+ * of exercises whose sets are performed alternately. `members` always has at
+ * least one entry; a superset currently holds exactly two.
+ */
+export interface WorkoutCard {
+    key: string;
+    isSuperset: boolean;
+    members: WorkoutExerciseWithSets[];
+}
+
+/** One row of a superset's combined set list. */
+export interface SupersetRow {
+    /** Index into the card's `members` this set belongs to. */
+    memberIndex: number;
+    /** The set's position within its own exercise (0-based) — used for its label and prefill. */
+    withinIndex: number;
+    set: ExerciseSet;
+}
+
+/**
+ * Groups a flat, sort-ordered exercise list into cards. Exercises sharing a
+ * non-null `superset_group` collapse into one card, ordered by first appearance;
+ * everything else becomes a standalone card. Robust to group members not being
+ * strictly adjacent in the input.
+ */
+export function groupIntoCards(exercises: WorkoutExerciseWithSets[]): WorkoutCard[] {
+    const cards: WorkoutCard[] = [];
+    const groupCardIndex = new Map<string, number>();
+
+    for (const ex of exercises) {
+        const group = ex.workoutExercise.superset_group;
+        if (group != null && groupCardIndex.has(group)) {
+            cards[groupCardIndex.get(group)!].members.push(ex);
+            continue;
+        }
+        const card: WorkoutCard = {
+            key: group != null ? `ss-${group}` : `ex-${ex.workoutExercise.id}`,
+            isSuperset: group != null,
+            members: [ex],
+        };
+        if (group != null) groupCardIndex.set(group, cards.length);
+        cards.push(card);
+    }
+
+    // A group that ended up with a single member renders as a normal exercise.
+    for (const card of cards) {
+        if (card.isSuperset && card.members.length < 2) {
+            card.isSuperset = false;
+            card.key = `ex-${card.members[0].workoutExercise.id}`;
+        }
+    }
+
+    return cards;
+}
+
+/**
+ * Orders every member's sets into one list by their `set_order`, which is kept
+ * global across the superset. Fresh supersets read as A1, B1, A2, B2, … (equal
+ * set_orders tie-break to the earlier member); once the user drags a set the
+ * new order persists. Ties break by member then set id for a stable result.
+ */
+export function orderSupersetRows(members: WorkoutExerciseWithSets[]): SupersetRow[] {
+    const rows: SupersetRow[] = [];
+    members.forEach((member, memberIndex) => {
+        member.sets.forEach((set, withinIndex) => {
+            rows.push({ memberIndex, withinIndex, set });
+        });
+    });
+    rows.sort((a, b) =>
+        (a.set.set_order - b.set.set_order) || (a.memberIndex - b.memberIndex) || (a.set.id - b.set.id));
+    return rows;
+}
+
+/**
+ * Which member the single "+ Add set" button should append to next: the member
+ * with the fewest sets so the exercises stay balanced, ties going to the earlier
+ * (base) member. Returns the member index.
+ */
+export function nextAddTarget(members: WorkoutExerciseWithSets[]): number {
+    let target = 0;
+    for (let i = 1; i < members.length; i++) {
+        if (members[i].sets.length < members[target].sets.length) target = i;
+    }
+    return target;
+}
+
+/** Index of the active (first uncompleted) row in an ordered list, or -1. */
+export function activeRowIndex(rows: SupersetRow[]): number {
+    return rows.findIndex((r) => !r.set.completed_at);
+}

--- a/src/features/exercise/hooks/useWorkout.ts
+++ b/src/features/exercise/hooks/useWorkout.ts
@@ -8,6 +8,8 @@ import {
     hasUnfinishedScheduledSets,
     removeExerciseFromWorkout,
     reorderExercise,
+    reorderExerciseGroups,
+    supersetExercises,
     updateWorkout,
     type WorkoutWithExercises,
 } from "@/src/features/exercise/services/exerciseDb";
@@ -29,8 +31,10 @@ export interface UseWorkoutReturn {
     updateStartTime: (epoch: number) => void;
     updateEndTime: (epoch: number) => void;
     addExercise: (templateId: number) => number | undefined;
+    supersetExercise: (baseWorkoutExerciseId: number, templateId: number) => number | undefined;
     removeExercise: (workoutExerciseId: number) => void;
     moveExercise: (workoutExerciseId: number, newOrder: number) => void;
+    reorderCards: (orderedExerciseIds: number[]) => void;
     reload: () => void;
     hasUnfinishedSets: boolean;
 }
@@ -161,6 +165,27 @@ export function useWorkout({ workoutId, date }: UseWorkoutOptions = {}): UseWork
         [currentWorkout, currentExercises.length],
     );
 
+    const supersetExercise = useCallback(
+        (baseWorkoutExerciseId: number, templateId: number) => {
+            if (!currentWorkout) return undefined;
+            const secondExercise = supersetExercises(baseWorkoutExerciseId, templateId);
+            const exercises = getExercisesForWorkout(currentWorkout.id);
+            setData((prev) => (prev ? { ...prev, exercises } : null));
+            return secondExercise.id;
+        },
+        [currentWorkout],
+    );
+
+    const reorderCards = useCallback(
+        (orderedExerciseIds: number[]) => {
+            if (!currentWorkout) return;
+            reorderExerciseGroups(currentWorkout.id, orderedExerciseIds);
+            const exercises = getExercisesForWorkout(currentWorkout.id);
+            setData((prev) => (prev ? { ...prev, exercises } : null));
+        },
+        [currentWorkout],
+    );
+
     const removeExercise = useCallback(
         (workoutExerciseId: number) => {
             if (!currentWorkout) return;
@@ -196,8 +221,10 @@ export function useWorkout({ workoutId, date }: UseWorkoutOptions = {}): UseWork
         updateStartTime,
         updateEndTime,
         addExercise,
+        supersetExercise,
         removeExercise,
         moveExercise,
+        reorderCards,
         reload,
         hasUnfinishedSets,
     };

--- a/src/features/exercise/hooks/useWorkoutActions.ts
+++ b/src/features/exercise/hooks/useWorkoutActions.ts
@@ -44,11 +44,17 @@ export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestT
         });
         completeSet(setId);
 
-        for (const ex of workout.data?.exercises ?? []) {
-            if (ex.sets.some((s) => s.id === setId)) {
-                restTimer.start(ex.workoutExercise.id, values.type);
-                break;
-            }
+        const exercises = workout.data?.exercises ?? [];
+        const owner = exercises.find((ex) => ex.sets.some((s) => s.id === setId));
+        if (owner) {
+            // In a superset only the first (base) exercise drives the rest timer, so
+            // finishing the second exercise's set never resets it. `exercises` is
+            // sort-ordered, so the first member found with this group is the base.
+            const group = owner.workoutExercise.superset_group;
+            const isBase = group == null
+                || exercises.find((ex) => ex.workoutExercise.superset_group === group)?.workoutExercise.id
+                    === owner.workoutExercise.id;
+            if (isBase) restTimer.start(owner.workoutExercise.id, values.type);
         }
         workout.reload();
     }, [workout, restTimer]);
@@ -101,6 +107,12 @@ export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestT
         workout.reload();
     }, [workout]);
 
+    // Superset rows span two exercises, so reorder by set id and target position.
+    const handleReorderSupersetSet = useCallback((setId: number, toIndex: number) => {
+        reorderSet(setId, toIndex + 1);
+        workout.reload();
+    }, [workout]);
+
     const lastSetsCache = useMemo(() => {
         const cache = new Map<number, ExerciseSet[]>();
         for (const ex of workout.data?.exercises ?? []) {
@@ -123,6 +135,7 @@ export function useWorkoutActions(workout: UseWorkoutReturn, restTimer: UseRestT
         handleAddSet,
         handleCopyFromLast,
         handleReorderSets,
+        handleReorderSupersetSet,
         lastSetsCache,
     };
 }

--- a/src/features/exercise/screens/ExerciseHistoryScreen.tsx
+++ b/src/features/exercise/screens/ExerciseHistoryScreen.tsx
@@ -10,7 +10,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ActivityIndicator, Alert, FlatList, StyleSheet, Text, View, useWindowDimensions } from "react-native";
+import { ActivityIndicator, Alert, FlatList, Pressable, StyleSheet, Text, View, useWindowDimensions } from "react-native";
 import { LineChart } from "react-native-gifted-charts";
 import { kgToLb } from "../helpers/exerciseUnits";
 import oneRepMax from "../helpers/oneRepMax";
@@ -22,19 +22,42 @@ export default function ExerciseHistoryScreen() {
     const styles = useMemo(() => createStyles(colors), [colors]);
     const { width: windowWidth } = useWindowDimensions();
     const router = useRouter();
-    const { templateId, workoutExerciseId } = useLocalSearchParams<{
-        templateId: string;
+    const { templateId, workoutExerciseId, templateIds, workoutExerciseIds } = useLocalSearchParams<{
+        templateId?: string;
         workoutExerciseId?: string;
+        // Comma-separated lists, present when arriving from a superset (multiple exercises).
+        templateIds?: string;
+        workoutExerciseIds?: string;
     }>();
-    const parsedId = templateId ? Number(templateId) : undefined;
-    const parsedWeId = workoutExerciseId ? Number(workoutExerciseId) : undefined;
 
-    const template: ExerciseTemplate | undefined = useMemo(
-        () => (parsedId ? getExerciseTemplateById(parsedId) : undefined),
-        [parsedId],
+    // The exercises selectable from the header — one, or several when a superset opened this screen.
+    const options = useMemo(() => {
+        const tIds = templateIds ? templateIds.split(",") : templateId ? [templateId] : [];
+        const wIds = workoutExerciseIds ? workoutExerciseIds.split(",") : workoutExerciseId ? [workoutExerciseId] : [];
+        return tIds.map((tid, i) => ({
+            templateId: Number(tid),
+            workoutExerciseId: wIds[i] ? Number(wIds[i]) : undefined,
+        }));
+    }, [templateId, workoutExerciseId, templateIds, workoutExerciseIds]);
+
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const active = options[selectedIndex] ?? options[0];
+    const parsedId = active?.templateId;
+    const parsedWeId = active?.workoutExerciseId;
+
+    const optionTemplates = useMemo(
+        () => options.map((o) => getExerciseTemplateById(o.templateId)),
+        [options],
     );
+    const template: ExerciseTemplate | undefined = optionTemplates[selectedIndex] ?? undefined;
     const { history, e1rmSeries, personalBest, isLoading } = useExerciseHistory(parsedId);
     const [selectedPointIndex, setSelectedPointIndex] = useState<number | null>(null);
+
+    // Member colors mirror the superset card's blue (A) / purple (B) tags.
+    const optionColor = useCallback(
+        (i: number) => (i === 0 ? colors.primary : colors.exercise),
+        [colors.primary, colors.exercise],
+    );
 
     const isAssistance = template?.resistance_mode === "assistance";
     const displayUnit = (template?.default_weight_unit as "kg" | "lb") ?? "kg";
@@ -165,6 +188,28 @@ export default function ExerciseHistoryScreen() {
                 contentContainerStyle={styles.listContent}
                 ListHeaderComponent={
                     <>
+                        {options.length > 1 && (
+                            <View style={styles.selectorRow}>
+                                {options.map((opt, i) => {
+                                    const isSel = i === selectedIndex;
+                                    const c = optionColor(i);
+                                    return (
+                                        <Pressable
+                                            key={`${opt.templateId}-${i}`}
+                                            onPress={() => { setSelectedIndex(i); setSelectedPointIndex(null); }}
+                                            style={[styles.selectorPill, isSel && { backgroundColor: c + "22", borderColor: c }]}
+                                        >
+                                            <Text
+                                                style={[styles.selectorText, isSel && { color: c, fontWeight: "700" }]}
+                                                numberOfLines={1}
+                                            >
+                                                {optionTemplates[i]?.name ?? "?"}
+                                            </Text>
+                                        </Pressable>
+                                    );
+                                })}
+                            </View>
+                        )}
                         {chartData.length > 0 && (
                             <View style={styles.chartCard}>
                                 <Text style={styles.chartTitle}>
@@ -281,6 +326,26 @@ function createStyles(colors: ThemeColors) {
         screen: { flex: 1, backgroundColor: colors.background },
         center: { flex: 1, alignItems: "center", justifyContent: "center", padding: spacing.lg },
         listContent: { padding: spacing.md },
+        selectorRow: {
+            flexDirection: "row",
+            gap: spacing.sm,
+            marginBottom: spacing.md,
+        },
+        selectorPill: {
+            flex: 1,
+            paddingVertical: spacing.sm,
+            paddingHorizontal: spacing.md,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.border,
+            backgroundColor: colors.surface,
+            alignItems: "center",
+        },
+        selectorText: {
+            fontSize: fontSize.sm,
+            fontWeight: "600",
+            color: colors.textSecondary,
+        },
         chartCard: {
             backgroundColor: colors.surface,
             borderRadius: borderRadius.lg,

--- a/src/features/exercise/screens/WorkoutScreen.tsx
+++ b/src/features/exercise/screens/WorkoutScreen.tsx
@@ -12,13 +12,15 @@ import AddExerciseModal from "../components/AddExerciseModal";
 import EditWorkoutTimesModal from "../components/EditWorkoutTimesModal";
 import ExerciseCard from "../components/ExerciseCard";
 import HistoricalWorkoutList from "../components/HistoricalWorkoutList";
+import SupersetCard from "../components/SupersetCard";
 import WorkoutHeader from "../components/WorkoutHeader";
 import WorkoutKeepAwake from "../components/WorkoutKeepAwake";
+import { groupIntoCards, type WorkoutCard } from "../helpers/supersets";
 import { useRestTimer } from "../hooks/useRestTimer";
 import { useWorkout } from "../hooks/useWorkout";
 import { useWorkoutActions } from "../hooks/useWorkoutActions";
 import {
-    copySetsFromLastSession, type ExerciseTemplate, type WorkoutExerciseWithSets,
+    copySetsFromLastSession, type ExerciseTemplate,
 } from "../services/exerciseDb";
 import { createWorkoutScreenStyles } from "./WorkoutScreenStyles";
 
@@ -46,6 +48,8 @@ export default function WorkoutScreen() {
     const reloadWorkout = workout.reload;
     const finishCurrentWorkout = workout.finishCurrentWorkout;
     const [showAddExercise, setShowAddExercise] = useState(false);
+    // Set while the add-exercise sheet is picking the second exercise for a superset (base's id).
+    const [supersetBaseId, setSupersetBaseId] = useState<number | null>(null);
     const [showTimesModal, setShowTimesModal] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
 
@@ -78,17 +82,31 @@ export default function WorkoutScreen() {
     }, [isDragging]);
 
     function handleExerciseSelected(template: ExerciseTemplate, copyFromLast: boolean) {
-        const weId = workout.addExercise(template.id);
+        const weId = supersetBaseId != null
+            ? workout.supersetExercise(supersetBaseId, template.id)
+            : workout.addExercise(template.id);
         if (weId) {
             if (copyFromLast) {
                 copySetsFromLastSession(template.id, weId);
             }
             LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-            setExpandedId(weId);
+            // Keep the base expanded when supersetting so the combined card stays open.
+            setExpandedId(supersetBaseId ?? weId);
         }
         workout.reload();
         setShowAddExercise(false);
+        setSupersetBaseId(null);
     }
+
+    function handleCloseAddExercise() {
+        setShowAddExercise(false);
+        setSupersetBaseId(null);
+    }
+
+    const handleSuperset = useCallback((baseWorkoutExerciseId: number) => {
+        setSupersetBaseId(baseWorkoutExerciseId);
+        setShowAddExercise(true);
+    }, []);
 
     function handleFinish() {
         finishCurrentWorkout();
@@ -136,28 +154,71 @@ export default function WorkoutScreen() {
         [workout.data?.exercises],
     );
 
+    const cards = useMemo(() => groupIntoCards(exercises), [exercises]);
+
+    const getLastSets = useCallback(
+        (templateId: number | null) => (templateId ? (actions.lastSetsCache.get(templateId) ?? []) : []),
+        [actions.lastSetsCache],
+    );
+
     const handleDragEnd = useCallback(({ from, to }: { from: number; to: number }) => {
         setIsDragging(false);
         if (from === to) return;
-        const movedExercise = exercises[from];
-        if (!movedExercise) return;
+        const reordered = [...cards];
+        const [moved] = reordered.splice(from, 1);
+        if (!moved) return;
+        reordered.splice(to, 0, moved);
         LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-        workout.moveExercise(movedExercise.workoutExercise.id, to + 1);
-    }, [exercises, workout]);
+        workout.reorderCards(reordered.flatMap((c) => c.members.map((m) => m.workoutExercise.id)));
+    }, [cards, workout]);
 
-    function renderExercise({ item, drag, isActive, getIndex }: RenderItemParams<WorkoutExerciseWithSets>) {
+    function renderCard({ item, drag, isActive, getIndex }: RenderItemParams<WorkoutCard>) {
         const index = getIndex() ?? 0;
-        const tid = item.workoutExercise.exercise_template_id;
         const timerActive = restTimer.isRunning;
-        const isExpanded = expandedId === item.workoutExercise.id;
+        const isExpanded = item.members.some((m) => m.workoutExercise.id === expandedId);
+        const wrapStyle = isActive ? styles.draggingCard : undefined;
+
+        if (item.isSuperset) {
+            return (
+                <View style={wrapStyle}>
+                    <SupersetCard
+                        card={item}
+                        index={index}
+                        isFinished={isFinished}
+                        isExpanded={isExpanded}
+                        onExpand={() => handleExpand(item.members[0].workoutExercise.id)}
+                        onDragStart={drag}
+                        getLastSets={getLastSets}
+                        onRemove={workout.removeExercise}
+                        onNoteChange={actions.handleNoteChange}
+                        onConfirmSet={actions.handleConfirmSet}
+                        onUpdateSet={actions.handleUpdateSet}
+                        onDeleteSet={actions.handleDeleteSet}
+                        onSetTypeChange={actions.handleSetTypeChange}
+                        onAddSet={actions.handleAddSet}
+                        onCopyFromLast={actions.handleCopyFromLast}
+                        onReorderSet={actions.handleReorderSupersetSet}
+                        restTimerActive={timerActive}
+                        restTimerElapsed={timerActive ? restTimer.elapsedSeconds : 0}
+                        restTimerTarget={timerActive ? restTimer.targetSeconds : 0}
+                        restTimerReached={timerActive ? restTimer.isTargetReached : false}
+                        onRestTimerSkip={restTimer.skip}
+                        onRestTimerChangeDuration={restTimer.setDuration}
+                    />
+                </View>
+            );
+        }
+
+        const member = item.members[0];
+        const tid = member.workoutExercise.exercise_template_id;
         return (
-            <View style={isActive ? styles.draggingCard : undefined}>
+            <View style={wrapStyle}>
                 <ExerciseCard
-                    item={item}
+                    item={member}
                     index={index}
                     isFinished={isFinished}
                     isExpanded={isExpanded}
-                    onExpand={() => handleExpand(item.workoutExercise.id)}
+                    onExpand={() => handleExpand(member.workoutExercise.id)}
                     onDragStart={drag}
                     lastWorkoutSets={tid ? (actions.lastSetsCache.get(tid) ?? []) : []}
                     onRemove={workout.removeExercise}
@@ -169,6 +230,7 @@ export default function WorkoutScreen() {
                     onAddSet={actions.handleAddSet}
                     onCopyFromLast={actions.handleCopyFromLast}
                     onReorderSets={actions.handleReorderSets}
+                    onSuperset={handleSuperset}
                     restTimerActive={timerActive}
                     restTimerElapsed={timerActive ? restTimer.elapsedSeconds : 0}
                     restTimerTarget={timerActive ? restTimer.targetSeconds : 0}
@@ -197,9 +259,9 @@ export default function WorkoutScreen() {
             />
 
             <DraggableFlatList
-                data={exercises}
-                keyExtractor={(item) => String(item.workoutExercise.id)}
-                renderItem={renderExercise}
+                data={cards}
+                keyExtractor={(item) => item.key}
+                renderItem={renderCard}
                 contentContainerStyle={styles.list}
                 activationDistance={0}
                 autoscrollThreshold={80}
@@ -238,7 +300,7 @@ export default function WorkoutScreen() {
 
             <AddExerciseModal
                 visible={showAddExercise}
-                onClose={() => setShowAddExercise(false)}
+                onClose={handleCloseAddExercise}
                 onSelect={handleExerciseSelected}
             />
 

--- a/src/features/exercise/services/exerciseDb.ts
+++ b/src/features/exercise/services/exerciseDb.ts
@@ -26,6 +26,8 @@ export {
     hasUnfinishedScheduledSets,
     removeExerciseFromWorkout,
     reorderExercise,
+    reorderExerciseGroups,
+    supersetExercises,
     updateWorkout,
     updateWorkoutExercise,
 } from "./workoutDb";

--- a/src/features/exercise/services/exerciseDbSupport.ts
+++ b/src/features/exercise/services/exerciseDbSupport.ts
@@ -1,6 +1,6 @@
 import { db } from "@/src/services/db";
 import { exerciseSets, exerciseTemplates, workoutExercises, workouts } from "@/src/services/db/schema";
-import { asc, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
 
 type ExerciseTemplate = typeof exerciseTemplates.$inferSelect;
 type Workout = typeof workouts.$inferSelect;
@@ -42,11 +42,32 @@ function getNextExerciseSortOrder(workoutId: number): number {
     return (lastExercise?.sortOrder ?? 0) + 1;
 }
 
+/**
+ * The workout-exercise ids that share a set-ordering scope: just the exercise
+ * itself, or — when it belongs to a superset — every member of that group, in
+ * display order. `set_order` is kept unique/dense across this whole scope so a
+ * superset's combined set list can be freely reordered.
+ */
+function getSetScopeExerciseIds(workoutExerciseId: number): number[] {
+    const we = getWorkoutExerciseOrThrow(workoutExerciseId);
+    if (we.superset_group == null) return [we.id];
+    return db
+        .select({ id: workoutExercises.id })
+        .from(workoutExercises)
+        .where(and(eq(workoutExercises.workout_id, we.workout_id), eq(workoutExercises.superset_group, we.superset_group)))
+        .orderBy(asc(workoutExercises.sort_order), asc(workoutExercises.id))
+        .all()
+        .map((r) => r.id);
+}
+
 function getNextSetOrder(workoutExerciseId: number): number {
+    const ids = getSetScopeExerciseIds(workoutExerciseId);
     const lastSet = db
         .select({ setOrder: exerciseSets.set_order })
         .from(exerciseSets)
-        .where(eq(exerciseSets.workout_exercise_id, workoutExerciseId))
+        .where(ids.length === 1
+            ? eq(exerciseSets.workout_exercise_id, ids[0])
+            : inArray(exerciseSets.workout_exercise_id, ids))
         .orderBy(desc(exerciseSets.set_order), desc(exerciseSets.id))
         .get();
 
@@ -58,6 +79,18 @@ function listSetsForExercise(workoutExerciseId: number): ExerciseSet[] {
         .select()
         .from(exerciseSets)
         .where(eq(exerciseSets.workout_exercise_id, workoutExerciseId))
+        .orderBy(asc(exerciseSets.set_order), asc(exerciseSets.id))
+        .all();
+}
+
+/** All sets across the exercise's ordering scope (see getSetScopeExerciseIds), globally ordered. */
+function listSetsForScope(workoutExerciseId: number): ExerciseSet[] {
+    const ids = getSetScopeExerciseIds(workoutExerciseId);
+    if (ids.length === 1) return listSetsForExercise(ids[0]);
+    return db
+        .select()
+        .from(exerciseSets)
+        .where(inArray(exerciseSets.workout_exercise_id, ids))
         .orderBy(asc(exerciseSets.set_order), asc(exerciseSets.id))
         .all();
 }
@@ -79,7 +112,8 @@ function normalizeExerciseSortOrder(workoutId: number) {
 }
 
 function normalizeSetOrder(workoutExerciseId: number) {
-    const orderedSets = listSetsForExercise(workoutExerciseId);
+    // Renumbers across the whole scope so a superset's global order stays dense.
+    const orderedSets = listSetsForScope(workoutExerciseId);
 
     orderedSets.forEach((set, index) => {
         const nextOrder = index + 1;
@@ -96,7 +130,9 @@ const exerciseDbSupport = {
     getExerciseSetOrThrow,
     getNextExerciseSortOrder,
     getNextSetOrder,
+    getSetScopeExerciseIds,
     listSetsForExercise,
+    listSetsForScope,
     normalizeExerciseSortOrder,
     normalizeSetOrder,
 };

--- a/src/features/exercise/services/exerciseSetDb.ts
+++ b/src/features/exercise/services/exerciseSetDb.ts
@@ -37,7 +37,8 @@ export function deleteSet(id: number) {
 
 export function reorderSet(id: number, newOrder: number) {
     const set = exerciseDbSupport.getExerciseSetOrThrow(id);
-    const sets = exerciseDbSupport.listSetsForExercise(set.workout_exercise_id);
+    // Scope-aware: within a superset the set moves across the whole combined list.
+    const sets = exerciseDbSupport.listSetsForScope(set.workout_exercise_id);
 
     const sourceIndex = sets.findIndex((s) => s.id === id);
     if (sourceIndex === -1) throw new Error(`Exercise set ${id} not found`);

--- a/src/features/exercise/services/workoutDb.ts
+++ b/src/features/exercise/services/workoutDb.ts
@@ -1,7 +1,7 @@
 import exerciseDbSupport from "@/src/features/exercise/services/exerciseDbSupport";
 import { db } from "@/src/services/db";
 import { exerciseSets, exerciseTemplates, workoutExercises, workouts } from "@/src/services/db/schema";
-import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, lte, sql } from "drizzle-orm";
 
 import type { ExerciseTemplate } from "./exerciseTemplateDb";
 
@@ -177,6 +177,73 @@ export function addExerciseToWorkout(data: NewWorkoutExercise): WorkoutExercise 
         .get();
 }
 
+/** A fresh opaque token that identifies a superset group. Shared by its members. */
+function newSupersetGroup(): string {
+    return `ss_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Groups `baseWorkoutExerciseId` into a superset with a new exercise created from
+ * `secondTemplateId` — the same person alternating between two exercises. The
+ * second exercise is inserted directly after the base so the two stay adjacent,
+ * and both share an opaque `superset_group` token. Returns the new exercise.
+ */
+export function supersetExercises(baseWorkoutExerciseId: number, secondTemplateId: number): WorkoutExercise {
+    const base = exerciseDbSupport.getWorkoutExerciseOrThrow(baseWorkoutExerciseId);
+    exerciseDbSupport.getExerciseTemplateOrThrow(secondTemplateId);
+
+    const group = base.superset_group ?? newSupersetGroup();
+    if (base.superset_group == null) {
+        db.update(workoutExercises).set({ superset_group: group }).where(eq(workoutExercises.id, base.id)).run();
+    }
+
+    // Shift everything after the base down one slot so the second exercise sits adjacent.
+    db.update(workoutExercises)
+        .set({ sort_order: sql`${workoutExercises.sort_order} + 1` })
+        .where(and(eq(workoutExercises.workout_id, base.workout_id), gt(workoutExercises.sort_order, base.sort_order)))
+        .run();
+
+    const secondExercise = db
+        .insert(workoutExercises)
+        .values({
+            workout_id: base.workout_id,
+            exercise_template_id: secondTemplateId,
+            sort_order: base.sort_order + 1,
+            superset_group: group,
+            started_at: Date.now(),
+        })
+        .returning()
+        .get();
+
+    exerciseDbSupport.normalizeExerciseSortOrder(base.workout_id);
+    return secondExercise;
+}
+
+/** After a member leaves a superset, clear the group flag if only one member is left. */
+function dissolveOrphanSuperset(workoutId: number, group: string) {
+    const members = db
+        .select()
+        .from(workoutExercises)
+        .where(and(eq(workoutExercises.workout_id, workoutId), eq(workoutExercises.superset_group, group)))
+        .all();
+    if (members.length <= 1) {
+        for (const member of members) {
+            db.update(workoutExercises).set({ superset_group: null }).where(eq(workoutExercises.id, member.id)).run();
+        }
+    }
+}
+
+/** Persists a full top-to-bottom ordering of a workout's exercises (superset members flattened in place). */
+export function reorderExerciseGroups(workoutId: number, orderedIds: number[]) {
+    exerciseDbSupport.getWorkoutOrThrow(workoutId);
+    orderedIds.forEach((id, index) => {
+        db.update(workoutExercises)
+            .set({ sort_order: index + 1 })
+            .where(and(eq(workoutExercises.id, id), eq(workoutExercises.workout_id, workoutId)))
+            .run();
+    });
+}
+
 export function reorderExercise(id: number, newOrder: number) {
     const targetExercise = exerciseDbSupport.getWorkoutExerciseOrThrow(id);
     const exercises = db
@@ -205,6 +272,9 @@ export function removeExerciseFromWorkout(id: number) {
     const workoutExercise = exerciseDbSupport.getWorkoutExerciseOrThrow(id);
     db.delete(exerciseSets).where(eq(exerciseSets.workout_exercise_id, id)).run();
     db.delete(workoutExercises).where(eq(workoutExercises.id, id)).run();
+    if (workoutExercise.superset_group != null) {
+        dissolveOrphanSuperset(workoutExercise.workout_id, workoutExercise.superset_group);
+    }
     exerciseDbSupport.normalizeExerciseSortOrder(workoutExercise.workout_id);
 }
 
@@ -227,6 +297,9 @@ export function copyWorkoutAsScheduled(sourceWorkoutId: number, targetWorkoutId:
         db.update(workouts).set({ title: sourceWorkout.title }).where(eq(workouts.id, targetWorkoutId)).run();
     }
 
+    // Remaps each source superset group to a fresh token for the copied members.
+    const groupMap = new Map<string, string>();
+
     for (const ex of sourceExercises) {
         const newWe = db
             .insert(workoutExercises)
@@ -238,6 +311,16 @@ export function copyWorkoutAsScheduled(sourceWorkoutId: number, targetWorkoutId:
             })
             .returning()
             .get();
+
+        const srcGroup = ex.workoutExercise.superset_group;
+        if (srcGroup != null) {
+            let newGroup = groupMap.get(srcGroup);
+            if (newGroup == null) {
+                newGroup = newSupersetGroup();
+                groupMap.set(srcGroup, newGroup);
+            }
+            db.update(workoutExercises).set({ superset_group: newGroup }).where(eq(workoutExercises.id, newWe.id)).run();
+        }
 
         for (const set of ex.sets) {
             db.insert(exerciseSets)

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -459,6 +459,7 @@ const de = {
             editNote: "Notiz bearbeiten",
             replace: "Übung ersetzen",
             copyFromLast: "Letzte Einheit kopieren",
+            superset: "Als Superset kombinieren…",
             noHistory: "Keine vorherige Einheit gefunden",
             note: "Notiz",
             notePlaceholder: "Übungsnotizen…",
@@ -507,6 +508,11 @@ const de = {
             deleteConfirm:
                 "Dieses Training und alle Daten löschen?",
             moreExercises: "+{{count}} weitere",
+        },
+        superset: {
+            copyMember: "Letzte kopieren: {{name}}",
+            removeMember: "Entfernen: {{name}}",
+            removeMemberConfirm: "Diese Übung und alle Sätze entfernen? Die verbleibende Übung ist dann kein Superset mehr.",
         },
         workout: {
             title: "Training",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -457,6 +457,7 @@ const en = {
             editNote: "Edit Note",
             replace: "Replace Exercise",
             copyFromLast: "Copy from Last Session",
+            superset: "Superset with…",
             noHistory: "No previous session found",
             note: "Note",
             notePlaceholder: "Exercise notes…",
@@ -504,6 +505,11 @@ const en = {
             exercises: "{{count}} exercises",
             deleteConfirm: "Delete this workout and all its data?",
             moreExercises: "+{{count}} more",
+        },
+        superset: {
+            copyMember: "Copy last: {{name}}",
+            removeMember: "Remove: {{name}}",
+            removeMemberConfirm: "Remove this exercise and all its sets? The remaining exercise will no longer be a superset.",
         },
         workout: {
             title: "Workout",

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -221,6 +221,7 @@ export function initDB() {
     "ALTER TABLE exercise_sets ADD COLUMN custom_values TEXT",
     "ALTER TABLE recipes ADD COLUMN parent_recipe_id INTEGER REFERENCES recipes(id)",
     "ALTER TABLE goals ADD COLUMN exercise_timer_sound TEXT NOT NULL DEFAULT 'off'",
+    "ALTER TABLE workout_exercises ADD COLUMN superset_group TEXT",
     // Sync: stable cross-device row identity (see SYNC.md)
     ...SYNC_TABLES.map((t) => `ALTER TABLE ${t.name} ADD COLUMN uuid TEXT`),
   ];

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -182,6 +182,10 @@ export const workoutExercises = sqliteTable("workout_exercises", {
     sort_order: integer("sort_order").notNull(),
     notes: text("notes"),
     started_at: integer("started_at"),
+    // Superset grouping: exercises sharing the same non-null token are performed
+    // as one superset (their sets alternate). Null = a standalone exercise. An
+    // opaque token (not a foreign key) so it syncs verbatim across devices.
+    superset_group: text("superset_group"),
     uuid: text("uuid"),
 });
 


### PR DESCRIPTION
Closes #394.

Adds **supersets**: pairing two exercises so you alternate a set of each with one shared rest timer, instead of the timer resetting whenever you log the other exercise.

## What it does
- **"Superset with…"** in an exercise's overflow menu opens the existing add-exercise sheet to pick the second exercise (paired to the base, sitting directly below it). Pairs only — once an exercise is in a superset, it can't add a third.
- Paired exercises render as **one combined card**: a colored left bar ties each set row to its exercise (blue = first, purple = second), and the header shows the two names in those colors.
- Fresh supersets read as A1, B1, A2, B2… up to `max(setsA, setsB)`. The single **"+ Add set"** appends to whichever exercise has fewer sets so they stay balanced.
- **Rest timer**: only finishing a set on the *first* exercise starts/resets the timer — logging the second one no longer disturbs it.
- **Set rows are draggable** like a normal card. Reordering persists (and may break the A/B alternation, by design).
- **One shared note** and a single history icon; the overflow menu splits Copy / Remove per exercise. The history screen gets a selector to switch between the two exercises.
- Finished/read-only workouts render grouped too (they reuse the workout screen).

## Data model
- New nullable `superset_group` **TEXT** token on `workout_exercises`, shared by both members. It's an opaque token (not a foreign key), so it **syncs verbatim across devices** with no id translation and no self-reference problems. Migration appended to `initDB()`.
- `set_order` becomes **group-aware**: within a superset it's a single global sequence across both exercises (adds append, deletes renumber the group, drags rewrite the order). Standalone exercises are unaffected (scope = just themselves).
- Removing one member dissolves the pairing on the other; copying a workout remaps groups to fresh tokens.

## Tests / checks
- Pure grouping / ordering / add-target logic extracted to `helpers/supersets.ts` with unit tests (`npm test` green, 31 tests).
- `npx tsc --noEmit` and `npm run lint` both clean.
- Added i18n keys in both `en` and `de`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)