### PR TITLE
Migrate OpenFoodFacts search to Search-a-licious; stop charging failed requests

### DIFF
--- a/src/features/log/hooks/useAddFoodSearch.ts
+++ b/src/features/log/hooks/useAddFoodSearch.ts
@@ -11,13 +11,14 @@ import {
 import {
     getProductByBarcode,
     guessUnit,
+    hydrateServing,
     parseServingSize,
     searchProducts,
     type OFFProduct,
 } from "@/src/services/openfoodfacts";
 import logger from "@/src/utils/logger";
 import { router, useLocalSearchParams } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Keyboard } from "react-native";
 
@@ -41,6 +42,7 @@ export function useAddFoodSearch() {
     const [showManualForm, setShowManualForm] = useState(false);
     const [showScanner, setShowScanner] = useState(false);
     const [pendingBarcode, setPendingBarcode] = useState<string | undefined>(undefined);
+    const isSelectingOFF = useRef(false);
 
     // ── Recipe search (variants grouped under their base, collapsed) ──
     const [recipeResults, setRecipeResults] = useState<RecipeGroup[]>([]);
@@ -119,26 +121,35 @@ export function useAddFoodSearch() {
         setSelectedFood(food);
     }
 
-    function handleSelectOFF(product: OFFProduct) {
+    async function handleSelectOFF(product: OFFProduct) {
         Keyboard.dismiss();
         const existing = getFoodByOpenfoodfactsId(product.code);
         if (existing) {
             setSelectedFood(existing);
             return;
         }
-        const food = addFood({
-            name: product.product_name ?? t("common.unknown"),
-            calories_per_100g: product.nutriments?.["energy-kcal_100g"] ?? 0,
-            protein_per_100g: product.nutriments?.proteins_100g ?? 0,
-            carbs_per_100g: product.nutriments?.carbohydrates_100g ?? 0,
-            fat_per_100g: product.nutriments?.fat_100g ?? 0,
-            openfoodfacts_id: product.code,
-            source: "openfoodfacts",
-            default_unit: guessUnit(product),
-            serving_size: parseServingSize(product),
-        });
-        logger.info("[DB] Created food from OFF search", { id: food.id, name: food.name });
-        setSelectedFood(food);
+        // Hydrating the serving fields is a round-trip, so a second tap could
+        // land before the food row exists and create it twice.
+        if (isSelectingOFF.current) return;
+        isSelectingOFF.current = true;
+        try {
+            const hydrated = await hydrateServing(product);
+            const food = addFood({
+                name: hydrated.product_name ?? t("common.unknown"),
+                calories_per_100g: hydrated.nutriments?.["energy-kcal_100g"] ?? 0,
+                protein_per_100g: hydrated.nutriments?.proteins_100g ?? 0,
+                carbs_per_100g: hydrated.nutriments?.carbohydrates_100g ?? 0,
+                fat_per_100g: hydrated.nutriments?.fat_100g ?? 0,
+                openfoodfacts_id: hydrated.code,
+                source: "openfoodfacts",
+                default_unit: guessUnit(hydrated),
+                serving_size: parseServingSize(hydrated),
+            });
+            logger.info("[DB] Created food from OFF search", { id: food.id, name: food.name });
+            setSelectedFood(food);
+        } finally {
+            isSelectingOFF.current = false;
+        }
     }
 
     async function lookupBarcode(barcode: string): Promise<Food | null> {

--- a/src/features/templates/hooks/useIngredientSearch.ts
+++ b/src/features/templates/hooks/useIngredientSearch.ts
@@ -1,4 +1,4 @@
-import { getProductByBarcode, guessUnit, parseServingSize, searchProducts, type OFFProduct } from "@/src/services/openfoodfacts";
+import { getProductByBarcode, guessUnit, hydrateServing, parseServingSize, searchProducts, type OFFProduct } from "@/src/services/openfoodfacts";
 import logger from "@/src/utils/logger";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -136,9 +136,20 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
 
     function handleSelectOFF(product: OFFProduct) {
         Keyboard.dismiss();
-        const food = getFoodByOpenfoodfactsId(product.code)
-            ?? unsavedFoodFromProduct(product, t("common.unknown"));
-        afterSheetDismissed(() => pickRef.current(food));
+        const existing = getFoodByOpenfoodfactsId(product.code);
+        if (existing) {
+            afterSheetDismissed(() => pickRef.current(existing));
+            return;
+        }
+        // A search result carries no serving fields, so they have to be read
+        // from the product API. Started before the hand-off so the fetch runs
+        // under the dismiss animation rather than after it; `hydrateServing`
+        // resolves either way.
+        const hydrating = hydrateServing(product);
+        afterSheetDismissed(async () => {
+            const hydrated = await hydrating;
+            pickRef.current(unsavedFoodFromProduct(hydrated, t("common.unknown")));
+        });
     }
 
     function handleManualFoodCreated(food: Food) {

--- a/src/services/__tests__/openfoodfacts.test.ts
+++ b/src/services/__tests__/openfoodfacts.test.ts
@@ -1,0 +1,226 @@
+/* eslint-disable import/first -- jest.mock() must precede the module-under-test import */
+// Tests for the Search-a-licious search path: hit → OFFProduct mapping, the
+// retry on a server-side failure, and the rule that only a *successful* search
+// spends a slot of the client-side rate-limit budget. `fetch` is the seam; i18n
+// is stubbed to return the key so assertions can match on it.
+
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("@/src/i18n", () => ({
+    __esModule: true,
+    default: {
+        language: "de",
+        t: (key: string) => key,
+    },
+}));
+
+jest.mock("@/src/utils/logger", () => ({
+    __esModule: true,
+    default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { hydrateServing, searchProducts } from "@/src/services/openfoodfacts";
+
+type FetchMock = jest.Mock<(url: string, init?: unknown) => Promise<unknown>>;
+
+function jsonResponse(body: unknown, status = 200) {
+    return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+function searchHits(hits: unknown[]) {
+    return jsonResponse({ hits, page: 1, page_size: 20, page_count: 1 });
+}
+
+let fetchMock: FetchMock;
+// The rate-limit window is module state, so every test starts on a clock far
+// enough ahead that the previous test's timestamps have aged out of it.
+let clock = Date.now();
+
+beforeEach(() => {
+    fetchMock = jest.fn() as FetchMock;
+    (global as { fetch?: unknown }).fetch = fetchMock;
+    jest.useFakeTimers();
+    clock += 120_000;
+    jest.setSystemTime(clock);
+});
+
+afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+});
+
+/** The retry sleeps, so pending timers have to be flushed while the call is in flight. */
+async function withTimersFlushed<T>(promise: Promise<T>): Promise<T> {
+    const settled = promise.catch((err: unknown) => ({ __error: err }));
+    for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+        jest.runOnlyPendingTimers();
+    }
+    const result = (await settled) as T | { __error: unknown };
+    if (result && typeof result === "object" && "__error" in result) throw result.__error;
+    return result as T;
+}
+
+function lastUrl(): string {
+    return String(fetchMock.mock.calls[fetchMock.mock.calls.length - 1][0]);
+}
+
+describe("searchProducts", () => {
+    it("queries Search-a-licious with the app language first and English as fallback", async () => {
+        fetchMock.mockResolvedValue(searchHits([]));
+
+        await withTimersFlushed(searchProducts("milch"));
+
+        const url = new URL(lastUrl());
+        expect(url.origin + url.pathname).toBe("https://search.openfoodfacts.org/search");
+        expect(url.searchParams.get("q")).toBe("milch");
+        expect(url.searchParams.get("langs")).toBe("de,en");
+        expect(url.searchParams.get("page")).toBe("1");
+        expect(url.searchParams.get("fields")).toContain("product_name_de");
+        expect(url.searchParams.get("fields")).toContain("nutriments");
+    });
+
+    it("maps hits to products, preferring the localized name", async () => {
+        fetchMock.mockResolvedValue(
+            searchHits([
+                {
+                    code: "1",
+                    product_name: "Whole milk",
+                    product_name_de: "Vollmilch",
+                    quantity: "1 l",
+                    nutriments: { "energy-kcal_100g": 64, proteins_100g: 3.4 },
+                },
+                { code: "2", product_name: "Skyr" },
+            ]),
+        );
+
+        const products = await withTimersFlushed(searchProducts("milch"));
+
+        expect(products).toEqual([
+            {
+                code: "1",
+                product_name: "Vollmilch",
+                quantity: "1 l",
+                nutriments: { "energy-kcal_100g": 64, proteins_100g: 3.4 },
+            },
+            { code: "2", product_name: "Skyr", quantity: undefined, nutriments: undefined },
+        ]);
+    });
+
+    it("drops hits without a code or a name", async () => {
+        fetchMock.mockResolvedValue(
+            searchHits([{ code: "1" }, { product_name: "No code" }, { code: "2", product_name: "Ok" }]),
+        );
+
+        const products = await withTimersFlushed(searchProducts("milch"));
+
+        expect(products.map((p) => p.code)).toEqual(["2"]);
+    });
+
+    it("retries once on a server error and returns the retried results", async () => {
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse({}, 503))
+            .mockResolvedValueOnce(searchHits([{ code: "1", product_name: "Milch" }]));
+
+        const products = await withTimersFlushed(searchProducts("milch"));
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(products.map((p) => p.code)).toEqual(["1"]);
+    });
+
+    it("retries once on a network error", async () => {
+        fetchMock
+            .mockRejectedValueOnce(new Error("Network request failed"))
+            .mockResolvedValueOnce(searchHits([{ code: "1", product_name: "Milch" }]));
+
+        const products = await withTimersFlushed(searchProducts("milch"));
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(products).toHaveLength(1);
+    });
+
+    it("does not retry a 4xx", async () => {
+        fetchMock.mockResolvedValue(jsonResponse({}, 422));
+
+        await expect(withTimersFlushed(searchProducts("milch"))).rejects.toThrow(
+            "common.searchFailedHttp",
+        );
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports a persistent server error as unavailable", async () => {
+        fetchMock.mockResolvedValue(jsonResponse({}, 503));
+
+        await expect(withTimersFlushed(searchProducts("milch"))).rejects.toThrow(
+            "common.openFoodFactsUnavailable",
+        );
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not spend rate-limit budget on failed searches", async () => {
+        fetchMock.mockResolvedValue(jsonResponse({}, 503));
+        for (let i = 0; i < 12; i++) {
+            await expect(withTimersFlushed(searchProducts("milch"))).rejects.toThrow(
+                "common.openFoodFactsUnavailable",
+            );
+        }
+
+        // A dozen failures must leave the whole budget intact.
+        fetchMock.mockResolvedValue(searchHits([{ code: "1", product_name: "Milch" }]));
+        for (let i = 0; i < 10; i++) {
+            await expect(withTimersFlushed(searchProducts("milch"))).resolves.toHaveLength(1);
+        }
+    });
+
+    it("rate-limits once the window is full of successful searches", async () => {
+        fetchMock.mockResolvedValue(searchHits([{ code: "1", product_name: "Milch" }]));
+        for (let i = 0; i < 10; i++) await withTimersFlushed(searchProducts("milch"));
+
+        await expect(withTimersFlushed(searchProducts("milch"))).rejects.toThrow(
+            "common.rateLimitedWait",
+        );
+
+        // …and frees up again once the sliding window has passed.
+        jest.setSystemTime(Date.now() + 61_000);
+        await expect(withTimersFlushed(searchProducts("milch"))).resolves.toHaveLength(1);
+    });
+});
+
+describe("hydrateServing", () => {
+    const product = { code: "1", product_name: "Vollmilch", quantity: "1 l" };
+
+    it("merges the serving fields the search index does not carry", async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse({
+                status: 1,
+                code: "1",
+                product: { code: "1", serving_size: "250 ml", serving_quantity: 250 },
+            }),
+        );
+
+        await expect(hydrateServing(product)).resolves.toEqual({
+            ...product,
+            serving_size: "250 ml",
+            serving_quantity: 250,
+        });
+        expect(lastUrl()).toContain("world.openfoodfacts.org/api/v2/product/1");
+    });
+
+    it("skips the request when the product already has serving data", async () => {
+        const withServing = { ...product, serving_quantity: 250 };
+
+        await expect(hydrateServing(withServing)).resolves.toBe(withServing);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("returns the product unchanged when the lookup fails", async () => {
+        fetchMock.mockRejectedValue(new Error("Network request failed"));
+        await expect(hydrateServing(product)).resolves.toEqual(product);
+
+        fetchMock.mockResolvedValue(jsonResponse({}, 503));
+        await expect(hydrateServing(product)).resolves.toEqual(product);
+
+        fetchMock.mockResolvedValue(jsonResponse({ status: 0, code: "1" }));
+        await expect(hydrateServing(product)).resolves.toEqual(product);
+    });
+});

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -3,6 +3,10 @@ import logger from "@/src/utils/logger";
 import type { FoodUnit } from "@/src/utils/units";
 
 const BASE_URL = "https://world.openfoodfacts.org";
+// Full-text search runs on Search-a-licious. The legacy `cgi/search.pl` (and
+// `/api/v2/search`) endpoint is rejected at OFF's edge with a 503 roughly half
+// the time, so search there failed for no reason a user could act on.
+const SEARCH_URL = "https://search.openfoodfacts.org/search";
 const USER_AGENT = "MacroFlow/1.0 (React Native; open-source nutrient tracker)";
 
 // Client-side rate limiter for search: OpenFoodFacts allows 10 req/min/IP.
@@ -12,15 +16,22 @@ const SEARCH_WINDOW_MS = 60_000;
 const SEARCH_MAX_PER_WINDOW = 10;
 const searchTimestamps: number[] = [];
 
+const SEARCH_PAGE_SIZE = 20;
+/** One retry is enough for the transient 5xx/network blips we see in practice. */
+const SEARCH_RETRIES = 1;
+const RETRY_DELAY_MS = 300;
+
+interface OFFNutriments {
+    "energy-kcal_100g"?: number;
+    proteins_100g?: number;
+    carbohydrates_100g?: number;
+    fat_100g?: number;
+}
+
 export interface OFFProduct {
     code: string;
     product_name?: string;
-    nutriments?: {
-        "energy-kcal_100g"?: number;
-        proteins_100g?: number;
-        carbohydrates_100g?: number;
-        fat_100g?: number;
-    };
+    nutriments?: OFFNutriments;
     serving_size?: string;
     serving_quantity?: number;
     quantity?: string;
@@ -32,12 +43,32 @@ interface OFFProductResponse {
     product?: OFFProduct;
 }
 
+/**
+ * A Search-a-licious result. Localized names come back as `product_name_de`,
+ * `product_name_en`, … — one key per language in `langs`, hence the index
+ * signature.
+ */
+interface OFFSearchHit {
+    code?: string;
+    product_name?: string;
+    nutriments?: OFFNutriments;
+    quantity?: string;
+    [localizedField: string]: unknown;
+}
+
 interface OFFSearchResponse {
-    products?: OFFProduct[];
+    hits?: OFFSearchHit[];
+    page?: number;
+    page_count?: number;
 }
 
 const FIELDS =
     "code,product_name,nutriments,serving_size,serving_quantity,quantity";
+
+// The Search-a-licious index carries no serving fields (`serving_size`,
+// `serving_quantity`); they are hydrated per selection by `hydrateServing`.
+const SEARCH_FIELDS = ["code", "product_name", "nutriments", "quantity"];
+const SERVING_FIELDS = "serving_size,serving_quantity,quantity";
 
 /** Guess the default unit from OFF serving_size or quantity string. */
 export function guessUnit(product: OFFProduct): FoodUnit {
@@ -81,10 +112,13 @@ export async function getProductByBarcode(
     return data.product;
 }
 
-export async function searchProducts(
-    query: string,
-    page = 1,
-): Promise<OFFProduct[]> {
+/**
+ * Claim one of the requests the sliding window allows, or throw with the wait
+ * time. A search that ends in an error must `release()` its slot again:
+ * charging for a response that carried no products means a flaky upstream also
+ * rate-limits the user.
+ */
+function reserveSearchSlot(): { release: () => void } {
     const now = Date.now();
     // Drop timestamps that have aged out of the sliding window.
     while (searchTimestamps.length && now - searchTimestamps[0] >= SEARCH_WINDOW_MS) {
@@ -97,32 +131,131 @@ export async function searchProducts(
         throw new Error(i18n.t("common.rateLimitedWait", { seconds: waitSec }));
     }
     searchTimestamps.push(now);
+    return {
+        release: () => {
+            const i = searchTimestamps.indexOf(now);
+            if (i !== -1) searchTimestamps.splice(i, 1);
+        },
+    };
+}
 
-    logger.info("[API] Searching products", { query, page });
+/**
+ * Languages to match product names in, app language first. English is kept as
+ * a fallback because many products are only named in English, and dropping it
+ * loses results.
+ */
+function searchLangs(): string[] {
+    const lang = (i18n.language ?? "en").split("-")[0] || "en";
+    return lang === "en" ? ["en"] : [lang, "en"];
+}
 
-    const params = new URLSearchParams({
-        action: "process",
-        search_simple: "1",
-        search_terms: query,
-        json: "1",
-        page: String(page),
-        page_size: "20",
-        fields: FIELDS,
-    });
-
-    const res = await fetch(`${BASE_URL}/cgi/search.pl?${params}`, {
-        headers: { "User-Agent": USER_AGENT },
-    });
-
-    if (!res.ok) {
-        logger.error("[API] Search failed", { status: res.status });
-        throw new Error(
-            res.status === 503
-                ? i18n.t("common.openFoodFactsUnavailable")
-                : i18n.t("common.searchFailedHttp", { status: res.status }),
-        );
+/** Retry a search once on a server-side failure; 4xx is our bug, not a blip. */
+async function fetchSearchWithRetry(url: string): Promise<Response> {
+    for (let attempt = 0; ; attempt++) {
+        try {
+            const res = await fetch(url, { headers: { "User-Agent": USER_AGENT } });
+            if (res.ok || res.status < 500 || attempt === SEARCH_RETRIES) return res;
+            logger.warn("[API] Search returned a server error, retrying", {
+                status: res.status,
+                attempt,
+            });
+        } catch (err) {
+            if (attempt === SEARCH_RETRIES) throw err;
+            logger.warn("[API] Search request errored, retrying", {
+                attempt,
+                error: String(err),
+            });
+        }
+        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
     }
+}
 
-    const data: OFFSearchResponse = await res.json();
-    return (data.products ?? []).filter((p) => p.product_name);
+function productFromHit(hit: OFFSearchHit, langs: string[]): OFFProduct {
+    const localizedName = langs
+        .map((lang) => hit[`product_name_${lang}`])
+        .find((name): name is string => typeof name === "string" && name.length > 0);
+    return {
+        code: String(hit.code),
+        product_name: localizedName ?? hit.product_name,
+        nutriments: hit.nutriments,
+        quantity: hit.quantity,
+    };
+}
+
+export async function searchProducts(
+    query: string,
+    page = 1,
+): Promise<OFFProduct[]> {
+    const slot = reserveSearchSlot();
+    let succeeded = false;
+
+    try {
+        logger.info("[API] Searching products", { query, page });
+
+        const langs = searchLangs();
+        const params = new URLSearchParams({
+            q: query,
+            langs: langs.join(","),
+            page: String(page),
+            page_size: String(SEARCH_PAGE_SIZE),
+            fields: [
+                ...SEARCH_FIELDS,
+                ...langs.map((lang) => `product_name_${lang}`),
+            ].join(","),
+        });
+
+        const res = await fetchSearchWithRetry(`${SEARCH_URL}?${params}`);
+
+        if (!res.ok) {
+            logger.error("[API] Search failed", { status: res.status });
+            throw new Error(
+                res.status >= 500
+                    ? i18n.t("common.openFoodFactsUnavailable")
+                    : i18n.t("common.searchFailedHttp", { status: res.status }),
+            );
+        }
+
+        const data: OFFSearchResponse = await res.json();
+        const products = (data.hits ?? [])
+            .filter((hit) => hit.code)
+            .map((hit) => productFromHit(hit, langs))
+            .filter((product) => product.product_name);
+
+        succeeded = true;
+        return products;
+    } finally {
+        if (!succeeded) slot.release();
+    }
+}
+
+/**
+ * Fill in the serving fields a search result cannot carry, from the product
+ * API. Best-effort and never throws: without it `guessUnit`/`parseServingSize`
+ * just fall back to their defaults, which is not worth failing a selection over.
+ */
+export async function hydrateServing(product: OFFProduct): Promise<OFFProduct> {
+    if (product.serving_size || product.serving_quantity) return product;
+
+    logger.info("[API] Hydrating serving fields", { code: product.code });
+    try {
+        const res = await fetch(
+            `${BASE_URL}/api/v2/product/${encodeURIComponent(product.code)}?fields=${SERVING_FIELDS}`,
+            { headers: { "User-Agent": USER_AGENT } },
+        );
+        if (!res.ok) {
+            logger.warn("[API] Serving hydration failed", { status: res.status });
+            return product;
+        }
+        const data: OFFProductResponse = await res.json();
+        if (data.status !== 1 || !data.product) return product;
+        return {
+            ...product,
+            serving_size: data.product.serving_size,
+            serving_quantity: data.product.serving_quantity,
+            quantity: product.quantity ?? data.product.quantity,
+        };
+    } catch (err) {
+        logger.warn("[API] Serving hydration errored", { error: String(err) });
+        return product;
+    }
 }


### PR DESCRIPTION
Resolves #398.

## The problem

`searchProducts()` used the legacy `cgi/search.pl` endpoint, which OFF rejects at the edge with a 503 roughly half the time — so "Search OpenFoodFacts" failed for no reason the user could act on. The client-side rate limiter made it worse: it recorded a timestamp *before* the fetch and never rolled it back, so a user burned their 10 req/min budget on responses that carried no products, then got `rateLimitedWait` on top of the 503s. There was no retry either, so one unlucky call was a dead end.

## Changes

**`src/services/openfoodfacts.ts`**

- Search moves to `https://search.openfoodfacts.org/search`, mapping the `{ hits: [...] }` shape to `OFFProduct`. Verified live: 200 in ~0.09–0.11 s on every call.
- **Rate limiter fixed.** `reserveSearchSlot()` claims a slot up front — so concurrent calls still cannot overshoot the cap — and `release()`s it in a `finally` on every failure path (HTTP error, network throw, malformed JSON). A failed search now costs nothing.
- **One retry** on 5xx or a network error, 300 ms apart. 4xx is not retried; that is our bug, not a blip.
- **Language-aware.** Sends `langs=de,en` for German users (`en` alone for English) and requests `product_name_de`/`product_name_en`, preferring the localized name. Searching English-only loses most hits for a German query — live check on `haferdrink`: 1715 hits with `langs=de,en` vs 31 with `langs=en`.
- **`hydrateServing(product)`** reads `serving_size`/`serving_quantity` from `/api/v2/product/<code>`, since the Search-a-licious index does not carry them. Best-effort and never throws — a failure falls back to the existing `guessUnit`/`parseServingSize` defaults. Confirmed against a real product: search alone gives `quantity: "33 cl"`, hydration recovers `serving_quantity: 330`.

**Both selection paths hydrate at pick time**

- `useAddFoodSearch.handleSelectOFF` is now async, with a ref guard so a double-tap during the round-trip cannot insert the food row twice.
- `useIngredientSearch.handleSelectOFF` starts the fetch *before* the sheet hand-off, so it overlaps the 300 ms dismiss animation and is effectively free.

The three OFF→`Food` mappings are otherwise left alone so #399 stays a clean, separate refactor.

## One deviation from the issue

**No `sort_by`.** The issue lists `sort_by=-unique_scans_n` under "better ranking", but it replaces text relevance with raw popularity. Measured on `q=milch`:

| Sort | Top results |
| --- | --- |
| default (relevance) | Kakao Milch, Frische fettarme Milch, Milch, … |
| `-unique_scans_n` | 70% Cacao noir intense, Geröstete Mandel, Le Beurre Tendre Doux, … |
| `-popularity_key` | Ziegenfrischkäse, Bio Bergkäse, 70% Cacao noir intense, … |

Both popularity sorts return chocolate and butter for a milk query, so default relevance ranking ships.

## Notes for follow-ups

- Malformed Lucene input (`[`, `2:1`, `++`) returns 200 with 0 hits rather than a 400, so free-text queries cannot break search — worst case is an empty result set.
- `brands` comes back as an **array** from Search-a-licious vs a comma-separated string from v2. Left out of the projection since no UI displays it, but the shape difference matters if #399 starts using it.
- `openfoodfacts.ts` is now 261 lines, past CONTRIBUTING's 250-line "extract reusable chunks" tier but under the 400 hard limit. Kept as one cohesive API client rather than splitting the search half into a second module — happy to split if preferred.

## Testing

- New `src/services/__tests__/openfoodfacts.test.ts`: 12 tests covering hit mapping, localized-name preference, retry on 5xx and on network error, no-retry on 4xx, the sliding window filling and expiring, that 12 consecutive failures leave the full budget intact, and hydration's three failure modes.
- `npm test` — 43 tests across 4 suites pass.
- `npx tsc --noEmit` and `npm run lint` — clean.
- Endpoint behaviour verified against the live API (response shape, timings, language handling, serving-field absence, hydration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
