### PR TITLE
Route every OpenFoodFacts import through one productToFood mapping

### DIFF
--- a/src/features/log/hooks/useAddFoodSearch.ts
+++ b/src/features/log/hooks/useAddFoodSearch.ts
@@ -10,9 +10,8 @@ import {
 } from "@/src/features/templates/services/templateDb";
 import {
     getProductByBarcode,
-    guessUnit,
     hydrateServing,
-    parseServingSize,
+    productToFood,
     searchProducts,
     type OFFProduct,
 } from "@/src/services/openfoodfacts";
@@ -134,17 +133,9 @@ export function useAddFoodSearch() {
         isSelectingOFF.current = true;
         try {
             const hydrated = await hydrateServing(product);
-            const food = addFood({
-                name: hydrated.product_name ?? t("common.unknown"),
-                calories_per_100g: hydrated.nutriments?.["energy-kcal_100g"] ?? 0,
-                protein_per_100g: hydrated.nutriments?.proteins_100g ?? 0,
-                carbs_per_100g: hydrated.nutriments?.carbohydrates_100g ?? 0,
-                fat_per_100g: hydrated.nutriments?.fat_100g ?? 0,
-                openfoodfacts_id: hydrated.code,
-                source: "openfoodfacts",
-                default_unit: guessUnit(hydrated),
-                serving_size: parseServingSize(hydrated),
-            });
+            const food = addFood(
+                productToFood(hydrated, { fallbackName: t("common.unknown") }),
+            );
             logger.info("[DB] Created food from OFF search", { id: food.id, name: food.name });
             setSelectedFood(food);
         } finally {
@@ -162,16 +153,7 @@ export function useAddFoodSearch() {
         if (!product) return null;
         const existing = getFoodByOpenfoodfactsId(product.code);
         if (existing) return existing;
-        const food = addFood({
-            name: product.product_name ?? t("common.unknown"),
-            calories_per_100g: product.nutriments?.["energy-kcal_100g"] ?? 0,
-            protein_per_100g: product.nutriments?.proteins_100g ?? 0,
-            carbs_per_100g: product.nutriments?.carbohydrates_100g ?? 0,
-            fat_per_100g: product.nutriments?.fat_100g ?? 0,
-            barcode,
-            openfoodfacts_id: product.code,
-            source: "openfoodfacts",
-        });
+        const food = addFood(productToFood(product, { fallbackName: t("common.unknown") }));
         logger.info("[DB] Created food from barcode", { id: food.id, name: food.name });
         return food;
     }

--- a/src/features/templates/hooks/useIngredientSearch.ts
+++ b/src/features/templates/hooks/useIngredientSearch.ts
@@ -1,4 +1,4 @@
-import { getProductByBarcode, guessUnit, hydrateServing, parseServingSize, searchProducts, type OFFProduct } from "@/src/services/openfoodfacts";
+import { getProductByBarcode, hydrateServing, productToFood, searchProducts, type OFFProduct } from "@/src/services/openfoodfacts";
 import logger from "@/src/utils/logger";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -18,20 +18,10 @@ const SHEET_SWAP_MS = 300;
  * `id: 0` so the rest of the editor can treat it like any other food; the row
  * is only written when the recipe is saved (see `materializeFood`).
  */
-function unsavedFoodFromProduct(product: OFFProduct, fallbackName: string, barcode?: string): Food {
-    const nutriments = product.nutriments ?? {};
+function unsavedFoodFromProduct(product: OFFProduct, fallbackName: string): Food {
     return {
         id: 0,
-        name: product.product_name || fallbackName,
-        calories_per_100g: nutriments["energy-kcal_100g"] ?? 0,
-        protein_per_100g: nutriments.proteins_100g ?? 0,
-        carbs_per_100g: nutriments.carbohydrates_100g ?? 0,
-        fat_per_100g: nutriments.fat_100g ?? 0,
-        barcode: barcode ?? null,
-        openfoodfacts_id: product.code,
-        source: "openfoodfacts",
-        default_unit: guessUnit(product),
-        serving_size: parseServingSize(product),
+        ...productToFood(product, { fallbackName }),
         last_logged_amount: null,
         last_logged_unit: null,
         last_logged_meal: null,
@@ -176,7 +166,7 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
         const product = await getProductByBarcode(barcode);
         if (!product) return null;
         return getFoodByOpenfoodfactsId(product.code)
-            ?? unsavedFoodFromProduct(product, t("common.unknown"), barcode);
+            ?? unsavedFoodFromProduct(product, t("common.unknown"));
     }
 
     return {

--- a/src/services/__tests__/openfoodfacts.test.ts
+++ b/src/services/__tests__/openfoodfacts.test.ts
@@ -19,7 +19,7 @@ jest.mock("@/src/utils/logger", () => ({
     default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
-import { hydrateServing, searchProducts } from "@/src/services/openfoodfacts";
+import { hydrateServing, productToFood, searchProducts } from "@/src/services/openfoodfacts";
 
 type FetchMock = jest.Mock<(url: string, init?: unknown) => Promise<unknown>>;
 
@@ -183,6 +183,90 @@ describe("searchProducts", () => {
         // …and frees up again once the sliding window has passed.
         jest.setSystemTime(Date.now() + 61_000);
         await expect(withTimersFlushed(searchProducts("milch"))).resolves.toHaveLength(1);
+    });
+});
+
+describe("productToFood", () => {
+    const opts = { fallbackName: "Unknown" };
+
+    it("maps every food field an OFF product carries", () => {
+        expect(
+            productToFood(
+                {
+                    code: "5449000000996",
+                    product_name: "Coca-Cola",
+                    serving_size: "330 ml",
+                    serving_quantity: 330,
+                    nutriments: {
+                        "energy-kcal_100g": 42,
+                        proteins_100g: 0,
+                        carbohydrates_100g: 10.6,
+                        fat_100g: 0,
+                    },
+                },
+                opts,
+            ),
+        ).toEqual({
+            name: "Coca-Cola",
+            calories_per_100g: 42,
+            protein_per_100g: 0,
+            carbs_per_100g: 10.6,
+            fat_per_100g: 0,
+            barcode: "5449000000996",
+            openfoodfacts_id: "5449000000996",
+            source: "openfoodfacts",
+            default_unit: "ml",
+            serving_size: 330,
+        });
+    });
+
+    // The bug behind #399: a scanned product and a searched one are the same
+    // OFF record, so they have to produce the same food.
+    it("does not depend on how the product was found", () => {
+        const product = { code: "1", product_name: "Vollmilch", quantity: "1 l" };
+
+        expect(productToFood(product, opts)).toEqual(productToFood({ ...product }, opts));
+    });
+
+    it("fills barcode from the product code, which is the EAN", () => {
+        expect(productToFood({ code: "1", product_name: "Milch" }, opts)).toMatchObject({
+            barcode: "1",
+            openfoodfacts_id: "1",
+        });
+    });
+
+    it("falls back to the given name and zeroed nutriments", () => {
+        expect(productToFood({ code: "1" }, opts)).toMatchObject({
+            name: "Unknown",
+            calories_per_100g: 0,
+            protein_per_100g: 0,
+            carbs_per_100g: 0,
+            fat_per_100g: 0,
+        });
+    });
+
+    it("prefers serving_quantity, then a number parsed out of serving_size, then 100 g", () => {
+        const size = (product: Parameters<typeof productToFood>[0]) =>
+            productToFood(product, opts).serving_size;
+
+        expect(size({ code: "1", serving_size: "250 ml", serving_quantity: 330 })).toBe(330);
+        expect(size({ code: "1", serving_size: "250 ml" })).toBe(250);
+        expect(size({ code: "1", serving_size: "one scoop" })).toBe(100);
+        expect(size({ code: "1" })).toBe(100);
+    });
+
+    it("guesses the unit from serving_size, else quantity, else grams", () => {
+        const unit = (product: Parameters<typeof productToFood>[0]) =>
+            productToFood(product, opts).default_unit;
+
+        expect(unit({ code: "1", serving_size: "330 ml", quantity: "1 kg" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "500 ml" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "1 liter" })).toBe("ml");
+        expect(unit({ code: "1", serving_size: "1 cup" })).toBe("cup");
+        expect(unit({ code: "1", serving_size: "2 tbsp" })).toBe("tbsp");
+        expect(unit({ code: "1", serving_size: "8 fl oz" })).toBe("fl_oz");
+        expect(unit({ code: "1", serving_size: "30 g" })).toBe("g");
+        expect(unit({ code: "1" })).toBe("g");
     });
 });
 

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -280,6 +280,16 @@ export function initDB() {
     `);
   }
 
+  // Backfill barcodes for OFF foods that arrived via text search: until #399
+  // only the scan path filled `barcode`, so those rows were invisible to
+  // `getFoodByBarcode`. OFF keys products by their EAN, so `openfoodfacts_id`
+  // is the barcode.
+  expoDb.execSync(`
+    UPDATE foods
+    SET barcode = openfoodfacts_id
+    WHERE barcode IS NULL AND openfoodfacts_id IS NOT NULL AND openfoodfacts_id <> '';
+  `);
+
   initSyncInfrastructure();
 }
 

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -1,4 +1,5 @@
 import i18n from "@/src/i18n";
+import type { foods } from "@/src/services/db/schema";
 import logger from "@/src/utils/logger";
 import type { FoodUnit } from "@/src/utils/units";
 
@@ -70,8 +71,18 @@ const FIELDS =
 const SEARCH_FIELDS = ["code", "product_name", "nutriments", "quantity"];
 const SERVING_FIELDS = "serving_size,serving_quantity,quantity";
 
+/**
+ * The `foods` columns an OFF product determines. Every column the DB would
+ * default is filled in, so the result is also enough to stand in for a food
+ * row that has not been written yet (see `useIngredientSearch`).
+ */
+export type FoodFromProduct = Omit<
+    Required<typeof foods.$inferInsert>,
+    "id" | "last_logged_amount" | "last_logged_unit" | "last_logged_meal" | "deleted" | "uuid"
+>;
+
 /** Guess the default unit from OFF serving_size or quantity string. */
-export function guessUnit(product: OFFProduct): FoodUnit {
+function guessUnit(product: OFFProduct): FoodUnit {
     const text = (product.serving_size ?? product.quantity ?? "").toLowerCase();
     if (/\bml\b/.test(text) || /\bcl\b/.test(text) || /\bliter|\blitre/.test(text))
         return "ml";
@@ -85,11 +96,42 @@ export function guessUnit(product: OFFProduct): FoodUnit {
 }
 
 /** Parse a numeric serving size from OFF, e.g. "250 ml" → 250. */
-export function parseServingSize(product: OFFProduct): number {
+function parseServingSize(product: OFFProduct): number {
     if (product.serving_quantity && product.serving_quantity > 0)
         return product.serving_quantity;
     const m = (product.serving_size ?? "").match(/([\d.]+)/);
     return m ? parseFloat(m[1]) || 100 : 100;
+}
+
+/**
+ * The one OFF product → food mapping. Every entry path (text search, barcode
+ * scan, recipe ingredient search) goes through here so a product yields the
+ * same food however the user found it.
+ *
+ * `barcode` and `openfoodfacts_id` both get `product.code`: OFF keys products
+ * by their EAN, so for an OFF-sourced food the two are the same value, and
+ * leaving `barcode` empty would hide the food from `getFoodByBarcode`.
+ *
+ * Serving fields are only as good as the product handed in — a Search-a-licious
+ * hit carries none, so run it through `hydrateServing` first.
+ */
+export function productToFood(
+    product: OFFProduct,
+    opts: { fallbackName: string },
+): FoodFromProduct {
+    const nutriments = product.nutriments ?? {};
+    return {
+        name: product.product_name || opts.fallbackName,
+        calories_per_100g: nutriments["energy-kcal_100g"] ?? 0,
+        protein_per_100g: nutriments.proteins_100g ?? 0,
+        carbs_per_100g: nutriments.carbohydrates_100g ?? 0,
+        fat_per_100g: nutriments.fat_100g ?? 0,
+        barcode: product.code,
+        openfoodfacts_id: product.code,
+        source: "openfoodfacts",
+        default_unit: guessUnit(product),
+        serving_size: parseServingSize(product),
+    };
 }
 
 export async function getProductByBarcode(


### PR DESCRIPTION
Closes #399.

The OpenFoodFacts product → `Food` mapping was written out three times and the copies disagreed, so which fields survived an import depended on how the user found the food.

## What changed

`productToFood(product, { fallbackName })` in `src/services/openfoodfacts.ts` is now the only OFF → food mapping. It returns a `FoodFromProduct` — every `foods` column an OFF product determines, with all DB defaults filled in — so it works both as an `addFood()` argument and as the body of an unsaved `id: 0` food.

All three call sites use it:

| Call site | Was missing | Now |
| --- | --- | --- |
| `useAddFoodSearch.handleSelectOFF` (search) | `barcode` | ✅ |
| `useAddFoodSearch.lookupBarcode` (scan) | `default_unit`, `serving_size` | ✅ |
| `useIngredientSearch.unsavedFoodFromProduct` | `barcode` unless scanned | ✅ |

`barcode` is now always `product.code`: OFF keys products by their EAN, so for an OFF-sourced food `barcode` and `openfoodfacts_id` are the same value, and leaving `barcode` empty hid the food from `getFoodByBarcode()`.

The scan path needed no new request — `getProductByBarcode` already asks for `serving_size`/`serving_quantity`, the fields were just dropped on the floor. Scanning Coca-Cola now gives the same 330 ml food that searching for it does, instead of a 100 g one.

`guessUnit`/`parseServingSize` are no longer exported, so the mapping cannot be bypassed.

## Backfill

`initDB()` gains one idempotent statement:

```sql
UPDATE foods SET barcode = openfoodfacts_id
WHERE barcode IS NULL AND openfoodfacts_id IS NOT NULL AND openfoodfacts_id <> '';
```

Without it the fix only helps foods imported from here on, and the empty column described in #399 stays empty forever for every existing install.

⚠️ It runs after the sync triggers exist from a prior start, so on existing devices it enqueues one `sync_queue` row per affected food. Convergent — every device computes the same value from the same `openfoodfacts_id` — but it is a one-time burst worth knowing about.

## Not in this PR

Writing tests for the mapping surfaced that `guessUnit`'s regex misses bare `l`/`L` and any unit written without a space (`"330ml"`, `"1l"`, `"1.5L"` all guess grams). That is a different dimension than the divergence #399 is about, and it lives in the fallback path #402 plans to keep, so it is filed separately as #407 rather than fixed here. The tests assert today's actual behaviour.

## Follow-ups this unblocks

`productToFood` is the landing spot #402 (structured serving fields), #400 (nutriment validation) and #401 (localized names) asked for.

## Testing

`npx tsc --noEmit`, `npm run lint` and `npm test` all pass — 49 tests, including 6 new `productToFood` cases covering the full mapping, the barcode-from-code rule, name/nutriment fallbacks, and the serving-size and unit precedence rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
