### PR TITLE
Refuse OFF imports without usable nutrition facts (closes #400)

### DIFF
--- a/src/features/log/components/FoodListItem.tsx
+++ b/src/features/log/components/FoodListItem.tsx
@@ -12,6 +12,10 @@ interface FoodListItemProps {
     carbs: number;
     fat: number;
     badge?: string;
+    /** Show dashes instead of numbers: the source has no nutrition facts at all. */
+    unknownNutrition?: boolean;
+    /** Caveat about the item itself, e.g. an OFF product that was delisted. */
+    warning?: string;
     onPress: () => void;
 }
 
@@ -22,6 +26,8 @@ export default function FoodListItem({
     carbs,
     fat,
     badge,
+    unknownNutrition,
+    warning,
     onPress,
 }: FoodListItemProps) {
     const colors = useThemeColors();
@@ -40,13 +46,25 @@ export default function FoodListItem({
                     {name}
                 </Text>
                 <Text style={styles.calories}>
-                    {Math.round(calories)} {t("common.cal")}
+                    {unknownNutrition ? "—" : `${Math.round(calories)} ${t("common.cal")}`}
                 </Text>
             </View>
+            {warning && (
+                <View style={styles.warning}>
+                    <Ionicons name="warning-outline" size={12} color={colors.warning} />
+                    <Text style={styles.warningText}>{warning}</Text>
+                </View>
+            )}
             <View style={styles.macros}>
-                <MacroPill label={t("common.proteinShort")} value={protein} color={colors.protein} />
-                <MacroPill label={t("common.carbsShort")} value={carbs} color={colors.carbs} />
-                <MacroPill label={t("common.fatShort")} value={fat} color={colors.fat} />
+                {unknownNutrition ? (
+                    <Text style={styles.unknownNutrition}>{t("common.offNoNutrition")}</Text>
+                ) : (
+                    <>
+                        <MacroPill label={t("common.proteinShort")} value={protein} color={colors.protein} />
+                        <MacroPill label={t("common.carbsShort")} value={carbs} color={colors.carbs} />
+                        <MacroPill label={t("common.fatShort")} value={fat} color={colors.fat} />
+                    </>
+                )}
                 {badge && (
                     <View style={styles.badge}>
                         <Ionicons
@@ -113,6 +131,18 @@ function createStyles(colors: ThemeColors) {
             gap: spacing.md,
         },
         macroPill: { fontSize: fontSize.xs, fontWeight: "500" },
+        unknownNutrition: {
+            fontSize: fontSize.xs,
+            fontStyle: "italic",
+            color: colors.textTertiary,
+        },
+        warning: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 3,
+            marginBottom: spacing.xs,
+        },
+        warningText: { fontSize: fontSize.xs, color: colors.warning },
         badge: {
             flexDirection: "row",
             alignItems: "center",

--- a/src/features/log/components/ManualFoodForm.tsx
+++ b/src/features/log/components/ManualFoodForm.tsx
@@ -5,8 +5,9 @@ import ModalHeader from "@/src/shared/atoms/ModalHeader";
 import UnitPicker from "@/src/shared/components/UnitPicker";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { useAppStore } from "@/src/shared/store/useAppStore";
-import { spacing } from "@/src/utils/theme";
+import { borderRadius, fontSize, spacing } from "@/src/utils/theme";
 import { unitsForSystem, type FoodUnit } from "@/src/utils/units";
+import { Ionicons } from "@expo/vector-icons";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -15,6 +16,8 @@ import {
     Platform,
     ScrollView,
     StyleSheet,
+    Text,
+    View,
 } from "react-native";
 
 interface ManualFoodFormProps {
@@ -24,6 +27,8 @@ interface ManualFoodFormProps {
     initialName?: string;
     /** Pre-fill the barcode field (e.g. after a barcode scan found no matching product) */
     initialBarcode?: string;
+    /** Explains why the user landed here, e.g. an OFF product without nutrition facts. */
+    notice?: string | null;
 }
 
 export default function ManualFoodForm({
@@ -32,6 +37,7 @@ export default function ManualFoodForm({
     onFoodCreated,
     initialName,
     initialBarcode,
+    notice,
 }: ManualFoodFormProps) {
     const { t } = useTranslation();
     const colors = useThemeColors();
@@ -45,11 +51,15 @@ export default function ManualFoodForm({
     const [defaultUnit, setDefaultUnit] = useState<FoodUnit>("g");
     const [barcode, setBarcode] = useState(initialBarcode ?? "");
 
-    // Re-sync the barcode field with the latest scan whenever the modal opens.
+    // Re-sync the pre-filled fields with the latest scan or selection whenever
+    // the modal opens; they are only initial values for the state above.
     const [prevVisible, setPrevVisible] = useState(visible);
     if (visible !== prevVisible) {
         setPrevVisible(visible);
-        if (visible) setBarcode(initialBarcode ?? "");
+        if (visible) {
+            setName(initialName ?? "");
+            setBarcode(initialBarcode ?? "");
+        }
     }
 
     function handleSave() {
@@ -92,6 +102,12 @@ export default function ManualFoodForm({
                     contentContainerStyle={styles.content}
                     keyboardShouldPersistTaps="handled"
                 >
+                    {notice && (
+                        <View style={[styles.notice, { backgroundColor: colors.surface, borderColor: colors.warning }]}>
+                            <Ionicons name="alert-circle-outline" size={18} color={colors.warning} />
+                            <Text style={[styles.noticeText, { color: colors.textSecondary }]}>{notice}</Text>
+                        </View>
+                    )}
                     <Input
                         label={t("log.foodName")}
                         placeholder={t("log.foodNamePlaceholder")}
@@ -170,4 +186,14 @@ const styles = StyleSheet.create({
     content: { padding: spacing.lg },
     field: { marginBottom: spacing.md },
     saveBtn: { marginTop: spacing.md },
+    notice: {
+        flexDirection: "row",
+        alignItems: "flex-start",
+        gap: spacing.sm,
+        padding: spacing.md,
+        marginBottom: spacing.md,
+        borderRadius: borderRadius.md,
+        borderWidth: 1,
+    },
+    noticeText: { flex: 1, fontSize: fontSize.sm, lineHeight: 18 },
 });

--- a/src/features/log/hooks/useAddFoodSearch.ts
+++ b/src/features/log/hooks/useAddFoodSearch.ts
@@ -10,7 +10,7 @@ import {
 } from "@/src/features/templates/services/templateDb";
 import {
     getProductByBarcode,
-    hydrateServing,
+    hydrateProduct,
     productToFood,
     searchProducts,
     type OFFProduct,
@@ -40,8 +40,17 @@ export function useAddFoodSearch() {
     const [selectedRecipe, setSelectedRecipe] = useState<Recipe | null>(null);
     const [showManualForm, setShowManualForm] = useState(false);
     const [showScanner, setShowScanner] = useState(false);
-    const [pendingBarcode, setPendingBarcode] = useState<string | undefined>(undefined);
     const isSelectingOFF = useRef(false);
+
+    // What the manual form should start from. Set when a scan finds no product
+    // (barcode only) or when OFF knows the product but has no nutrition facts
+    // for it — the latter would otherwise import as a 0 kcal food, so we hand
+    // the user the name and barcode and let them fill in the numbers.
+    const [manualPrefill, setManualPrefill] = useState<{
+        name?: string;
+        barcode?: string;
+        missingNutrition?: boolean;
+    } | null>(null);
 
     // ── Recipe search (variants grouped under their base, collapsed) ──
     const [recipeResults, setRecipeResults] = useState<RecipeGroup[]>([]);
@@ -132,10 +141,19 @@ export function useAddFoodSearch() {
         if (isSelectingOFF.current) return;
         isSelectingOFF.current = true;
         try {
-            const hydrated = await hydrateServing(product);
-            const food = addFood(
-                productToFood(hydrated, { fallbackName: t("common.unknown") }),
-            );
+            const hydrated = await hydrateProduct(product);
+            const imported = productToFood(hydrated, { fallbackName: t("common.unknown") });
+            if (!imported.ok) {
+                logger.info("[API] OFF product has no nutrition facts", { code: hydrated.code });
+                setManualPrefill({
+                    name: imported.name,
+                    barcode: imported.barcode,
+                    missingNutrition: true,
+                });
+                setShowManualForm(true);
+                return;
+            }
+            const food = addFood(imported.food);
             logger.info("[DB] Created food from OFF search", { id: food.id, name: food.name });
             setSelectedFood(food);
         } finally {
@@ -143,7 +161,13 @@ export function useAddFoodSearch() {
         }
     }
 
+    /**
+     * A scan resolves to a food, or to null so the scanner can offer manual
+     * entry. A product OFF knows but has no nutrition facts for takes the
+     * second route, with `manualPrefill` carrying the name it does know.
+     */
     async function lookupBarcode(barcode: string): Promise<Food | null> {
+        setManualPrefill(null);
         const local = getFoodByBarcode(barcode);
         if (local) {
             logger.info("[SCAN] Found locally", { id: local.id });
@@ -153,14 +177,24 @@ export function useAddFoodSearch() {
         if (!product) return null;
         const existing = getFoodByOpenfoodfactsId(product.code);
         if (existing) return existing;
-        const food = addFood(productToFood(product, { fallbackName: t("common.unknown") }));
+        const imported = productToFood(product, { fallbackName: t("common.unknown") });
+        if (!imported.ok) {
+            logger.info("[SCAN] OFF product has no nutrition facts", { barcode });
+            setManualPrefill({
+                name: imported.name,
+                barcode: imported.barcode,
+                missingNutrition: true,
+            });
+            return null;
+        }
+        const food = addFood(imported.food);
         logger.info("[DB] Created food from barcode", { id: food.id, name: food.name });
         return food;
     }
 
     function handleFoodCreated(food: Food) {
         setShowManualForm(false);
-        setPendingBarcode(undefined);
+        setManualPrefill(null);
         setTimeout(() => setSelectedFood(food), 300);
     }
 
@@ -171,13 +205,20 @@ export function useAddFoodSearch() {
 
     function handleBarcodeNotFound(barcode: string) {
         setShowScanner(false);
-        setPendingBarcode(barcode);
+        // Keeps the name from a nutrition-less OFF product, if the lookup found one.
+        setManualPrefill((prev) => ({ ...prev, barcode }));
         setTimeout(() => setShowManualForm(true), 300);
     }
 
     function handleCloseManualForm() {
         setShowManualForm(false);
-        setPendingBarcode(undefined);
+        setManualPrefill(null);
+    }
+
+    /** "Create New": a blank form, whatever an earlier scan left behind. */
+    function openManualForm() {
+        setManualPrefill(null);
+        setShowManualForm(true);
     }
 
     function handleEntrySaved() {
@@ -191,6 +232,13 @@ export function useAddFoodSearch() {
     );
     const filteredOFF = offResults.filter((p) => !localOffIds.has(p.code));
     const showLocalSection = query.trim().length >= 2;
+
+    // The manual form opens either pre-filled from a product or blank from the
+    // "Create New" button, in which case the search query is the best guess.
+    const manualName = manualPrefill?.name ?? query.trim();
+    const manualNotice = manualPrefill?.missingNutrition
+        ? t("common.offMissingNutritionNotice")
+        : null;
 
     return {
         query,
@@ -208,8 +256,10 @@ export function useAddFoodSearch() {
         selectedRecipe,
         setSelectedRecipe,
         showManualForm,
-        setShowManualForm,
-        pendingBarcode,
+        openManualForm,
+        manualName,
+        manualBarcode: manualPrefill?.barcode,
+        manualNotice,
         showScanner,
         setShowScanner,
         showLocalSection,

--- a/src/features/log/screens/AddFoodScreen.tsx
+++ b/src/features/log/screens/AddFoodScreen.tsx
@@ -1,3 +1,4 @@
+import { isObsolete, productNutrition } from "@/src/services/openfoodfacts";
 import Button from "@/src/shared/atoms/Button";
 import BarcodeScannerView from "@/src/shared/components/BarcodeScannerView";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
@@ -67,7 +68,7 @@ export default function AddFoodScreen() {
                     title={t("log.createNew")}
                     variant="outline"
                     icon={<Ionicons name="create-outline" size={18} color={colors.text} />}
-                    onPress={() => search.setShowManualForm(true)}
+                    onPress={search.openManualForm}
                     style={styles.actionButton}
                 />
             </View>
@@ -198,18 +199,26 @@ export default function AddFoodScreen() {
                             <Text style={styles.emptyText}>{t("common.noOnlineResults")}</Text>
                         )}
 
-                        {search.offResults.map((p) => (
-                            <FoodListItem
-                                key={p.code}
-                                name={p.product_name ?? t("common.unknown")}
-                                calories={p.nutriments?.["energy-kcal_100g"] ?? 0}
-                                protein={p.nutriments?.proteins_100g ?? 0}
-                                carbs={p.nutriments?.carbohydrates_100g ?? 0}
-                                fat={p.nutriments?.fat_100g ?? 0}
-                                badge="OFF"
-                                onPress={() => search.handleSelectOFF(p)}
-                            />
-                        ))}
+                        {search.offResults.map((p) => {
+                            // The search index carries only the as-sold per-100 g
+                            // figures, so this preview can fall short of what the
+                            // import ends up with once the product is hydrated.
+                            const nutrition = productNutrition(p);
+                            return (
+                                <FoodListItem
+                                    key={p.code}
+                                    name={p.product_name ?? t("common.unknown")}
+                                    calories={nutrition?.calories_per_100g ?? 0}
+                                    protein={nutrition?.protein_per_100g ?? 0}
+                                    carbs={nutrition?.carbs_per_100g ?? 0}
+                                    fat={nutrition?.fat_per_100g ?? 0}
+                                    unknownNutrition={!nutrition}
+                                    warning={isObsolete(p) ? t("common.offObsolete") : undefined}
+                                    badge="OFF"
+                                    onPress={() => search.handleSelectOFF(p)}
+                                />
+                            );
+                        })}
                     </>
                 )}
 
@@ -226,8 +235,9 @@ export default function AddFoodScreen() {
                 visible={search.showManualForm}
                 onClose={search.handleCloseManualForm}
                 onFoodCreated={search.handleFoodCreated}
-                initialName={search.query.trim()}
-                initialBarcode={search.pendingBarcode}
+                initialName={search.manualName}
+                initialBarcode={search.manualBarcode}
+                notice={search.manualNotice}
             />
 
             <BarcodeScannerView

--- a/src/features/templates/components/AddIngredientSheet.tsx
+++ b/src/features/templates/components/AddIngredientSheet.tsx
@@ -1,4 +1,4 @@
-import type { OFFProduct } from "@/src/services/openfoodfacts";
+import { isObsolete, productNutrition, type OFFProduct } from "@/src/services/openfoodfacts";
 import Button from "@/src/shared/atoms/Button";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
@@ -355,18 +355,29 @@ export default function AddIngredientSheet({
                         {offResults.length > 0 && (
                             <>
                                 <Text style={styles.groupLabel}>{t("log.sectionOpenFoodFacts")}</Text>
-                                {offResults.map((product) => (
-                                    <ResultRow
-                                        key={product.code}
-                                        name={product.product_name || t("common.unknown")}
-                                        hint={t("templates.calPer100g", {
-                                            cal: Math.round(product.nutriments?.["energy-kcal_100g"] ?? 0),
-                                        })}
-                                        onPress={() => onSelectOFF(product)}
-                                        styles={styles}
-                                        colors={colors}
-                                    />
-                                ))}
+                                {offResults.map((product) => {
+                                    // The search index carries only the as-sold
+                                    // per-100 g figures, so this preview can fall
+                                    // short of the hydrated import.
+                                    const nutrition = productNutrition(product);
+                                    return (
+                                        <ResultRow
+                                            key={product.code}
+                                            name={product.product_name || t("common.unknown")}
+                                            hint={
+                                                nutrition
+                                                    ? t("templates.calPer100g", {
+                                                          cal: Math.round(nutrition.calories_per_100g),
+                                                      })
+                                                    : t("common.offNoNutrition")
+                                            }
+                                            warning={isObsolete(product) ? t("common.offObsolete") : undefined}
+                                            onPress={() => onSelectOFF(product)}
+                                            styles={styles}
+                                            colors={colors}
+                                        />
+                                    );
+                                })}
                             </>
                         )}
 
@@ -387,17 +398,25 @@ export default function AddIngredientSheet({
 interface ResultRowProps {
     name: string;
     hint: string;
+    /** Caveat about the item itself, e.g. an OFF product that was delisted. */
+    warning?: string;
     onPress: () => void;
     styles: ReturnType<typeof createStyles>;
     colors: ThemeColors;
 }
 
-function ResultRow({ name, hint, onPress, styles, colors }: ResultRowProps) {
+function ResultRow({ name, hint, warning, onPress, styles, colors }: ResultRowProps) {
     return (
         <Pressable onPress={onPress} style={styles.resultRow}>
             <View style={styles.resultMain}>
                 <Text style={styles.resultName} numberOfLines={1}>{name}</Text>
                 <Text style={styles.resultHint}>{hint}</Text>
+                {warning && (
+                    <View style={styles.resultWarning}>
+                        <Ionicons name="warning-outline" size={12} color={colors.warning} />
+                        <Text style={styles.resultWarningText}>{warning}</Text>
+                    </View>
+                )}
             </View>
             <Ionicons name="add-circle-outline" size={22} color={colors.primary} />
         </Pressable>
@@ -481,6 +500,8 @@ function createStyles(colors: ThemeColors) {
         resultMain: { flex: 1 },
         resultName: { fontSize: fontSize.sm, fontWeight: "600", color: colors.text },
         resultHint: { fontSize: fontSize.xs, color: colors.textTertiary, marginTop: 2 },
+        resultWarning: { flexDirection: "row", alignItems: "center", gap: 3, marginTop: 2 },
+        resultWarningText: { fontSize: fontSize.xs, color: colors.warning },
         emptyState: { alignItems: "center", gap: spacing.xs, paddingVertical: spacing.lg },
         emptyTitle: { fontSize: fontSize.sm, fontWeight: "600", color: colors.text, textAlign: "center" },
         emptyBody: {

--- a/src/features/templates/components/FoodForm.tsx
+++ b/src/features/templates/components/FoodForm.tsx
@@ -4,8 +4,9 @@ import UnitPicker from "@/src/shared/components/UnitPicker";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { useAppStore } from "@/src/shared/store/useAppStore";
 import logger from "@/src/utils/logger";
-import { fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
 import { unitsForSystem, type FoodUnit } from "@/src/utils/units";
+import { Ionicons } from "@expo/vector-icons";
 import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert, ScrollView, StyleSheet, Text, View } from "react-native";
@@ -18,13 +19,17 @@ interface FoodFormProps {
     foodId?: number;
     /** Pre-fill the name field (e.g. from search query) */
     initialName?: string;
+    /** Pre-fill the barcode field (e.g. from a scanned product) */
+    initialBarcode?: string;
+    /** Explains why the user landed here, e.g. an OFF product without nutrition facts. */
+    notice?: string | null;
     /** Label for the save/create button */
     submitLabel?: string;
     /** Called after successful save with the created/updated food */
     onSaved: (food: Food) => void;
 }
 
-export default function FoodForm({ foodId, initialName, submitLabel, onSaved }: FoodFormProps) {
+export default function FoodForm({ foodId, initialName, initialBarcode, notice, submitLabel, onSaved }: FoodFormProps) {
     const { t } = useTranslation();
     const colors = useThemeColors();
     const styles = React.useMemo(() => createStyles(colors), [colors]);
@@ -36,7 +41,7 @@ export default function FoodForm({ foodId, initialName, submitLabel, onSaved }: 
     const [carbs, setCarbs] = useState("");
     const [fat, setFat] = useState("");
     const [defaultUnit, setDefaultUnit] = useState<FoodUnit>("g");
-    const [barcode, setBarcode] = useState("");
+    const [barcode, setBarcode] = useState(initialBarcode ?? "");
     const [servingUnitRows, setServingUnitRows] = useState<ServingUnitRow[]>([]);
 
     useEffect(() => {
@@ -169,6 +174,13 @@ export default function FoodForm({ foodId, initialName, submitLabel, onSaved }: 
             contentContainerStyle={styles.content}
             keyboardShouldPersistTaps="handled"
         >
+            {notice && (
+                <View style={styles.notice}>
+                    <Ionicons name="alert-circle-outline" size={18} color={colors.warning} />
+                    <Text style={styles.noticeText}>{notice}</Text>
+                </View>
+            )}
+
             <Input
                 label={t("log.foodName")}
                 placeholder={t("log.foodNamePlaceholder")}
@@ -267,6 +279,23 @@ function createStyles(colors: ThemeColors) {
             marginBottom: spacing.md,
         },
         halfField: { flex: 1 },
+        notice: {
+            flexDirection: "row",
+            alignItems: "flex-start",
+            gap: spacing.sm,
+            padding: spacing.md,
+            marginBottom: spacing.md,
+            borderRadius: borderRadius.md,
+            borderWidth: 1,
+            borderColor: colors.warning,
+            backgroundColor: colors.surface,
+        },
+        noticeText: {
+            flex: 1,
+            fontSize: fontSize.sm,
+            lineHeight: 18,
+            color: colors.textSecondary,
+        },
         macroWarning: {
             fontSize: fontSize.sm,
             color: colors.warning,

--- a/src/features/templates/components/ManualFoodForm.tsx
+++ b/src/features/templates/components/ManualFoodForm.tsx
@@ -16,6 +16,10 @@ interface ManualFoodFormProps {
     onClose: () => void;
     onFoodCreated: (food: Food) => void;
     initialName?: string;
+    /** Pre-fill the barcode field, e.g. from a scanned OFF product we could not import. */
+    initialBarcode?: string;
+    /** Explains why the user landed here, e.g. an OFF product without nutrition facts. */
+    notice?: string | null;
 }
 
 export default function ManualFoodForm({
@@ -23,9 +27,20 @@ export default function ManualFoodForm({
     onClose,
     onFoodCreated,
     initialName,
+    initialBarcode,
+    notice,
 }: ManualFoodFormProps) {
     const { t } = useTranslation();
     const colors = useThemeColors();
+
+    // `FoodForm` only reads the initial values on mount, so each opening gets a
+    // fresh one — otherwise the fields keep whatever the previous visit left.
+    const [formKey, setFormKey] = React.useState(0);
+    const [prevVisible, setPrevVisible] = React.useState(visible);
+    if (visible !== prevVisible) {
+        setPrevVisible(visible);
+        if (visible) setFormKey((key) => key + 1);
+    }
 
     return (
         <Modal
@@ -40,7 +55,10 @@ export default function ManualFoodForm({
             >
                 <ModalHeader title={t("log.createNewFood")} onClose={onClose} />
                 <FoodForm
+                    key={formKey}
                     initialName={initialName}
+                    initialBarcode={initialBarcode}
+                    notice={notice}
                     submitLabel={t("log.createFood")}
                     onSaved={(food) => onFoodCreated(food)}
                 />

--- a/src/features/templates/hooks/useIngredientSearch.ts
+++ b/src/features/templates/hooks/useIngredientSearch.ts
@@ -1,4 +1,4 @@
-import { getProductByBarcode, hydrateServing, productToFood, searchProducts, type OFFProduct } from "@/src/services/openfoodfacts";
+import { getProductByBarcode, hydrateProduct, productToFood, searchProducts, type FoodFromProduct, type OFFProduct } from "@/src/services/openfoodfacts";
 import logger from "@/src/utils/logger";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -18,10 +18,10 @@ const SHEET_SWAP_MS = 300;
  * `id: 0` so the rest of the editor can treat it like any other food; the row
  * is only written when the recipe is saved (see `materializeFood`).
  */
-function unsavedFoodFromProduct(product: OFFProduct, fallbackName: string): Food {
+function unsavedFood(food: FoodFromProduct): Food {
     return {
         id: 0,
-        ...productToFood(product, { fallbackName }),
+        ...food,
         last_logged_amount: null,
         last_logged_unit: null,
         last_logged_meal: null,
@@ -47,6 +47,14 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
     const [offError, setOffError] = useState<string | null>(null);
     const [showScanner, setShowScanner] = useState(false);
     const [showManualForm, setShowManualForm] = useState(false);
+
+    // What the manual form starts from when an OFF product cannot be imported
+    // because it has no nutrition facts: rather than a 0 kcal ingredient, the
+    // user gets the form with the name and barcode already in place.
+    const [manualPrefill, setManualPrefill] = useState<{
+        name: string;
+        barcode: string;
+    } | null>(null);
 
     // Kept in a ref so the sheet-dismiss timers always reach the current
     // handler rather than the one captured when the sheet opened.
@@ -116,6 +124,7 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
     }
 
     function openManualForm() {
+        setManualPrefill(null);
         afterSheetDismissed(() => setShowManualForm(true));
     }
 
@@ -131,19 +140,27 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
             afterSheetDismissed(() => pickRef.current(existing));
             return;
         }
-        // A search result carries no serving fields, so they have to be read
-        // from the product API. Started before the hand-off so the fetch runs
-        // under the dismiss animation rather than after it; `hydrateServing`
-        // resolves either way.
-        const hydrating = hydrateServing(product);
+        // A search result carries neither the serving fields nor the full
+        // nutriments, so they have to be read from the product API. Started
+        // before the hand-off so the fetch runs under the dismiss animation
+        // rather than after it; `hydrateProduct` resolves either way.
+        const hydrating = hydrateProduct(product);
         afterSheetDismissed(async () => {
             const hydrated = await hydrating;
-            pickRef.current(unsavedFoodFromProduct(hydrated, t("common.unknown")));
+            const imported = productToFood(hydrated, { fallbackName: t("common.unknown") });
+            if (!imported.ok) {
+                logger.info("[API] OFF product has no nutrition facts", { code: hydrated.code });
+                setManualPrefill({ name: imported.name, barcode: imported.barcode });
+                setShowManualForm(true);
+                return;
+            }
+            pickRef.current(unsavedFood(imported.food));
         });
     }
 
     function handleManualFoodCreated(food: Food) {
         setShowManualForm(false);
+        setManualPrefill(null);
         afterSheetDismissed(() => pickRef.current(food));
     }
 
@@ -154,10 +171,17 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
 
     function handleBarcodeNotFound() {
         setShowScanner(false);
+        // A product OFF knows but has no nutrition facts for goes to the manual
+        // form with what we do know; a barcode OFF has never seen is a dead end.
+        if (manualPrefill) {
+            setTimeout(() => setShowManualForm(true), SHEET_SWAP_MS);
+            return;
+        }
         Alert.alert(t("templates.notFound"), t("templates.productNotFound"));
     }
 
     async function lookupBarcode(barcode: string): Promise<Food | null> {
+        setManualPrefill(null);
         const local = getFoodByBarcode(barcode);
         if (local) {
             logger.info("[SCAN] Found locally", { id: local.id });
@@ -165,8 +189,15 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
         }
         const product = await getProductByBarcode(barcode);
         if (!product) return null;
-        return getFoodByOpenfoodfactsId(product.code)
-            ?? unsavedFoodFromProduct(product, t("common.unknown"));
+        const existing = getFoodByOpenfoodfactsId(product.code);
+        if (existing) return existing;
+        const imported = productToFood(product, { fallbackName: t("common.unknown") });
+        if (!imported.ok) {
+            logger.info("[SCAN] OFF product has no nutrition facts", { barcode });
+            setManualPrefill({ name: imported.name, barcode: imported.barcode });
+            return null;
+        }
+        return unsavedFood(imported.food);
     }
 
     return {
@@ -189,6 +220,9 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
         showManualForm,
         setShowManualForm,
         openManualForm,
+        manualName: manualPrefill?.name,
+        manualBarcode: manualPrefill?.barcode,
+        manualNotice: manualPrefill ? t("common.offMissingNutritionNotice") : null,
         handleManualFoodCreated,
         handleBarcodeFound,
         handleBarcodeNotFound,

--- a/src/features/templates/screens/RecipeEditorScreen.tsx
+++ b/src/features/templates/screens/RecipeEditorScreen.tsx
@@ -199,7 +199,9 @@ export default function RecipeEditorScreen() {
                 visible={recipe.showManualForm}
                 onClose={() => recipe.setShowManualForm(false)}
                 onFoodCreated={recipe.handleManualFoodCreated}
-                initialName={recipe.foodQuery}
+                initialName={recipe.manualName ?? recipe.foodQuery}
+                initialBarcode={recipe.manualBarcode}
+                notice={recipe.manualNotice}
             />
 
             <BarcodeScannerView

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -36,6 +36,10 @@ const de = {
         carbsShort: "KH",
         fatShort: "F",
         noOnlineResults: "Keine Online-Ergebnisse",
+        offNoNutrition: "Keine Nährwertangaben",
+        offObsolete: "Nicht mehr erhältlich",
+        offMissingNutritionNotice:
+            "OpenFoodFacts hat für dieses Produkt keine Nährwertangaben. Ergänze sie unten, um es in deiner Bibliothek zu speichern.",
         itemCount_one: "{{count}} Element",
         itemCount_other: "{{count}} Elemente",
     },

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -37,6 +37,10 @@ const en = {
         carbsShort: "C",
         fatShort: "F",
         noOnlineResults: "No online results",
+        offNoNutrition: "No nutrition facts",
+        offObsolete: "Discontinued",
+        offMissingNutritionNotice:
+            "OpenFoodFacts has no nutrition facts for this product. Add them below to save it to your library.",
         itemCount_one: "{{count}} item",
         itemCount_other: "{{count}} items",
     },

--- a/src/services/__tests__/openfoodfacts.test.ts
+++ b/src/services/__tests__/openfoodfacts.test.ts
@@ -19,7 +19,14 @@ jest.mock("@/src/utils/logger", () => ({
     default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
-import { hydrateServing, productToFood, searchProducts } from "@/src/services/openfoodfacts";
+import {
+    hydrateProduct,
+    isObsolete,
+    productNutrition,
+    productToFood,
+    searchProducts,
+    type OFFProduct,
+} from "@/src/services/openfoodfacts";
 
 type FetchMock = jest.Mock<(url: string, init?: unknown) => Promise<unknown>>;
 
@@ -102,9 +109,31 @@ describe("searchProducts", () => {
                 product_name: "Vollmilch",
                 quantity: "1 l",
                 nutriments: { "energy-kcal_100g": 64, proteins_100g: 3.4 },
+                obsolete: false,
             },
-            { code: "2", product_name: "Skyr", quantity: undefined, nutriments: undefined },
+            {
+                code: "2",
+                product_name: "Skyr",
+                quantity: undefined,
+                nutriments: undefined,
+                obsolete: false,
+            },
         ]);
+    });
+
+    // The index only sets `obsolete` on delisted products, and they are not
+    // filtered out — the UI flags them instead of hiding them.
+    it("carries the obsolete flag through from the index", async () => {
+        fetchMock.mockResolvedValue(
+            searchHits([
+                { code: "1", product_name: "Discontinued", obsolete: true },
+                { code: "2", product_name: "Current" },
+            ]),
+        );
+
+        const products = await withTimersFlushed(searchProducts("milch"));
+
+        expect(products.map(isObsolete)).toEqual([true, false]);
     });
 
     it("drops hits without a code or a name", async () => {
@@ -186,26 +215,148 @@ describe("searchProducts", () => {
     });
 });
 
+// #400: an unchecked `?? 0` turned every partial OFF payload into a plausible
+// 0 kcal food. Energy is the gate — everything here is about which figures a
+// product really carries and when there are none.
+describe("productNutrition", () => {
+    it("reads the as-sold per-100 g figures", () => {
+        expect(
+            productNutrition({
+                nutriments: {
+                    "energy-kcal_100g": 42,
+                    proteins_100g: 0,
+                    carbohydrates_100g: 10.6,
+                    fat_100g: 0,
+                },
+            }),
+        ).toEqual({
+            calories_per_100g: 42,
+            protein_per_100g: 0,
+            carbs_per_100g: 10.6,
+            fat_per_100g: 0,
+            prepared: false,
+        });
+    });
+
+    it("returns null when the product carries no energy figure at all", () => {
+        expect(productNutrition({})).toBeNull();
+        expect(productNutrition({ nutriments: {} })).toBeNull();
+        expect(productNutrition({ nutriments: { proteins_100g: 3.4 } })).toBeNull();
+    });
+
+    it("honours no_nutrition_data even when nutriments are present", () => {
+        expect(
+            productNutrition({
+                no_nutrition_data: "on",
+                nutriments: { "energy-kcal_100g": 42 },
+            }),
+        ).toBeNull();
+    });
+
+    // A real zero — water, diet soda — is data, not a missing value.
+    it("keeps an explicit zero", () => {
+        expect(productNutrition({ nutriments: { "energy-kcal_100g": 0 } })).toMatchObject({
+            calories_per_100g: 0,
+        });
+    });
+
+    // Plenty of EU products publish only the kilojoule figure, which used to
+    // read as 0 kcal even with every macro filled in.
+    it("derives kcal from the kJ figure when kcal is absent", () => {
+        expect(
+            productNutrition({
+                nutriments: { "energy-kj_100g": 647, proteins_100g: 13.1, fat_100g: 11.2 },
+            }),
+        ).toMatchObject({ calories_per_100g: 154.64, protein_per_100g: 13.1 });
+    });
+
+    it("scales per-serving figures to per 100 g when only those exist", () => {
+        expect(
+            productNutrition({
+                serving_quantity: 330,
+                nutriments: { "energy-kcal_serving": 139, carbohydrates_serving: 35 },
+            }),
+        ).toEqual({
+            calories_per_100g: 42.12,
+            protein_per_100g: 0,
+            carbs_per_100g: 10.61,
+            fat_per_100g: 0,
+            prepared: false,
+        });
+    });
+
+    // Without the serving mass there is no way to normalize, so it is a gap
+    // rather than a number to guess at.
+    it("refuses per-serving figures when the serving mass is unknown", () => {
+        expect(
+            productNutrition({ nutriments: { "energy-kcal_serving": 139 } }),
+        ).toBeNull();
+        expect(
+            productNutrition({
+                serving_quantity: 0,
+                nutriments: { "energy-kcal_serving": 139 },
+            }),
+        ).toBeNull();
+    });
+
+    // `serving_size`/`default_unit` describe the pack, so as-sold figures have
+    // to win — pairing a dry scoop with made-up-drink numbers underprices it.
+    it("prefers as-sold figures over prepared ones", () => {
+        expect(
+            productNutrition({
+                nutriments: {
+                    "energy-kcal_100g": 377,
+                    "energy-kcal_prepared_100g": 72,
+                },
+            }),
+        ).toMatchObject({ calories_per_100g: 377, prepared: false });
+    });
+
+    it("falls back to prepared figures when there are no as-sold ones", () => {
+        expect(
+            productNutrition({
+                nutriments: {
+                    "energy-kcal_prepared_100g": 72,
+                    proteins_prepared_100g: 3.6,
+                    carbohydrates_prepared_100g: 9.8,
+                    fat_prepared_100g: 1.8,
+                },
+            }),
+        ).toEqual({
+            calories_per_100g: 72,
+            protein_per_100g: 3.6,
+            carbs_per_100g: 9.8,
+            fat_per_100g: 1.8,
+            prepared: true,
+        });
+    });
+});
+
 describe("productToFood", () => {
     const opts = { fallbackName: "Unknown" };
+    const nutriments = {
+        "energy-kcal_100g": 42,
+        proteins_100g: 0,
+        carbohydrates_100g: 10.6,
+        fat_100g: 0,
+    };
+
+    /** Narrow to the success case; every field assertion below needs the food. */
+    function foodFrom(product: OFFProduct) {
+        const imported = productToFood(product, opts);
+        if (!imported.ok) throw new Error(`expected an importable product, got ${imported.reason}`);
+        return imported.food;
+    }
 
     it("maps every food field an OFF product carries", () => {
         expect(
-            productToFood(
-                {
-                    code: "5449000000996",
-                    product_name: "Coca-Cola",
-                    serving_size: "330 ml",
-                    serving_quantity: 330,
-                    nutriments: {
-                        "energy-kcal_100g": 42,
-                        proteins_100g: 0,
-                        carbohydrates_100g: 10.6,
-                        fat_100g: 0,
-                    },
-                },
-                opts,
-            ),
+            foodFrom({
+                code: "5449000000996",
+                product_name: "Coca-Cola",
+                serving_size: "330 ml",
+                serving_quantity: 330,
+                nutriments,
+            }),
         ).toEqual({
             name: "Coca-Cola",
             calories_per_100g: 42,
@@ -223,31 +374,42 @@ describe("productToFood", () => {
     // The bug behind #399: a scanned product and a searched one are the same
     // OFF record, so they have to produce the same food.
     it("does not depend on how the product was found", () => {
-        const product = { code: "1", product_name: "Vollmilch", quantity: "1 l" };
+        const product = { code: "1", product_name: "Vollmilch", quantity: "1 l", nutriments };
 
         expect(productToFood(product, opts)).toEqual(productToFood({ ...product }, opts));
     });
 
     it("fills barcode from the product code, which is the EAN", () => {
-        expect(productToFood({ code: "1", product_name: "Milch" }, opts)).toMatchObject({
+        expect(foodFrom({ code: "1", product_name: "Milch", nutriments })).toMatchObject({
             barcode: "1",
             openfoodfacts_id: "1",
         });
     });
 
-    it("falls back to the given name and zeroed nutriments", () => {
-        expect(productToFood({ code: "1" }, opts)).toMatchObject({
-            name: "Unknown",
-            calories_per_100g: 0,
-            protein_per_100g: 0,
-            carbs_per_100g: 0,
-            fat_per_100g: 0,
+    it("falls back to the given name", () => {
+        expect(foodFrom({ code: "1", nutriments })).toMatchObject({ name: "Unknown" });
+    });
+
+    // The heart of #400: no numbers means no food, and the caller gets what it
+    // needs to open manual entry instead of writing a 0 kcal row.
+    it("refuses a product with no nutrition facts, keeping name and barcode", () => {
+        expect(productToFood({ code: "737628064502", product_name: "Tisane" }, opts)).toEqual({
+            ok: false,
+            reason: "no-nutrition-data",
+            name: "Tisane",
+            barcode: "737628064502",
         });
     });
 
+    it("reports whether the figures describe the prepared product", () => {
+        expect(productToFood({ code: "1", nutriments }, opts)).toMatchObject({ prepared: false });
+        expect(
+            productToFood({ code: "1", nutriments: { "energy-kcal_prepared_100g": 72 } }, opts),
+        ).toMatchObject({ prepared: true });
+    });
+
     it("prefers serving_quantity, then a number parsed out of serving_size, then 100 g", () => {
-        const size = (product: Parameters<typeof productToFood>[0]) =>
-            productToFood(product, opts).serving_size;
+        const size = (product: OFFProduct) => foodFrom({ ...product, nutriments }).serving_size;
 
         expect(size({ code: "1", serving_size: "250 ml", serving_quantity: 330 })).toBe(330);
         expect(size({ code: "1", serving_size: "250 ml" })).toBe(250);
@@ -256,8 +418,7 @@ describe("productToFood", () => {
     });
 
     it("guesses the unit from serving_size, else quantity, else grams", () => {
-        const unit = (product: Parameters<typeof productToFood>[0]) =>
-            productToFood(product, opts).default_unit;
+        const unit = (product: OFFProduct) => foodFrom({ ...product, nutriments }).default_unit;
 
         expect(unit({ code: "1", serving_size: "330 ml", quantity: "1 kg" })).toBe("ml");
         expect(unit({ code: "1", quantity: "500 ml" })).toBe("ml");
@@ -270,41 +431,55 @@ describe("productToFood", () => {
     });
 });
 
-describe("hydrateServing", () => {
-    const product = { code: "1", product_name: "Vollmilch", quantity: "1 l" };
+describe("hydrateProduct", () => {
+    const hit: OFFProduct = { code: "1", product_name: "Vollmilch", quantity: "1 l" };
 
-    it("merges the serving fields the search index does not carry", async () => {
+    it("merges in everything the search index does not carry", async () => {
         fetchMock.mockResolvedValue(
             jsonResponse({
                 status: 1,
                 code: "1",
-                product: { code: "1", serving_size: "250 ml", serving_quantity: 250 },
+                product: {
+                    code: "1",
+                    product_name: "Whole milk",
+                    serving_size: "250 ml",
+                    serving_quantity: 250,
+                    no_nutrition_data: "on",
+                    nutriments: { "energy-kcal_serving": 160 },
+                },
             }),
         );
 
-        await expect(hydrateServing(product)).resolves.toEqual({
-            ...product,
+        await expect(hydrateProduct(hit)).resolves.toEqual({
+            code: "1",
+            // The index is the only source of a localized name, so it wins.
+            product_name: "Vollmilch",
+            quantity: "1 l",
             serving_size: "250 ml",
             serving_quantity: 250,
+            no_nutrition_data: "on",
+            nutriments: { "energy-kcal_serving": 160 },
+            complete: true,
         });
         expect(lastUrl()).toContain("world.openfoodfacts.org/api/v2/product/1");
+        expect(lastUrl()).toContain("no_nutrition_data");
     });
 
-    it("skips the request when the product already has serving data", async () => {
-        const withServing = { ...product, serving_quantity: 250 };
+    it("skips the request for a product that already came from the product API", async () => {
+        const complete = { ...hit, complete: true };
 
-        await expect(hydrateServing(withServing)).resolves.toBe(withServing);
+        await expect(hydrateProduct(complete)).resolves.toBe(complete);
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it("returns the product unchanged when the lookup fails", async () => {
+    it("returns the search hit unchanged when the lookup fails", async () => {
         fetchMock.mockRejectedValue(new Error("Network request failed"));
-        await expect(hydrateServing(product)).resolves.toEqual(product);
+        await expect(hydrateProduct(hit)).resolves.toEqual(hit);
 
         fetchMock.mockResolvedValue(jsonResponse({}, 503));
-        await expect(hydrateServing(product)).resolves.toEqual(product);
+        await expect(hydrateProduct(hit)).resolves.toEqual(hit);
 
         fetchMock.mockResolvedValue(jsonResponse({ status: 0, code: "1" }));
-        await expect(hydrateServing(product)).resolves.toEqual(product);
+        await expect(hydrateProduct(hit)).resolves.toEqual(hit);
     });
 });

--- a/src/services/offNutriments.ts
+++ b/src/services/offNutriments.ts
@@ -1,0 +1,145 @@
+/**
+ * Turning an OpenFoodFacts nutriment payload into the per-100 g figures a food
+ * row needs. Split out of `openfoodfacts.ts` because deciding *which* of a
+ * product's figures to trust is the fiddly half of the import, and it is pure:
+ * no fetching, no i18n, no logging.
+ */
+
+/**
+ * OFF publishes one key per nutrient × preparation × scope — `proteins_100g`,
+ * `energy-kcal_serving`, `carbohydrates_prepared_100g`, … — so the keys we read
+ * are composed rather than declared. The four named ones are the common case
+ * and stay spelled out for the call sites that only want those.
+ */
+export interface OFFNutriments {
+    "energy-kcal_100g"?: number;
+    proteins_100g?: number;
+    carbohydrates_100g?: number;
+    fat_100g?: number;
+    [nutrimentKey: string]: number | undefined;
+}
+
+/** The part of an OFF product that decides its nutrition figures. */
+export interface NutritionSource {
+    nutriments?: OFFNutriments;
+    /** The serving mass in g or ml, needed to normalize per-serving figures. */
+    serving_quantity?: number;
+    /** `"on"` when the contributor stated the pack carries no nutrition facts. */
+    no_nutrition_data?: string;
+}
+
+export interface ProductNutrition {
+    calories_per_100g: number;
+    protein_per_100g: number;
+    carbs_per_100g: number;
+    fat_per_100g: number;
+    /** True when the numbers describe the product as prepared, not as sold. */
+    prepared: boolean;
+}
+
+/** Energy conversion, for the many products that carry only the kJ figure. */
+const KJ_PER_KCAL = 4.184;
+
+/** The OFF nutriment key stem behind each macro column. */
+const MACRO_STEMS = {
+    protein_per_100g: "proteins",
+    carbs_per_100g: "carbohydrates",
+    fat_per_100g: "fat",
+} as const;
+
+/** As sold vs. as prepared — OFF suffixes the prepared keys. */
+type Preparation = "" | "_prepared";
+/** Which quantity the figures describe. */
+type Scope = "100g" | "serving";
+
+/** Trim the float noise OFF's own unit conversions leave behind. */
+function round2(value: number): number {
+    return Math.round(value * 100) / 100;
+}
+
+/** Read one composed nutriment key, e.g. `proteins_prepared_serving`. */
+function nutriment(
+    nutriments: OFFNutriments,
+    stem: string,
+    preparation: Preparation,
+    scope: Scope,
+): number | undefined {
+    const value = nutriments[`${stem}${preparation}_${scope}`];
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Energy in kcal. Plenty of products (mostly EU ones) publish only
+ * `energy-kj_*`, which used to read as 0 kcal even though the macros were all
+ * there. The bare `energy_*` key is deliberately not used: its unit varies.
+ */
+function energyKcal(
+    nutriments: OFFNutriments,
+    preparation: Preparation,
+    scope: Scope,
+): number | undefined {
+    const kcal = nutriment(nutriments, "energy-kcal", preparation, scope);
+    if (kcal !== undefined) return kcal;
+    const kj = nutriment(nutriments, "energy-kj", preparation, scope);
+    return kj !== undefined ? kj / KJ_PER_KCAL : undefined;
+}
+
+/** The figures for one preparation/scope combination, or null if it has none. */
+function readNutrition(
+    product: NutritionSource,
+    preparation: Preparation,
+    scope: Scope,
+): ProductNutrition | null {
+    const nutriments = product.nutriments ?? {};
+    const calories = energyKcal(nutriments, preparation, scope);
+    // Energy is the gate: a product without it has no nutrition facts worth
+    // importing, and a missing *individual* macro is normal in OFF data.
+    if (calories === undefined) return null;
+
+    // Per-serving figures only scale to per-100 g if the serving mass is known.
+    const perServing = scope === "serving";
+    const servingQuantity = product.serving_quantity ?? 0;
+    if (perServing && !(servingQuantity > 0)) return null;
+    const factor = perServing ? 100 / servingQuantity : 1;
+
+    const macros = Object.fromEntries(
+        Object.entries(MACRO_STEMS).map(([column, stem]) => [
+            column,
+            round2((nutriment(nutriments, stem, preparation, scope) ?? 0) * factor),
+        ]),
+    ) as Omit<ProductNutrition, "calories_per_100g" | "prepared">;
+
+    return {
+        calories_per_100g: round2(calories * factor),
+        ...macros,
+        prepared: preparation === "_prepared",
+    };
+}
+
+/**
+ * The per-100 g figures a product yields, or null when it carries none usable —
+ * which is what an unchecked `?? 0` used to turn into a plausible 0 kcal food.
+ *
+ * As-sold values win over prepared ones because `serving_size` and
+ * `default_unit` describe the product in the pack: pairing a dry-soup serving
+ * with its made-up figures would misprice every entry. Prepared values are the
+ * fallback for the products (cordials, powders) whose as-sold facts OFF never
+ * recorded. Note that `nutrition_data_prepared_per` is set on plenty of
+ * products that have no prepared figures at all, so the values themselves —
+ * not that flag — decide.
+ *
+ * Within a preparation, `*_100g` wins over `*_serving`: OFF normalizes to
+ * per-100 g whenever it can, so `nutrition_data_per` describes how a
+ * contributor typed the values in, not what `*_100g` means. `*_serving` is only
+ * reached for the products that have no per-100 g companion.
+ */
+export function productNutrition(product: NutritionSource): ProductNutrition | null {
+    if (product.no_nutrition_data) return null;
+    for (const preparation of ["", "_prepared"] as const) {
+        for (const scope of ["100g", "serving"] as const) {
+            const nutrition = readNutrition(product, preparation, scope);
+            if (nutrition) return nutrition;
+        }
+    }
+    return null;
+}

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -1,7 +1,15 @@
 import i18n from "@/src/i18n";
 import type { foods } from "@/src/services/db/schema";
+import {
+    productNutrition,
+    type NutritionSource,
+    type OFFNutriments,
+} from "@/src/services/offNutriments";
 import logger from "@/src/utils/logger";
 import type { FoodUnit } from "@/src/utils/units";
+
+export { productNutrition } from "@/src/services/offNutriments";
+export type { OFFNutriments, ProductNutrition } from "@/src/services/offNutriments";
 
 const BASE_URL = "https://world.openfoodfacts.org";
 // Full-text search runs on Search-a-licious. The legacy `cgi/search.pl` (and
@@ -22,20 +30,18 @@ const SEARCH_PAGE_SIZE = 20;
 const SEARCH_RETRIES = 1;
 const RETRY_DELAY_MS = 300;
 
-interface OFFNutriments {
-    "energy-kcal_100g"?: number;
-    proteins_100g?: number;
-    carbohydrates_100g?: number;
-    fat_100g?: number;
-}
-
-export interface OFFProduct {
+export interface OFFProduct extends NutritionSource {
     code: string;
     product_name?: string;
-    nutriments?: OFFNutriments;
     serving_size?: string;
-    serving_quantity?: number;
     quantity?: string;
+    /** `true` from the search index, `"on"` / `""` from the product API. */
+    obsolete?: boolean | string;
+    /**
+     * True once every field in `FIELDS` has been fetched. A search hit carries
+     * only `SEARCH_FIELDS`, so it needs `hydrateProduct` before it can be judged.
+     */
+    complete?: boolean;
 }
 
 interface OFFProductResponse {
@@ -54,6 +60,8 @@ interface OFFSearchHit {
     product_name?: string;
     nutriments?: OFFNutriments;
     quantity?: string;
+    /** Only present, and only ever `true`, for delisted products. */
+    obsolete?: boolean;
     [localizedField: string]: unknown;
 }
 
@@ -64,12 +72,13 @@ interface OFFSearchResponse {
 }
 
 const FIELDS =
-    "code,product_name,nutriments,serving_size,serving_quantity,quantity";
+    "code,product_name,nutriments,serving_size,serving_quantity,quantity,no_nutrition_data,obsolete";
 
-// The Search-a-licious index carries no serving fields (`serving_size`,
-// `serving_quantity`); they are hydrated per selection by `hydrateServing`.
-const SEARCH_FIELDS = ["code", "product_name", "nutriments", "quantity"];
-const SERVING_FIELDS = "serving_size,serving_quantity,quantity";
+// The Search-a-licious index carries neither the serving fields
+// (`serving_size`, `serving_quantity`) nor `no_nutrition_data`, and its
+// `nutriments` hold only the as-sold per-100 g figures. `hydrateProduct` fetches
+// the rest per selection. `obsolete` *is* indexed, and only appears when true.
+const SEARCH_FIELDS = ["code", "product_name", "nutriments", "quantity", "obsolete"];
 
 /**
  * The `foods` columns an OFF product determines. Every column the DB would
@@ -103,6 +112,20 @@ function parseServingSize(product: OFFProduct): number {
     return m ? parseFloat(m[1]) || 100 : 100;
 }
 
+/** OFF answers `status: 1` for delisted products too, so callers must ask. */
+export function isObsolete(product: OFFProduct): boolean {
+    return product.obsolete === true || product.obsolete === "on";
+}
+
+/**
+ * A product either maps to a food or explains why it cannot. The failure
+ * carries what we *do* know so the caller can send the user to manual entry
+ * with the name and barcode already filled in, rather than into a dead end.
+ */
+export type ProductImport =
+    | { ok: true; food: FoodFromProduct; prepared: boolean }
+    | { ok: false; reason: "no-nutrition-data"; name: string; barcode: string };
+
 /**
  * The one OFF product → food mapping. Every entry path (text search, barcode
  * scan, recipe ingredient search) goes through here so a product yields the
@@ -112,25 +135,33 @@ function parseServingSize(product: OFFProduct): number {
  * by their EAN, so for an OFF-sourced food the two are the same value, and
  * leaving `barcode` empty would hide the food from `getFoodByBarcode`.
  *
- * Serving fields are only as good as the product handed in — a Search-a-licious
- * hit carries none, so run it through `hydrateServing` first.
+ * Serving fields and the validation flags are only as good as the product
+ * handed in — a Search-a-licious hit carries neither, so run it through
+ * `hydrateProduct` before importing.
  */
 export function productToFood(
     product: OFFProduct,
     opts: { fallbackName: string },
-): FoodFromProduct {
-    const nutriments = product.nutriments ?? {};
+): ProductImport {
+    const name = product.product_name || opts.fallbackName;
+    const nutrition = productNutrition(product);
+    if (!nutrition) {
+        return { ok: false, reason: "no-nutrition-data", name, barcode: product.code };
+    }
+
+    const { prepared, ...macros } = nutrition;
     return {
-        name: product.product_name || opts.fallbackName,
-        calories_per_100g: nutriments["energy-kcal_100g"] ?? 0,
-        protein_per_100g: nutriments.proteins_100g ?? 0,
-        carbs_per_100g: nutriments.carbohydrates_100g ?? 0,
-        fat_per_100g: nutriments.fat_100g ?? 0,
-        barcode: product.code,
-        openfoodfacts_id: product.code,
-        source: "openfoodfacts",
-        default_unit: guessUnit(product),
-        serving_size: parseServingSize(product),
+        ok: true,
+        prepared,
+        food: {
+            name,
+            ...macros,
+            barcode: product.code,
+            openfoodfacts_id: product.code,
+            source: "openfoodfacts",
+            default_unit: guessUnit(product),
+            serving_size: parseServingSize(product),
+        },
     };
 }
 
@@ -151,7 +182,7 @@ export async function getProductByBarcode(
 
     const data: OFFProductResponse = await res.json();
     if (data.status !== 1 || !data.product?.product_name) return null;
-    return data.product;
+    return { ...data.product, complete: true };
 }
 
 /**
@@ -221,6 +252,7 @@ function productFromHit(hit: OFFSearchHit, langs: string[]): OFFProduct {
         product_name: localizedName ?? hit.product_name,
         nutriments: hit.nutriments,
         quantity: hit.quantity,
+        obsolete: hit.obsolete === true,
     };
 }
 
@@ -271,33 +303,38 @@ export async function searchProducts(
 }
 
 /**
- * Fill in the serving fields a search result cannot carry, from the product
- * API. Best-effort and never throws: without it `guessUnit`/`parseServingSize`
- * just fall back to their defaults, which is not worth failing a selection over.
+ * Fill in everything a search result cannot carry — the serving fields, the
+ * prepared/per-serving nutriments and `no_nutrition_data` — from the product
+ * API. Best-effort and never throws: on failure the thinner search hit stands,
+ * which is not worth failing a selection over.
  */
-export async function hydrateServing(product: OFFProduct): Promise<OFFProduct> {
-    if (product.serving_size || product.serving_quantity) return product;
+export async function hydrateProduct(product: OFFProduct): Promise<OFFProduct> {
+    if (product.complete) return product;
 
-    logger.info("[API] Hydrating serving fields", { code: product.code });
+    logger.info("[API] Hydrating product", { code: product.code });
     try {
         const res = await fetch(
-            `${BASE_URL}/api/v2/product/${encodeURIComponent(product.code)}?fields=${SERVING_FIELDS}`,
+            `${BASE_URL}/api/v2/product/${encodeURIComponent(product.code)}?fields=${FIELDS}`,
             { headers: { "User-Agent": USER_AGENT } },
         );
         if (!res.ok) {
-            logger.warn("[API] Serving hydration failed", { status: res.status });
+            logger.warn("[API] Product hydration failed", { status: res.status });
             return product;
         }
         const data: OFFProductResponse = await res.json();
         if (data.status !== 1 || !data.product) return product;
         return {
-            ...product,
-            serving_size: data.product.serving_size,
-            serving_quantity: data.product.serving_quantity,
-            quantity: product.quantity ?? data.product.quantity,
+            ...data.product,
+            // The search index is the only source of a localized product name;
+            // its nutriments and pack size still beat nothing where the product
+            // API returned neither.
+            product_name: product.product_name || data.product.product_name,
+            nutriments: data.product.nutriments ?? product.nutriments,
+            quantity: data.product.quantity || product.quantity,
+            complete: true,
         };
     } catch (err) {
-        logger.warn("[API] Serving hydration errored", { error: String(err) });
+        logger.warn("[API] Product hydration errored", { error: String(err) });
         return product;
     }
 }


### PR DESCRIPTION
Closes #400. Builds on the shared `productToFood()` from #399.

## The problem

We read OFF nutriments with `?? 0` and no validation, so any partial payload became a plausible-looking food with wrong numbers — usually 0 kcal / 0 / 0 / 0.

## What changed

`productToFood` now returns a discriminated result:

```ts
type ProductImport =
    | { ok: true; food: FoodFromProduct; prepared: boolean }
    | { ok: false; reason: "no-nutrition-data"; name: string; barcode: string };
```

All three entry paths (text search, barcode scan, recipe ingredient search) route the failure into the existing manual-entry form, pre-filled with the name and barcode and carrying a notice explaining why — a dead end becomes a useful flow. Nothing is written to the library.

Deciding *which* figures a product yields moved into a new pure `src/services/offNutriments.ts` (no fetching, no i18n, no logging), which also kept `openfoodfacts.ts` under the 400-line limit.

**Resolution rules**, all covered by tests:

- **Energy is the gate.** A missing `energy-kcal_100g` is a gap, not a zero. An explicit `0` (water, diet soda) is still data and imports fine.
- **`no_nutrition_data` is honoured**, even when stray nutriments are present.
- **kcal is derived from `energy-kj_*`** when only that is published. This turned out to be a large share of products the issue did not mention — in a 50-hit sample, 2 had full macros and a kJ figure but no kcal, and imported at 0 kcal. (Sanity check: `647 kJ / 4.184 = 154.6 kcal` for eggs. ✓) The bare `energy_*` key is deliberately unused; its unit varies.
- **`*_serving` figures are scaled to per-100 g** via `serving_quantity`, and refused outright when the serving mass is unknown rather than guessed at.
- **As-sold beats prepared**, with prepared as the fallback — see the note below.
- **`obsolete` is flagged, not hidden**, in both search lists.

`hydrateServing` became `hydrateProduct`: a Search-a-licious hit carries none of the validation fields, so the full record is fetched before the product is judged. Guarded by an explicit `complete` flag rather than the old "does it have serving fields?" heuristic.

## Two deliberate deviations from the issue's proposed fix

**1. `nutrition_data_per` is not consulted.** Verified against live data: OFF normalizes to `*_100g` whenever it can, so the flag describes how a contributor *typed the values in*, not what `*_100g` means. Coca-Cola has `nutrition_data_per: "serving"` and a correct `energy-kcal_100g: 42`; reading `energy-kcal_serving: 139 / 330 × 100` gives `42.12` — the same answer with added float noise. Preferring `*_100g` and falling back to `*_serving` covers the gap the issue describes without the field. There's a comment in the code so this doesn't get re-litigated.

**2. Prepared values are the fallback, not the preference.** The issue suggested preferring prepared where `nutrition_data_prepared_per` is set. Live data argues against both halves:

- The flag is set on products with no prepared figures at all (Coca-Cola has `nutrition_data_prepared_per: "100g"` and zero prepared nutriments), so the *values* decide, not the flag.
- Preferring prepared silently invalidates `serving_size`. Nesquik's serving is `13.5 g` — a scoop of powder. Pairing that with the prepared `72 kcal/100g` prices a scoop at 9.7 kcal instead of ~51. As-sold keeps `serving_size`/`default_unit` coherent, and prepared still rescues the products (powders, cordials) whose as-sold facts OFF never recorded.

The `prepared` flag is returned on the success result so a future UI surface can say which basis was used; nothing consumes it yet. Worth noting it interacts with #402's structured serving fields.

## Verification

Ran the real payloads for six products through the import — all correct:

| Product | Case | Result |
| --- | --- | --- |
| Nutella | plain as-sold 100 g | 539 kcal ✓ |
| Coca-Cola | `nutrition_data_per: serving` | 42 kcal, `ml`, 330 ✓ |
| Nesquik | only prepared figures | 72 kcal, `prepared: true` ✓ |
| Tisane Bio | `nutriments: null` | refused, name + barcode kept ✓ |
| Bio fresh Eggs | kJ-only | macros intact ✓ |
| 1664 | obsolete | flagged, still importable ✓ |

`npm test` (61 passing, 30 in the OFF suite), `npm run lint` and `npx tsc --noEmit` are all clean. New i18n keys are in both `en.ts` and `de.ts`.

One pre-existing bug fixed along the way: both manual-entry forms only read their pre-filled values on mount, so they kept whatever the previous visit left behind. They now re-sync on open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)