### PR TITLE
Import OFF products under a localized, branded name

### DIFF
--- a/src/features/log/screens/AddFoodScreen.tsx
+++ b/src/features/log/screens/AddFoodScreen.tsx
@@ -1,4 +1,4 @@
-import { isObsolete, productNutrition } from "@/src/services/openfoodfacts";
+import { isObsolete, productName, productNutrition } from "@/src/services/openfoodfacts";
 import Button from "@/src/shared/atoms/Button";
 import BarcodeScannerView from "@/src/shared/components/BarcodeScannerView";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
@@ -207,7 +207,7 @@ export default function AddFoodScreen() {
                             return (
                                 <FoodListItem
                                     key={p.code}
-                                    name={p.product_name ?? t("common.unknown")}
+                                    name={productName(p, t("common.unknown"))}
                                     calories={nutrition?.calories_per_100g ?? 0}
                                     protein={nutrition?.protein_per_100g ?? 0}
                                     carbs={nutrition?.carbs_per_100g ?? 0}

--- a/src/features/templates/components/AddIngredientSheet.tsx
+++ b/src/features/templates/components/AddIngredientSheet.tsx
@@ -1,4 +1,4 @@
-import { isObsolete, productNutrition, type OFFProduct } from "@/src/services/openfoodfacts";
+import { isObsolete, productName, productNutrition, type OFFProduct } from "@/src/services/openfoodfacts";
 import Button from "@/src/shared/atoms/Button";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
@@ -363,7 +363,7 @@ export default function AddIngredientSheet({
                                     return (
                                         <ResultRow
                                             key={product.code}
-                                            name={product.product_name || t("common.unknown")}
+                                            name={productName(product, t("common.unknown"))}
                                             hint={
                                                 nutrition
                                                     ? t("templates.calPer100g", {

--- a/src/services/__tests__/openfoodfacts.test.ts
+++ b/src/services/__tests__/openfoodfacts.test.ts
@@ -22,6 +22,7 @@ jest.mock("@/src/utils/logger", () => ({
 import {
     hydrateProduct,
     isObsolete,
+    productName,
     productNutrition,
     productToFood,
     searchProducts,
@@ -84,16 +85,20 @@ describe("searchProducts", () => {
         expect(url.searchParams.get("langs")).toBe("de,en");
         expect(url.searchParams.get("page")).toBe("1");
         expect(url.searchParams.get("fields")).toContain("product_name_de");
+        expect(url.searchParams.get("fields")).toContain("brands");
         expect(url.searchParams.get("fields")).toContain("nutriments");
     });
 
-    it("maps hits to products, preferring the localized name", async () => {
+    // The localized names stay as the keys they came as: `productName` picks
+    // one, so that the search list and the import cannot disagree (#401).
+    it("maps hits to products, keeping every localized name", async () => {
         fetchMock.mockResolvedValue(
             searchHits([
                 {
                     code: "1",
                     product_name: "Whole milk",
                     product_name_de: "Vollmilch",
+                    brands: ["Weihenstephan", " Müller"],
                     quantity: "1 l",
                     nutriments: { "energy-kcal_100g": 64, proteins_100g: 3.4 },
                 },
@@ -106,7 +111,9 @@ describe("searchProducts", () => {
         expect(products).toEqual([
             {
                 code: "1",
-                product_name: "Vollmilch",
+                product_name: "Whole milk",
+                product_name_de: "Vollmilch",
+                brands: ["Weihenstephan", " Müller"],
                 quantity: "1 l",
                 nutriments: { "energy-kcal_100g": 64, proteins_100g: 3.4 },
                 obsolete: false,
@@ -114,11 +121,25 @@ describe("searchProducts", () => {
             {
                 code: "2",
                 product_name: "Skyr",
+                brands: undefined,
                 quantity: undefined,
                 nutriments: undefined,
                 obsolete: false,
             },
         ]);
+        expect(products.map((p) => productName(p, "Unknown"))).toEqual([
+            "Weihenstephan Vollmilch",
+            "Skyr",
+        ]);
+    });
+
+    // A product OFF only knows a German name for still has a name.
+    it("keeps a hit whose only name is a localized one", async () => {
+        fetchMock.mockResolvedValue(searchHits([{ code: "1", product_name_de: "Vollmilch" }]));
+
+        const products = await withTimersFlushed(searchProducts("milch"));
+
+        expect(products.map((p) => productName(p, "Unknown"))).toEqual(["Vollmilch"]);
     });
 
     // The index only sets `obsolete` on delisted products, and they are not
@@ -332,6 +353,70 @@ describe("productNutrition", () => {
     });
 });
 
+// #401: `product_name` is whatever language the product itself is in, and no
+// request parameter makes v2 localize it. The app language is stubbed to "de"
+// above, so the chain under test is product_name_de → product_name_en →
+// product_name.
+describe("productName", () => {
+    const name = (product: OFFProduct) => productName(product, "Unknown");
+
+    it("prefers the app language, then English, then the product's own name", () => {
+        const product = {
+            code: "1",
+            product_name: "PESTO alla GENOVESE",
+            product_name_en: "Green pesto",
+            product_name_de: "Grünes Pesto alla Genovese",
+        };
+
+        expect(name(product)).toBe("Grünes Pesto alla Genovese");
+        expect(name({ ...product, product_name_de: undefined })).toBe("Green pesto");
+        expect(name({ ...product, product_name_de: "", product_name_en: "" })).toBe(
+            "PESTO alla GENOVESE",
+        );
+    });
+
+    it("falls back to the given name when OFF has none", () => {
+        expect(name({ code: "1" })).toBe("Unknown");
+        expect(name({ code: "1", product_name: "   " })).toBe("Unknown");
+    });
+
+    it("prefixes the brand so near-identical products can be told apart", () => {
+        expect(name({ code: "1", product_name_de: "Grünes Pesto", brands: "Barilla" })).toBe(
+            "Barilla Grünes Pesto",
+        );
+    });
+
+    // `brands` is a list with the owner first, and the tail is often an address
+    // OFF split on its own commas. The product API sends it as one string, the
+    // search index as an array — both have to read the same.
+    it("uses only the first brand, however the endpoint shaped the list", () => {
+        expect(name({ code: "1", product_name: "Pesto", brands: "Barilla,43122 Parma - Italy" })).toBe(
+            "Barilla Pesto",
+        );
+        expect(name({ code: "1", product_name: "Pesto", brands: ["Barilla", " Italien"] })).toBe(
+            "Barilla Pesto",
+        );
+    });
+
+    it("ignores an empty brand list", () => {
+        expect(name({ code: "1", product_name: "Pesto", brands: [] })).toBe("Pesto");
+        expect(name({ code: "1", product_name: "Pesto", brands: "" })).toBe("Pesto");
+    });
+
+    it("leaves a name that already carries the brand alone", () => {
+        expect(name({ code: "1", product_name: "Nutella", brands: "Nutella,Ferrero" })).toBe(
+            "Nutella",
+        );
+        expect(name({ code: "1", product_name: "coca-cola", brands: "Coca-Cola" })).toBe(
+            "coca-cola",
+        );
+    });
+
+    it("stands in the brand for a product with no name at all", () => {
+        expect(name({ code: "1", brands: "Barilla" })).toBe("Barilla");
+    });
+});
+
 describe("productToFood", () => {
     const opts = { fallbackName: "Unknown" };
     const nutriments = {
@@ -390,6 +475,19 @@ describe("productToFood", () => {
         expect(foodFrom({ code: "1", nutriments })).toMatchObject({ name: "Unknown" });
     });
 
+    // The name a user picked in the search list is the name they get (#401).
+    it("imports the localized, brand-prefixed name", () => {
+        expect(
+            foodFrom({
+                code: "8076809513753",
+                product_name: "PESTO alla GENOVESE",
+                product_name_de: "Grünes Pesto alla Genovese",
+                brands: "Barilla",
+                nutriments,
+            }),
+        ).toMatchObject({ name: "Barilla Grünes Pesto alla Genovese" });
+    });
+
     // The heart of #400: no numbers means no food, and the caller gets what it
     // needs to open manual entry instead of writing a 0 kcal row.
     it("refuses a product with no nutrition facts, keeping name and barcode", () => {
@@ -432,7 +530,12 @@ describe("productToFood", () => {
 });
 
 describe("hydrateProduct", () => {
-    const hit: OFFProduct = { code: "1", product_name: "Vollmilch", quantity: "1 l" };
+    const hit: OFFProduct = {
+        code: "1",
+        product_name: "Whole milk",
+        product_name_de: "Vollmilch",
+        quantity: "1 l",
+    };
 
     it("merges in everything the search index does not carry", async () => {
         fetchMock.mockResolvedValue(
@@ -442,6 +545,8 @@ describe("hydrateProduct", () => {
                 product: {
                     code: "1",
                     product_name: "Whole milk",
+                    product_name_de: "Vollmilch",
+                    brands: "Weihenstephan",
                     serving_size: "250 ml",
                     serving_quantity: 250,
                     no_nutrition_data: "on",
@@ -452,8 +557,9 @@ describe("hydrateProduct", () => {
 
         await expect(hydrateProduct(hit)).resolves.toEqual({
             code: "1",
-            // The index is the only source of a localized name, so it wins.
-            product_name: "Vollmilch",
+            product_name: "Whole milk",
+            product_name_de: "Vollmilch",
+            brands: "Weihenstephan",
             quantity: "1 l",
             serving_size: "250 ml",
             serving_quantity: 250,
@@ -463,6 +569,33 @@ describe("hydrateProduct", () => {
         });
         expect(lastUrl()).toContain("world.openfoodfacts.org/api/v2/product/1");
         expect(lastUrl()).toContain("no_nutrition_data");
+        // The localized names have to be asked for explicitly (#401).
+        expect(lastUrl()).toContain("product_name_de");
+    });
+
+    // OFF answers with `""` for text fields it has no value for, which used to
+    // be enough to wipe a localized name or the pack size off the search hit.
+    it("does not let the API's blanks overwrite the search hit", async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse({
+                status: 1,
+                code: "1",
+                product: {
+                    code: "1",
+                    product_name: "",
+                    product_name_de: "",
+                    brands: "",
+                    quantity: "",
+                    serving_size: "250 ml",
+                },
+            }),
+        );
+
+        await expect(hydrateProduct(hit)).resolves.toEqual({
+            ...hit,
+            serving_size: "250 ml",
+            complete: true,
+        });
     });
 
     it("skips the request for a product that already came from the product API", async () => {

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -32,7 +32,20 @@ const RETRY_DELAY_MS = 300;
 
 export interface OFFProduct extends NutritionSource {
     code: string;
+    /**
+     * OFF's name in the *product's* own language, whatever that is — a German
+     * user searching "pesto" gets `PESTO alla GENOVESE`. `productName` resolves
+     * the localized keys below first; nothing should read this one directly.
+     */
     product_name?: string;
+    /** `product_name_de`, `product_name_en`, … — one key per requested language. */
+    [localizedName: `product_name_${string}`]: string | undefined;
+    /**
+     * Owning brand first. The product API sends one comma-separated string
+     * (`"Barilla,Barilla Pesto"`), the search index the same list as an array —
+     * `primaryBrand` reads either.
+     */
+    brands?: string | string[];
     serving_size?: string;
     quantity?: string;
     /** `true` from the search index, `"on"` / `""` from the product API. */
@@ -58,6 +71,8 @@ interface OFFProductResponse {
 interface OFFSearchHit {
     code?: string;
     product_name?: string;
+    /** Already split into a list here, unlike the product API's one string. */
+    brands?: string[];
     nutriments?: OFFNutriments;
     quantity?: string;
     /** Only present, and only ever `true`, for delisted products. */
@@ -71,14 +86,32 @@ interface OFFSearchResponse {
     page_count?: number;
 }
 
-const FIELDS =
-    "code,product_name,nutriments,serving_size,serving_quantity,quantity,no_nutrition_data,obsolete";
+const FIELDS = [
+    "code",
+    "product_name",
+    "brands",
+    "nutriments",
+    "serving_size",
+    "serving_quantity",
+    "quantity",
+    "no_nutrition_data",
+    "obsolete",
+];
 
 // The Search-a-licious index carries neither the serving fields
 // (`serving_size`, `serving_quantity`) nor `no_nutrition_data`, and its
 // `nutriments` hold only the as-sold per-100 g figures. `hydrateProduct` fetches
 // the rest per selection. `obsolete` *is* indexed, and only appears when true.
-const SEARCH_FIELDS = ["code", "product_name", "nutriments", "quantity", "obsolete"];
+const SEARCH_FIELDS = ["code", "product_name", "brands", "nutriments", "quantity", "obsolete"];
+
+/**
+ * The `fields` parameter both endpoints take. The localized names have to be
+ * asked for by name: neither `?lc=de`, `?cc=de` nor `de.openfoodfacts.org`
+ * makes v2 localize `product_name` for you (#401).
+ */
+function fieldsParam(fields: string[]): string {
+    return [...fields, ...nameLangs().map((lang) => `product_name_${lang}`)].join(",");
+}
 
 /**
  * The `foods` columns an OFF product determines. Every column the DB would
@@ -112,6 +145,56 @@ function parseServingSize(product: OFFProduct): number {
     return m ? parseFloat(m[1]) || 100 : 100;
 }
 
+/**
+ * Languages to read product names in, app language first. English is kept as a
+ * fallback because many products are only named in English, and dropping it
+ * loses both results and names.
+ */
+function nameLangs(): string[] {
+    const lang = (i18n.language ?? "en").split("-")[0] || "en";
+    return lang === "en" ? ["en"] : [lang, "en"];
+}
+
+/** The best name OFF has for the product, or undefined if it has none. */
+function localizedName(product: OFFProduct): string | undefined {
+    for (const lang of nameLangs()) {
+        const name = product[`product_name_${lang}`]?.trim();
+        if (name) return name;
+    }
+    return product.product_name?.trim() || undefined;
+}
+
+/**
+ * The owning brand, which OFF lists first. Everything after it is unreliable:
+ * the product API hands `brands` over as one comma-separated string, and OFF's
+ * data has whole postal addresses in that field, so the tail is often the rest
+ * of an address split on its own commas. The search index sends the same field
+ * pre-split into an array — with the same junk in it.
+ */
+function primaryBrand(product: OFFProduct): string | undefined {
+    const brands = product.brands;
+    const first = Array.isArray(brands) ? brands[0] : brands?.split(",")[0];
+    return typeof first === "string" ? first.trim() || undefined : undefined;
+}
+
+/**
+ * How a product is named everywhere in the app — in the search list and in the
+ * food it is imported as, so the row a user picks is the row they get.
+ *
+ * The brand is prefixed because a bare "Pesto alla Genovese" says little next
+ * to five near-identical hits, and it goes into `foods.name` rather than only
+ * the search list so that searching the library for "Barilla" finds it. Names
+ * that already carry the brand ("Nutella", brand `Nutella,Ferrero`) are left
+ * alone.
+ */
+export function productName(product: OFFProduct, fallback: string): string {
+    const name = localizedName(product);
+    const brand = primaryBrand(product);
+    if (!name) return brand ?? fallback;
+    if (!brand || name.toLowerCase().includes(brand.toLowerCase())) return name;
+    return `${brand} ${name}`;
+}
+
 /** OFF answers `status: 1` for delisted products too, so callers must ask. */
 export function isObsolete(product: OFFProduct): boolean {
     return product.obsolete === true || product.obsolete === "on";
@@ -138,12 +221,16 @@ export type ProductImport =
  * Serving fields and the validation flags are only as good as the product
  * handed in — a Search-a-licious hit carries neither, so run it through
  * `hydrateProduct` before importing.
+ *
+ * The name is resolved (`productName`) at import time and then frozen in the
+ * DB, so switching the app language later leaves existing foods named as they
+ * were imported.
  */
 export function productToFood(
     product: OFFProduct,
     opts: { fallbackName: string },
 ): ProductImport {
-    const name = product.product_name || opts.fallbackName;
+    const name = productName(product, opts.fallbackName);
     const nutrition = productNutrition(product);
     if (!nutrition) {
         return { ok: false, reason: "no-nutrition-data", name, barcode: product.code };
@@ -171,7 +258,7 @@ export async function getProductByBarcode(
     logger.info("[API] Fetching product by barcode", { barcode });
 
     const res = await fetch(
-        `${BASE_URL}/api/v2/product/${encodeURIComponent(barcode)}?fields=${FIELDS}`,
+        `${BASE_URL}/api/v2/product/${encodeURIComponent(barcode)}?fields=${fieldsParam(FIELDS)}`,
         { headers: { "User-Agent": USER_AGENT } },
     );
 
@@ -181,7 +268,7 @@ export async function getProductByBarcode(
     }
 
     const data: OFFProductResponse = await res.json();
-    if (data.status !== 1 || !data.product?.product_name) return null;
+    if (data.status !== 1 || !data.product || !localizedName(data.product)) return null;
     return { ...data.product, complete: true };
 }
 
@@ -212,16 +299,6 @@ function reserveSearchSlot(): { release: () => void } {
     };
 }
 
-/**
- * Languages to match product names in, app language first. English is kept as
- * a fallback because many products are only named in English, and dropping it
- * loses results.
- */
-function searchLangs(): string[] {
-    const lang = (i18n.language ?? "en").split("-")[0] || "en";
-    return lang === "en" ? ["en"] : [lang, "en"];
-}
-
 /** Retry a search once on a server-side failure; 4xx is our bug, not a blip. */
 async function fetchSearchWithRetry(url: string): Promise<Response> {
     for (let attempt = 0; ; attempt++) {
@@ -243,13 +320,28 @@ async function fetchSearchWithRetry(url: string): Promise<Response> {
     }
 }
 
+/**
+ * The localized names the index returned, kept as the `product_name_<lang>`
+ * keys they came as: picking one is `productName`'s job, and doing it here
+ * would let the search list and the import disagree.
+ */
+function localizedNames(hit: OFFSearchHit, langs: string[]): Partial<OFFProduct> {
+    const names: Partial<OFFProduct> = {};
+    for (const lang of langs) {
+        const name = hit[`product_name_${lang}`];
+        if (typeof name === "string" && name.length > 0) {
+            names[`product_name_${lang}`] = name;
+        }
+    }
+    return names;
+}
+
 function productFromHit(hit: OFFSearchHit, langs: string[]): OFFProduct {
-    const localizedName = langs
-        .map((lang) => hit[`product_name_${lang}`])
-        .find((name): name is string => typeof name === "string" && name.length > 0);
     return {
         code: String(hit.code),
-        product_name: localizedName ?? hit.product_name,
+        product_name: hit.product_name,
+        ...localizedNames(hit, langs),
+        brands: hit.brands,
         nutriments: hit.nutriments,
         quantity: hit.quantity,
         obsolete: hit.obsolete === true,
@@ -266,16 +358,13 @@ export async function searchProducts(
     try {
         logger.info("[API] Searching products", { query, page });
 
-        const langs = searchLangs();
+        const langs = nameLangs();
         const params = new URLSearchParams({
             q: query,
             langs: langs.join(","),
             page: String(page),
             page_size: String(SEARCH_PAGE_SIZE),
-            fields: [
-                ...SEARCH_FIELDS,
-                ...langs.map((lang) => `product_name_${lang}`),
-            ].join(","),
+            fields: fieldsParam(SEARCH_FIELDS),
         });
 
         const res = await fetchSearchWithRetry(`${SEARCH_URL}?${params}`);
@@ -293,13 +382,27 @@ export async function searchProducts(
         const products = (data.hits ?? [])
             .filter((hit) => hit.code)
             .map((hit) => productFromHit(hit, langs))
-            .filter((product) => product.product_name);
+            .filter((product) => localizedName(product));
 
         succeeded = true;
         return products;
     } finally {
         if (!succeeded) slot.release();
     }
+}
+
+/**
+ * The product API's answer laid over the search hit. OFF returns `""` for text
+ * fields it has no value for, so a blank from the API must not erase what the
+ * index did carry — that is how a localized name or a pack size gets lost.
+ */
+function mergeProduct(hit: OFFProduct, fetched: OFFProduct): OFFProduct {
+    const filled = Object.fromEntries(
+        Object.entries(fetched).filter(
+            ([, value]) => value !== undefined && value !== null && value !== "",
+        ),
+    );
+    return { ...hit, ...filled };
 }
 
 /**
@@ -314,7 +417,7 @@ export async function hydrateProduct(product: OFFProduct): Promise<OFFProduct> {
     logger.info("[API] Hydrating product", { code: product.code });
     try {
         const res = await fetch(
-            `${BASE_URL}/api/v2/product/${encodeURIComponent(product.code)}?fields=${FIELDS}`,
+            `${BASE_URL}/api/v2/product/${encodeURIComponent(product.code)}?fields=${fieldsParam(FIELDS)}`,
             { headers: { "User-Agent": USER_AGENT } },
         );
         if (!res.ok) {
@@ -323,16 +426,7 @@ export async function hydrateProduct(product: OFFProduct): Promise<OFFProduct> {
         }
         const data: OFFProductResponse = await res.json();
         if (data.status !== 1 || !data.product) return product;
-        return {
-            ...data.product,
-            // The search index is the only source of a localized product name;
-            // its nutriments and pack size still beat nothing where the product
-            // API returned neither.
-            product_name: product.product_name || data.product.product_name,
-            nutriments: data.product.nutriments ?? product.nutriments,
-            quantity: data.product.quantity || product.quantity,
-            complete: true,
-        };
+        return { ...mergeProduct(product, data.product), complete: true };
     } catch (err) {
         logger.warn("[API] Product hydration errored", { error: String(err) });
         return product;


### PR DESCRIPTION
Closes #401.

`product_name` is whatever language the product itself is in, and no request parameter changes that — `?lc=de`, `?cc=de` and `de.openfoodfacts.org` all still answer `PESTO alla GENOVESE`. The localized names have to be asked for by name.

## What changed

- **Both endpoints** now request `product_name_<app language>`, `product_name_en` and `brands` via a shared `fieldsParam()`. Previously only search asked for localized names, so every barcode scan got the product's own language regardless of the app language.
- **One `productName(product, fallback)`** resolves the name: `product_name_<i18n.language>` → `product_name_en` → `product_name` → fallback, then prefixes the owning brand unless the name already carries it. `productToFood` and both search lists (`AddFoodScreen`, `AddIngredientSheet`) call it, so the row a user picks is the row they get.
- The brand lands in `foods.name` rather than only the search list, so searching the library for "Barilla" finds it.
- `productFromHit` no longer collapses the localized names into `product_name`; it passes the keys through and lets `productName` decide.

## Two things the live API turned up

- **`brands` has a different shape per endpoint.** The product API sends one comma-separated string (`"Barilla"`), the search index the same list pre-split into an array (`["Barilla", " BARILLA Pesto", " Italien"]`). In both, the entries after the first are unreliable — one live hit had a full postal address split across the list, because OFF splits that field on its own commas. `primaryBrand` reads either shape and takes only the first entry.
- **Hydration could erase names.** OFF answers `""` for text fields it has no value for. Now that the product API also supplies localized names, the old three-field merge would have needed that guard on each of them, so it is replaced by a field-by-field merge that skips blanks.

## Verification

Live against OFF on 2026-07-29, with the app language German:

| Barcode | Before | After |
| --- | --- | --- |
| 8076809513753 | `PESTO alla GENOVESE` | `Barilla Grünes Pesto alla Genovese` |
| 3017620422003 | `Nutella` | `Nutella` (brand already in the name) |
| 5449000000996 | `coca-cola` | `coca-cola` (brand already in the name) |

`npx tsc --noEmit`, `npx jest` (71 tests, 15 new covering the name chain, both `brands` shapes, and the hydration merge) and `npm run lint` all pass.

Note the name is resolved at import time and then frozen in the DB, so a user who switches language later keeps the old names — as called out in the issue, and #404 would fix it as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)