### PR TITLE
Derive serving units from the OFF serving and package quantities

### DIFF
--- a/src/features/log/hooks/useAddFoodSearch.ts
+++ b/src/features/log/hooks/useAddFoodSearch.ts
@@ -1,6 +1,6 @@
 import { getRecipeGroups, type RecipeGroup } from "@/src/features/templates/services/recipeVariantsDb";
 import {
-    addFood,
+    addFoodWithServingUnits,
     getFoodByBarcode,
     getFoodByOpenfoodfactsId,
     getRecipeById,
@@ -153,7 +153,7 @@ export function useAddFoodSearch() {
                 setShowManualForm(true);
                 return;
             }
-            const food = addFood(imported.food);
+            const food = addFoodWithServingUnits(imported.food, imported.servingUnits);
             logger.info("[DB] Created food from OFF search", { id: food.id, name: food.name });
             setSelectedFood(food);
         } finally {
@@ -187,7 +187,7 @@ export function useAddFoodSearch() {
             });
             return null;
         }
-        const food = addFood(imported.food);
+        const food = addFoodWithServingUnits(imported.food, imported.servingUnits);
         logger.info("[DB] Created food from barcode", { id: food.id, name: food.name });
         return food;
     }

--- a/src/features/templates/hooks/useIngredientSearch.ts
+++ b/src/features/templates/hooks/useIngredientSearch.ts
@@ -1,4 +1,4 @@
-import { getProductByBarcode, hydrateProduct, productToFood, searchProducts, type FoodFromProduct, type OFFProduct } from "@/src/services/openfoodfacts";
+import { getProductByBarcode, hydrateProduct, productToFood, searchProducts, type DerivedServingUnit, type OFFProduct, type ProductImport } from "@/src/services/openfoodfacts";
 import logger from "@/src/utils/logger";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -8,26 +8,41 @@ import {
     getFoodByOpenfoodfactsId,
     searchFoodsByName,
     type Food,
+    type ServingUnit,
 } from "../services/templateDb";
 
 /** Dismiss animation of a bottom sheet, before the next one may open. */
 const SHEET_SWAP_MS = 300;
 
 /**
+ * A food the editor is working with, which may not be in the library yet. An
+ * unsaved one carries the serving units its OpenFoodFacts import derived: they
+ * belong to a food row that does not exist, so they travel with the draft and
+ * are written at `materializeFood` time, along with the food itself.
+ */
+export type UnsavedFood = Food & { pendingServingUnits?: ServingUnit[] };
+
+/**
  * A food picked from OpenFoodFacts that is not in the library yet. It carries
  * `id: 0` so the rest of the editor can treat it like any other food; the row
- * is only written when the recipe is saved (see `materializeFood`).
+ * is only written when the recipe is saved (see `materializeFood`). Its serving
+ * units carry `id: 0` for the same reason.
  */
-function unsavedFood(food: FoodFromProduct): Food {
+function unsavedFood(imported: Extract<ProductImport, { ok: true }>): UnsavedFood {
     return {
         id: 0,
-        ...food,
+        ...imported.food,
         last_logged_amount: null,
         last_logged_unit: null,
         last_logged_meal: null,
         deleted: 0,
         uuid: null,
+        pendingServingUnits: imported.servingUnits.map(unsavedServingUnit),
     };
+}
+
+function unsavedServingUnit(unit: DerivedServingUnit): ServingUnit {
+    return { id: 0, food_id: 0, uuid: null, ...unit };
 }
 
 /**
@@ -35,7 +50,7 @@ function unsavedFood(food: FoodFromProduct): Food {
  * three ways out of it (on-device search, barcode scan, manual entry). Every
  * path ends in `onPickFood`, called once the sheets have been dismissed.
  */
-export function useIngredientSearch(onPickFood: (food: Food) => void) {
+export function useIngredientSearch(onPickFood: (food: UnsavedFood) => void) {
     const { t } = useTranslation();
 
     const [showSearchSheet, setShowSearchSheet] = useState(false);
@@ -154,17 +169,17 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
                 setShowManualForm(true);
                 return;
             }
-            pickRef.current(unsavedFood(imported.food));
+            pickRef.current(unsavedFood(imported));
         });
     }
 
-    function handleManualFoodCreated(food: Food) {
+    function handleManualFoodCreated(food: UnsavedFood) {
         setShowManualForm(false);
         setManualPrefill(null);
         afterSheetDismissed(() => pickRef.current(food));
     }
 
-    function handleBarcodeFound(food: Food) {
+    function handleBarcodeFound(food: UnsavedFood) {
         setShowScanner(false);
         afterSheetDismissed(() => pickRef.current(food));
     }
@@ -180,7 +195,7 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
         Alert.alert(t("templates.notFound"), t("templates.productNotFound"));
     }
 
-    async function lookupBarcode(barcode: string): Promise<Food | null> {
+    async function lookupBarcode(barcode: string): Promise<UnsavedFood | null> {
         setManualPrefill(null);
         const local = getFoodByBarcode(barcode);
         if (local) {
@@ -197,7 +212,7 @@ export function useIngredientSearch(onPickFood: (food: Food) => void) {
             setManualPrefill({ name: imported.name, barcode: imported.barcode });
             return null;
         }
-        return unsavedFood(imported.food);
+        return unsavedFood(imported);
     }
 
     return {

--- a/src/features/templates/hooks/useRecipeEditor.ts
+++ b/src/features/templates/hooks/useRecipeEditor.ts
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Keyboard } from "react-native";
 import {
     addFood,
+    addServingUnit,
     addRecipe,
     addRecipeItem,
     deleteRecipeItem,
@@ -18,10 +19,9 @@ import {
     updateRecipe,
     updateRecipeItem,
     updateRecipeServings,
-    type Food,
     type ServingUnit,
 } from "../services/templateDb";
-import { useIngredientSearch } from "./useIngredientSearch";
+import { useIngredientSearch, type UnsavedFood } from "./useIngredientSearch";
 
 /**
  * One ingredient as it is being edited. Nothing here exists in the database
@@ -32,7 +32,7 @@ import { useIngredientSearch } from "./useIngredientSearch";
 export interface DraftIngredient {
     key: string;
     itemId?: number;
-    food: Food;
+    food: UnsavedFood;
     quantityGrams: number;
     quantityUnit: string;
     servingUnits: ServingUnit[];
@@ -84,7 +84,7 @@ export function useRecipeEditor() {
     const [editing, setEditing] = useState<{ draft: DraftIngredient; isNew: boolean } | null>(null);
 
     /** A food was picked in the search sheet: open the amount sheet for it. */
-    function openDraftForFood(food: Food) {
+    function openDraftForFood(food: UnsavedFood) {
         const foodUnit = (food.default_unit ?? "g") as FoodUnit;
         setEditing({
             isNew: true,
@@ -93,8 +93,9 @@ export function useRecipeEditor() {
                 food,
                 quantityGrams: toGrams(food.serving_size ?? 100, foodUnit),
                 quantityUnit: foodUnit,
-                // A food that is not in the library yet cannot have any.
-                servingUnits: food.id ? getServingUnits(food.id) : [],
+                // A food that is not in the library yet has no rows to read, but
+                // an OpenFoodFacts import may have derived some for it already.
+                servingUnits: food.id ? getServingUnits(food.id) : food.pendingServingUnits ?? [],
             },
         });
     }
@@ -162,15 +163,23 @@ export function useRecipeEditor() {
 
     // ── Saving ────────────────────────────────────────────
 
-    /** Resolves a draft's food to a row id, creating the food if it is new. */
-    function materializeFood(food: Food): number {
+    /**
+     * Resolves a draft's food to a row id, creating the food if it is new —
+     * together with the serving units the draft has been carrying for it, which
+     * could not be written without that id. A food that already exists keeps
+     * the units it already has.
+     */
+    function materializeFood(food: UnsavedFood, servingUnits: ServingUnit[]): number {
         if (food.id) return food.id;
         const existing =
             (food.openfoodfacts_id ? getFoodByOpenfoodfactsId(food.openfoodfacts_id) : undefined)
             ?? (food.barcode ? getFoodByBarcode(food.barcode) : undefined);
         if (existing) return existing.id;
-        const { id: _id, uuid: _uuid, ...values } = food;
+        const { id: _id, uuid: _uuid, pendingServingUnits: _pending, ...values } = food;
         const created = addFood(values);
+        for (const unit of servingUnits) {
+            addServingUnit({ food_id: created.id, name: unit.name, grams: unit.grams });
+        }
         logger.info("[DB] Created food for recipe", { id: created.id, name: created.name });
         return created.id;
     }
@@ -190,7 +199,7 @@ export function useRecipeEditor() {
 
         const staleItemIds = new Set(getRecipeItems(id).map((row) => row.recipe_items.id));
         for (const draft of items) {
-            const foodId = materializeFood(draft.food);
+            const foodId = materializeFood(draft.food, draft.servingUnits);
             const values = {
                 food_id: foodId,
                 quantity_grams: draft.quantityGrams,

--- a/src/features/templates/services/templateDb.ts
+++ b/src/features/templates/services/templateDb.ts
@@ -17,6 +17,22 @@ export function addFood(food: NewFood): Food {
     return db.insert(foods).values(food).returning().get();
 }
 
+/**
+ * A food and the serving units it arrived with, in one step. Kept together
+ * because the units cannot be written before the food has an id, and an import
+ * that produced units wants all of them or none.
+ */
+export function addFoodWithServingUnits(
+    food: NewFood,
+    units: { name: string; grams: number }[],
+): Food {
+    const created = addFood(food);
+    for (const unit of units) {
+        addServingUnit({ food_id: created.id, name: unit.name, grams: unit.grams });
+    }
+    return created;
+}
+
 export function searchFoodsByName(query: string): Food[] {
     return db
         .select()

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -40,6 +40,8 @@ const de = {
         offObsolete: "Nicht mehr erhältlich",
         offMissingNutritionNotice:
             "OpenFoodFacts hat für dieses Produkt keine Nährwertangaben. Ergänze sie unten, um es in deiner Bibliothek zu speichern.",
+        offServingUnitServing: "Portion",
+        offServingUnitPackage: "Packung",
         itemCount_one: "{{count}} Element",
         itemCount_other: "{{count}} Elemente",
     },

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -41,6 +41,11 @@ const en = {
         offObsolete: "Discontinued",
         offMissingNutritionNotice:
             "OpenFoodFacts has no nutrition facts for this product. Add them below to save it to your library.",
+        // Names of the serving units derived from an OpenFoodFacts import. They
+        // are stored in the food's rows, so changing them renames nothing that
+        // was imported before.
+        offServingUnitServing: "serving",
+        offServingUnitPackage: "package",
         itemCount_one: "{{count}} item",
         itemCount_other: "{{count}} items",
     },

--- a/src/services/__tests__/openfoodfacts.test.ts
+++ b/src/services/__tests__/openfoodfacts.test.ts
@@ -515,6 +515,18 @@ describe("productToFood", () => {
         expect(size({ code: "1" })).toBe(100);
     });
 
+    // The 100 g used to be indistinguishable from a product whose serving
+    // really is 100 g — Nutella (3017620422003) states no serving at all.
+    it("says when the serving size is its own invention", () => {
+        const guessed = (product: OFFProduct) =>
+            productToFood({ ...product, nutriments }, opts) as { servingSizeGuessed: boolean };
+
+        expect(guessed({ code: "1" }).servingSizeGuessed).toBe(true);
+        expect(guessed({ code: "1", serving_size: "one scoop" }).servingSizeGuessed).toBe(true);
+        expect(guessed({ code: "1", serving_quantity: 100 }).servingSizeGuessed).toBe(false);
+        expect(guessed({ code: "1", serving_size: "15 g" }).servingSizeGuessed).toBe(false);
+    });
+
     it("guesses the unit from serving_size, else quantity, else grams", () => {
         const unit = (product: OFFProduct) => foodFrom({ ...product, nutriments }).default_unit;
 
@@ -526,6 +538,91 @@ describe("productToFood", () => {
         expect(unit({ code: "1", serving_size: "8 fl oz" })).toBe("fl_oz");
         expect(unit({ code: "1", serving_size: "30 g" })).toBe("g");
         expect(unit({ code: "1" })).toBe("g");
+    });
+
+    // OFF's normalized units are the answer the regex was guessing at, and they
+    // exist for products that carry no serving_size text at all (#402).
+    it("takes the unit from OFF's normalized fields over the free text", () => {
+        const unit = (product: OFFProduct) => foodFrom({ ...product, nutriments }).default_unit;
+
+        expect(unit({ code: "1", serving_quantity_unit: "ml", serving_size: "1 cup" })).toBe("ml");
+        expect(unit({ code: "1", serving_quantity_unit: "g", quantity: "500 ml" })).toBe("g");
+        // Nutella: a normalized unit, no serving_size, no serving_quantity.
+        expect(unit({ code: "3017620422003", serving_quantity_unit: "g" })).toBe("g");
+        // The package unit stands in when the serving has none.
+        expect(unit({ code: "1", product_quantity_unit: "ml" })).toBe("ml");
+        // Anything outside the two OFF normalizes to leaves the regex in charge.
+        expect(unit({ code: "1", serving_quantity_unit: "kg", serving_size: "2 tbsp" })).toBe("tbsp");
+    });
+});
+
+// #402: OFF's two quantities are exactly a serving unit each, so a scanned
+// product is loggable as "1 serving" / "1 package" without hand-building one.
+describe("productToFood serving units", () => {
+    const opts = { fallbackName: "Unknown" };
+    const nutriments = { "energy-kcal_100g": 42 };
+
+    function unitsFrom(product: OFFProduct) {
+        const imported = productToFood({ ...product, nutriments }, opts);
+        if (!imported.ok) throw new Error(`expected an importable product, got ${imported.reason}`);
+        return imported.servingUnits;
+    }
+
+    it("derives one unit per quantity OFF publishes", () => {
+        expect(
+            unitsFrom({
+                code: "8076809513753",
+                serving_quantity: 100,
+                serving_quantity_unit: "g",
+                product_quantity: 190,
+                product_quantity_unit: "g",
+            }),
+        ).toEqual([
+            { name: "common.offServingUnitServing", grams: 100 },
+            { name: "common.offServingUnitPackage", grams: 190 },
+        ]);
+    });
+
+    // A 330 ml can is one serving: two chips for the same amount is clutter.
+    it("drops a package that is exactly one serving", () => {
+        expect(
+            unitsFrom({
+                code: "5449000000996",
+                serving_quantity: 330,
+                serving_quantity_unit: "ml",
+                product_quantity: 330,
+                product_quantity_unit: "ml",
+            }),
+        ).toEqual([{ name: "common.offServingUnitServing", grams: 330 }]);
+    });
+
+    it("derives only what the product carries", () => {
+        // Alesto nuts: a serving, no pack size.
+        expect(unitsFrom({ code: "20724696", serving_quantity: 30, serving_quantity_unit: "g" }))
+            .toEqual([{ name: "common.offServingUnitServing", grams: 30 }]);
+        expect(unitsFrom({ code: "1", product_quantity: 500, product_quantity_unit: "g" }))
+            .toEqual([{ name: "common.offServingUnitPackage", grams: 500 }]);
+        expect(unitsFrom({ code: "1" })).toEqual([]);
+    });
+
+    it("skips a quantity that is absent, zero or unparseable", () => {
+        expect(unitsFrom({ code: "1", serving_quantity: 0, product_quantity: "" })).toEqual([]);
+        expect(unitsFrom({ code: "1", product_quantity: "unknown" })).toEqual([]);
+    });
+
+    // OFF sends these as strings on plenty of products.
+    it("reads a quantity that arrived as a string", () => {
+        expect(unitsFrom({ code: "1", product_quantity: "190", product_quantity_unit: "g" }))
+            .toEqual([{ name: "common.offServingUnitPackage", grams: 190 }]);
+    });
+
+    // serving_units.grams is grams; ml rides on the app's ≈1 g/ml assumption,
+    // and there is no honest conversion for anything else.
+    it("skips a quantity in a unit it cannot store as grams", () => {
+        expect(unitsFrom({ code: "1", serving_quantity: 8, serving_quantity_unit: "fl oz" }))
+            .toEqual([]);
+        expect(unitsFrom({ code: "1", product_quantity: 1, product_quantity_unit: "l" }))
+            .toEqual([]);
     });
 });
 
@@ -569,6 +666,9 @@ describe("hydrateProduct", () => {
         });
         expect(lastUrl()).toContain("world.openfoodfacts.org/api/v2/product/1");
         expect(lastUrl()).toContain("no_nutrition_data");
+        // The structured serving/package quantities behind the derived units (#402).
+        expect(lastUrl()).toContain("serving_quantity_unit");
+        expect(lastUrl()).toContain("product_quantity_unit");
         // The localized names have to be asked for explicitly (#401).
         expect(lastUrl()).toContain("product_name_de");
     });

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -47,6 +47,15 @@ export interface OFFProduct extends NutritionSource {
      */
     brands?: string | string[];
     serving_size?: string;
+    /**
+     * OFF's own normalization of `serving_quantity`: the number is already
+     * converted and this is the plain unit it was converted to, only ever
+     * `"g"` or `"ml"`. Preferred over reading `serving_size` free text.
+     */
+    serving_quantity_unit?: string;
+    /** Net contents of the whole package, normalized the same way. */
+    product_quantity?: number | string;
+    product_quantity_unit?: string;
     quantity?: string;
     /** `true` from the search index, `"on"` / `""` from the product API. */
     obsolete?: boolean | string;
@@ -93,13 +102,16 @@ const FIELDS = [
     "nutriments",
     "serving_size",
     "serving_quantity",
+    "serving_quantity_unit",
+    "product_quantity",
+    "product_quantity_unit",
     "quantity",
     "no_nutrition_data",
     "obsolete",
 ];
 
-// The Search-a-licious index carries neither the serving fields
-// (`serving_size`, `serving_quantity`) nor `no_nutrition_data`, and its
+// The Search-a-licious index carries neither the serving/package fields
+// (`serving_size`, `serving_quantity`, `product_quantity`, …) nor `no_nutrition_data`, and its
 // `nutriments` hold only the as-sold per-100 g figures. `hydrateProduct` fetches
 // the rest per selection. `obsolete` *is* indexed, and only appears when true.
 const SEARCH_FIELDS = ["code", "product_name", "brands", "nutriments", "quantity", "obsolete"];
@@ -123,8 +135,46 @@ export type FoodFromProduct = Omit<
     "id" | "last_logged_amount" | "last_logged_unit" | "last_logged_meal" | "deleted" | "uuid"
 >;
 
-/** Guess the default unit from OFF serving_size or quantity string. */
+/** The serving size assumed for a product that states none. */
+const DEFAULT_SERVING_SIZE = 100;
+
+/** OFF sends its quantity fields as numbers on some products and strings on others. */
+function numeric(value: number | string | undefined): number | undefined {
+    const n = typeof value === "string" ? parseFloat(value) : value;
+    return typeof n === "number" && Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * The two units OFF normalizes its quantities to, and the only ones we can
+ * store: `serving_units.grams` is grams, so `ml` rides on the app-wide ≈1 g/ml
+ * assumption in `src/utils/units.ts`. Anything else is left to the caller.
+ */
+function storableUnit(unit: string | undefined): FoodUnit | undefined {
+    const u = unit?.trim().toLowerCase();
+    return u === "g" || u === "ml" ? u : undefined;
+}
+
+/**
+ * The unit a food's amounts are entered in. OFF's `*_quantity_unit` fields are
+ * already normalized to `"g"` or `"ml"`, so they beat reading the free text:
+ * plenty of products (Nutella, 3017620422003) carry the unit and no
+ * `serving_size` string at all, and the numbers we pair the unit with —
+ * `serving_quantity`, `product_quantity` — are normalized to match it.
+ */
 function guessUnit(product: OFFProduct): FoodUnit {
+    return (
+        storableUnit(product.serving_quantity_unit)
+        ?? storableUnit(product.product_quantity_unit)
+        ?? unitFromText(product)
+    );
+}
+
+/**
+ * Fallback for products carrying no normalized unit at all. Note that `cl` maps
+ * to `ml` without touching the number: safe only because the number beside it
+ * comes from OFF pre-converted ("33 cl" → `serving_quantity: 330`).
+ */
+function unitFromText(product: OFFProduct): FoodUnit {
     const text = (product.serving_size ?? product.quantity ?? "").toLowerCase();
     if (/\bml\b/.test(text) || /\bcl\b/.test(text) || /\bliter|\blitre/.test(text))
         return "ml";
@@ -137,12 +187,61 @@ function guessUnit(product: OFFProduct): FoodUnit {
     return "g";
 }
 
-/** Parse a numeric serving size from OFF, e.g. "250 ml" → 250. */
-function parseServingSize(product: OFFProduct): number {
-    if (product.serving_quantity && product.serving_quantity > 0)
-        return product.serving_quantity;
-    const m = (product.serving_size ?? "").match(/([\d.]+)/);
-    return m ? parseFloat(m[1]) || 100 : 100;
+/**
+ * The serving size in `default_unit`, e.g. "250 ml" → 250, or undefined when
+ * OFF states none. Undefined rather than `DEFAULT_SERVING_SIZE` so that a
+ * guess stays distinguishable from a product whose serving really is 100 g.
+ */
+function parseServingSize(product: OFFProduct): number | undefined {
+    const quantity = numeric(product.serving_quantity);
+    if (quantity !== undefined && quantity > 0) return quantity;
+    const parsed = numeric((product.serving_size ?? "").match(/([\d.]+)/)?.[1]);
+    return parsed !== undefined && parsed > 0 ? parsed : undefined;
+}
+
+/** One `serving_units` row a product implies, before the food row exists. */
+export interface DerivedServingUnit {
+    name: string;
+    grams: number;
+}
+
+/** A normalized OFF quantity as grams, or undefined if there is none to store. */
+function quantityGrams(
+    value: number | string | undefined,
+    unit: string | undefined,
+): number | undefined {
+    const amount = numeric(value);
+    if (amount === undefined || amount <= 0) return undefined;
+    // A missing unit is normal on older products, and harmless: OFF only ever
+    // normalizes to g or ml, which are the same number of grams either way.
+    // A unit we cannot convert is what disqualifies the quantity.
+    if (unit && !storableUnit(unit)) return undefined;
+    return amount;
+}
+
+/**
+ * The serving units OFF's two quantities imply: one serving, and the whole
+ * package. Scan a jar of pesto and both "1 serving" and "1 package (190 g)" are
+ * there, rather than the user hand-building a fact OFF already published.
+ *
+ * A package that weighs exactly one serving (a 330 ml can of Coke) yields no
+ * second row — the same amount under two names is only clutter in the picker.
+ *
+ * The names are resolved at import time and then frozen in the DB, like
+ * `productName`: entries reference a serving unit by name, so re-translating
+ * one later would orphan them.
+ */
+function servingUnitsFromProduct(product: OFFProduct): DerivedServingUnit[] {
+    const units: DerivedServingUnit[] = [];
+    const serving = quantityGrams(product.serving_quantity, product.serving_quantity_unit);
+    if (serving !== undefined) {
+        units.push({ name: i18n.t("common.offServingUnitServing"), grams: serving });
+    }
+    const pack = quantityGrams(product.product_quantity, product.product_quantity_unit);
+    if (pack !== undefined && pack !== serving) {
+        units.push({ name: i18n.t("common.offServingUnitPackage"), grams: pack });
+    }
+    return units;
 }
 
 /**
@@ -206,7 +305,18 @@ export function isObsolete(product: OFFProduct): boolean {
  * with the name and barcode already filled in, rather than into a dead end.
  */
 export type ProductImport =
-    | { ok: true; food: FoodFromProduct; prepared: boolean }
+    | {
+        ok: true;
+        food: FoodFromProduct;
+        prepared: boolean;
+        /** To write once the food row exists — they need its id. */
+        servingUnits: DerivedServingUnit[];
+        /**
+         * True when OFF states no serving size and `food.serving_size` is our
+         * `DEFAULT_SERVING_SIZE` rather than the product's own figure.
+         */
+        servingSizeGuessed: boolean;
+    }
     | { ok: false; reason: "no-nutrition-data"; name: string; barcode: string };
 
 /**
@@ -217,6 +327,11 @@ export type ProductImport =
  * `barcode` and `openfoodfacts_id` both get `product.code`: OFF keys products
  * by their EAN, so for an OFF-sourced food the two are the same value, and
  * leaving `barcode` empty would hide the food from `getFoodByBarcode`.
+ *
+ * The derived serving units come back beside the food rather than in it: they
+ * are rows of their own and need the food's id, so the caller writes them once
+ * it has one (`addFoodWithServingUnits`, or `materializeFood` for a recipe
+ * ingredient that is not saved yet).
  *
  * Serving fields and the validation flags are only as good as the product
  * handed in — a Search-a-licious hit carries neither, so run it through
@@ -237,9 +352,19 @@ export function productToFood(
     }
 
     const { prepared, ...macros } = nutrition;
+    const servingSize = parseServingSize(product);
+    if (servingSize === undefined) {
+        logger.info("[API] OFF product states no serving size, assuming the default", {
+            code: product.code,
+            assumed: DEFAULT_SERVING_SIZE,
+        });
+    }
+
     return {
         ok: true,
         prepared,
+        servingUnits: servingUnitsFromProduct(product),
+        servingSizeGuessed: servingSize === undefined,
         food: {
             name,
             ...macros,
@@ -247,7 +372,7 @@ export function productToFood(
             openfoodfacts_id: product.code,
             source: "openfoodfacts",
             default_unit: guessUnit(product),
-            serving_size: parseServingSize(product),
+            serving_size: servingSize ?? DEFAULT_SERVING_SIZE,
         },
     };
 }


### PR DESCRIPTION
Closes #402.

OFF gives two quantities per product and both map exactly onto a `serving_units` row, but no OFF import ever wrote one — every OFF-sourced food arrived gram-only. Scan a jar of pesto now and both "1 serving" and "1 package (190 g)" are there.

### Derived serving units

`productToFood` derives a row from `serving_quantity` ("serving" / "Portion") and one from `product_quantity` ("package" / "Packung"), and returns them beside the food since the rows need its id. Rows are skipped when the value is absent or zero, and the package row when it equals the serving one — a 330 ml can of Coke does not get the same amount under two names.

Only `g` and `ml` become rows: `serving_units.grams` is grams, so ml rides on the app-wide ≈1 g/ml assumption in `src/utils/units.ts` and anything else has no honest conversion.

All four import paths write them:

| Path | How |
| --- | --- |
| `useAddFoodSearch.handleSelectOFF` / `.lookupBarcode` | new `addFoodWithServingUnits` |
| `useIngredientSearch.handleSelectOFF` / `.lookupBarcode` | carried on the `id: 0` draft as `pendingServingUnits`, written by `materializeFood` when the recipe is saved |

The names are resolved at import time and frozen in the DB, like `productName` — entries reference a serving unit by name, so re-translating one later would orphan them.

### Structured fields over string parsing

`guessUnit` now prefers `serving_quantity_unit` / `product_quantity_unit` and keeps the regex only for products carrying neither. Besides being what the regex was guessing at, this fixes a latent mismatch between the number and its unit: `serving_quantity` arrives normalized, so a product with `serving_size: "1 cup (240 ml)"` and `serving_quantity: 240` used to import as 240 **cup**.

`parseServingSize` returns `undefined` instead of a silent `100`, and `productToFood` reports `servingSizeGuessed` alongside the default it applied. Nutella (3017620422003) states no serving size at all, so its real 15 g serving used to be indistinguishable from an invented 100 g one.

### Not included

Nothing backfills serving units for OFF foods already in the library; this affects new imports only.

### Verification

`npx tsc --noEmit`, `npm run lint` and `npm test` all pass. 8 new cases in `openfoodfacts.test.ts` cover the derivation against the products verified live in the issue (Coca-Cola 5449000000996, Barilla Pesto 8076809513753, Alesto nuts 20724696), the structured-unit preference including the Nutella case, the guessed-serving-size flag, and the new fields in the hydration URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
