### PR TITLE
Match volume units OFF spells bare or space-less (closes #407)

### DIFF
--- a/src/services/__tests__/openfoodfacts.test.ts
+++ b/src/services/__tests__/openfoodfacts.test.ts
@@ -540,6 +540,43 @@ describe("productToFood", () => {
         expect(unit({ code: "1" })).toBe("g");
     });
 
+    // #407: OFF's `quantity` writes liters bare and often drops the space, and
+    // both spellings used to fall through every branch onto the "g" default.
+    it("reads a volume however OFF spells it", () => {
+        const unit = (product: OFFProduct) => foodFrom({ ...product, nutriments }).default_unit;
+
+        expect(unit({ code: "1", quantity: "1 l" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "2 L" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "0.33 l" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "1,5 L" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "1l" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "1.5L" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "330ml" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "33cl" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "1 Liter" })).toBe("ml");
+        expect(unit({ code: "1", quantity: "2 liters" })).toBe("ml");
+        // The same space-less spelling on the units the regex already knew.
+        expect(unit({ code: "1", serving_size: "8fl oz" })).toBe("fl_oz");
+        expect(unit({ code: "1", serving_size: "1cup" })).toBe("cup");
+        expect(unit({ code: "1", serving_size: "2tbsp" })).toBe("tbsp");
+        expect(unit({ code: "1", serving_size: "1tsp" })).toBe("tsp");
+        expect(unit({ code: "1", serving_size: "8oz" })).toBe("oz");
+        expect(unit({ code: "1", serving_size: "1lb" })).toBe("lb");
+    });
+
+    // A bare "l" is one letter away from words a serving_size really contains,
+    // so it only counts when nothing lettered precedes it.
+    it("does not read a unit out of the middle of a word", () => {
+        const unit = (product: OFFProduct) => foodFrom({ ...product, nutriments }).default_unit;
+
+        expect(unit({ code: "1", serving_size: "1 large egg (50 g)" })).toBe("g");
+        expect(unit({ code: "1", serving_size: "30 g caramel" })).toBe("g");
+        expect(unit({ code: "1", serving_size: "1 bowl" })).toBe("g");
+        // "fl oz" and "lb" both end in a letter that must not read as liters.
+        expect(unit({ code: "1", serving_size: "8 fl oz" })).toBe("fl_oz");
+        expect(unit({ code: "1", serving_size: "1 lb" })).toBe("lb");
+    });
+
     // OFF's normalized units are the answer the regex was guessing at, and they
     // exist for products that carry no serving_size text at all (#402).
     it("takes the unit from OFF's normalized fields over the free text", () => {

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -170,21 +170,33 @@ function guessUnit(product: OFFProduct): FoodUnit {
 }
 
 /**
+ * Every spelling of a unit OFF's free text uses, most specific first: the
+ * alternations are ordered so `liter` is tried before the bare `l` it starts
+ * with, and `fl oz` before `oz`.
+ *
+ * `(?:^|[^a-z])` stands in for a leading `\b`, which would demand a separator
+ * between the number and the unit and so miss `330ml` (#407). A *letter* in
+ * front is still what disqualifies a match, so `fl` is not a liter and `caramel`
+ * is not a millilitre.
+ */
+const TEXT_UNITS: [RegExp, FoodUnit][] = [
+    [/(?:^|[^a-z])(?:liters?|litres?|ml|cl|l)\b/, "ml"],
+    [/(?:^|[^a-z])fl\s?oz\b/, "fl_oz"],
+    [/(?:^|[^a-z])cup/, "cup"],
+    [/(?:^|[^a-z])tbsp\b/, "tbsp"],
+    [/(?:^|[^a-z])tsp\b/, "tsp"],
+    [/(?:^|[^a-z])oz\b/, "oz"],
+    [/(?:^|[^a-z])lb\b/, "lb"],
+];
+
+/**
  * Fallback for products carrying no normalized unit at all. Note that `cl` maps
  * to `ml` without touching the number: safe only because the number beside it
  * comes from OFF pre-converted ("33 cl" → `serving_quantity: 330`).
  */
 function unitFromText(product: OFFProduct): FoodUnit {
     const text = (product.serving_size ?? product.quantity ?? "").toLowerCase();
-    if (/\bml\b/.test(text) || /\bcl\b/.test(text) || /\bliter|\blitre/.test(text))
-        return "ml";
-    if (/\bfl\s?oz\b/.test(text)) return "fl_oz";
-    if (/\bcup/.test(text)) return "cup";
-    if (/\btbsp\b/.test(text)) return "tbsp";
-    if (/\btsp\b/.test(text)) return "tsp";
-    if (/\boz\b/.test(text)) return "oz";
-    if (/\blb\b/.test(text)) return "lb";
-    return "g";
+    return TEXT_UNITS.find(([pattern]) => pattern.test(text))?.[1] ?? "g";
 }
 
 /**


### PR DESCRIPTION
Closes #407.

## Problem

`unitFromText()` (the free-text fallback in `guessUnit`) anchored every unit on a leading `\b`:

- `\bml\b` needs a separator between number and unit, so `330ml` matched nothing.
- The liter branch was `/\bliter|\blitre/`, so a bare `1 l` matched nothing.

Both fell through to the `"g"` default, so any drink whose `quantity` is written `1 l` or `330ml` — a large share of them — imported as a gram food.

## Fix

The if-chain becomes an ordered `TEXT_UNITS` table. Each pattern starts with `(?:^|[^a-z])` instead of `\b`: a *letter* in front still disqualifies a match (so `fl` is not a liter and `caramel` is not a millilitre), but a digit no longer does. Ordering does the rest — `liters?`/`litres?` ahead of the bare `l` they start with, `fl oz` ahead of `oz` — and the same leading-`\b` fix applies to every other unit, so `2tbsp` and `8oz` read too.

Out of scope, as the issue notes: `cl` still maps to `ml` without converting the number (called out in #402), and this fallback only runs at all for products carrying neither `serving_quantity_unit` nor `product_quantity_unit`.

## Tests

Two cases in `src/services/__tests__/openfoodfacts.test.ts`: every spelling from the issue's table, plus the space-less form of the other units; and a negative case pinning that a bare `l` is not read out of `bowl`, `fl oz` or `lb`.

`npm test` (81 passed), `npm run lint` and `npx tsc --noEmit` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)