### PR TITLE
OpenFoodFacts API hygiene: v3 endpoint, User-Agent contact, product-read rate limit

### DIFF
--- a/src/services/__tests__/openfoodfacts.test.ts
+++ b/src/services/__tests__/openfoodfacts.test.ts
@@ -19,7 +19,16 @@ jest.mock("@/src/utils/logger", () => ({
     default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
+// Stands in for app.json, which is where the User-Agent's version comes from.
+jest.mock("expo-constants", () => ({
+    __esModule: true,
+    default: { expoConfig: { version: "1.2.3" } },
+}));
+
+import { isRateLimitError } from "@/src/services/rateLimit";
+
 import {
+    getProductByBarcode,
     hydrateProduct,
     isObsolete,
     productName,
@@ -37,6 +46,23 @@ function jsonResponse(body: unknown, status = 200) {
 
 function searchHits(hits: unknown[]) {
     return jsonResponse({ hits, page: 1, page_size: 20, page_count: 1 });
+}
+
+/** The v3 product envelope: the outcome is `result.id`, not a numeric status. */
+function productResponse(product: unknown) {
+    return jsonResponse({
+        status: "success",
+        result: { id: "product_found" },
+        code: (product as { code?: string }).code,
+        product,
+    });
+}
+
+function notFoundResponse() {
+    return jsonResponse(
+        { status: "failure", result: { id: "product_not_found" }, errors: [] },
+        404,
+    );
 }
 
 let fetchMock: FetchMock;
@@ -231,7 +257,8 @@ describe("searchProducts", () => {
         );
 
         // …and frees up again once the sliding window has passed.
-        jest.setSystemTime(Date.now() + 61_000);
+        clock += 61_000;
+        jest.setSystemTime(clock);
         await expect(withTimersFlushed(searchProducts("milch"))).resolves.toHaveLength(1);
     });
 });
@@ -673,19 +700,15 @@ describe("hydrateProduct", () => {
 
     it("merges in everything the search index does not carry", async () => {
         fetchMock.mockResolvedValue(
-            jsonResponse({
-                status: 1,
+            productResponse({
                 code: "1",
-                product: {
-                    code: "1",
-                    product_name: "Whole milk",
-                    product_name_de: "Vollmilch",
-                    brands: "Weihenstephan",
-                    serving_size: "250 ml",
-                    serving_quantity: 250,
-                    no_nutrition_data: "on",
-                    nutriments: { "energy-kcal_serving": 160 },
-                },
+                product_name: "Whole milk",
+                product_name_de: "Vollmilch",
+                brands: "Weihenstephan",
+                serving_size: "250 ml",
+                serving_quantity: 250,
+                no_nutrition_data: "on",
+                nutriments: { "energy-kcal_serving": 160 },
             }),
         );
 
@@ -701,7 +724,7 @@ describe("hydrateProduct", () => {
             nutriments: { "energy-kcal_serving": 160 },
             complete: true,
         });
-        expect(lastUrl()).toContain("world.openfoodfacts.org/api/v2/product/1");
+        expect(lastUrl()).toContain("world.openfoodfacts.org/api/v3/product/1");
         expect(lastUrl()).toContain("no_nutrition_data");
         // The structured serving/package quantities behind the derived units (#402).
         expect(lastUrl()).toContain("serving_quantity_unit");
@@ -714,17 +737,13 @@ describe("hydrateProduct", () => {
     // be enough to wipe a localized name or the pack size off the search hit.
     it("does not let the API's blanks overwrite the search hit", async () => {
         fetchMock.mockResolvedValue(
-            jsonResponse({
-                status: 1,
+            productResponse({
                 code: "1",
-                product: {
-                    code: "1",
-                    product_name: "",
-                    product_name_de: "",
-                    brands: "",
-                    quantity: "",
-                    serving_size: "250 ml",
-                },
+                product_name: "",
+                product_name_de: "",
+                brands: "",
+                quantity: "",
+                serving_size: "250 ml",
             }),
         );
 
@@ -749,7 +768,88 @@ describe("hydrateProduct", () => {
         fetchMock.mockResolvedValue(jsonResponse({}, 503));
         await expect(hydrateProduct(hit)).resolves.toEqual(hit);
 
-        fetchMock.mockResolvedValue(jsonResponse({ status: 0, code: "1" }));
+        fetchMock.mockResolvedValue(
+            jsonResponse({ status: "failure", result: { id: "product_not_found" } }),
+        );
         await expect(hydrateProduct(hit)).resolves.toEqual(hit);
+    });
+
+    // Hydration is a product read like any other and spends from the same
+    // budget — but it is best-effort, so running out is not an error the user
+    // has to see mid-selection.
+    it("returns the search hit unchanged once the product budget is spent", async () => {
+        fetchMock.mockResolvedValue(productResponse({ code: "1", serving_size: "250 ml" }));
+        for (let i = 0; i < 15; i++) await getProductByBarcode(String(i));
+
+        await expect(hydrateProduct(hit)).resolves.toEqual(hit);
+        expect(fetchMock).toHaveBeenCalledTimes(15);
+    });
+});
+
+describe("getProductByBarcode", () => {
+    it("reads the product from the v3 endpoint, identifying the app to OFF", async () => {
+        fetchMock.mockResolvedValue(
+            productResponse({
+                code: "8076809513753",
+                product_name: "Pesto alla Genovese",
+                nutriments: { "energy-kcal_100g": 458 },
+            }),
+        );
+
+        await expect(getProductByBarcode("8076809513753")).resolves.toEqual({
+            code: "8076809513753",
+            product_name: "Pesto alla Genovese",
+            nutriments: { "energy-kcal_100g": 458 },
+            complete: true,
+        });
+
+        expect(lastUrl()).toContain("world.openfoodfacts.org/api/v3/product/8076809513753");
+        expect(lastUrl()).toContain("product_name_de");
+        // OFF's documented format: AppName/Version (ContactEmail), version from app.json.
+        const headers = (fetchMock.mock.calls[0][1] as { headers: Record<string, string> }).headers;
+        expect(headers["User-Agent"]).toBe("MacroFlow/1.2.3 (info.macroflow@gmail.com)");
+    });
+
+    // v3 answers an unknown barcode with a 404 where v2 sent a 200 and `status: 0`.
+    it("returns null for a barcode OFF does not know", async () => {
+        fetchMock.mockResolvedValue(notFoundResponse());
+        await expect(getProductByBarcode("0000000000000")).resolves.toBeNull();
+    });
+
+    it("returns null when the lookup fails or the product has no name", async () => {
+        fetchMock.mockResolvedValue(jsonResponse({}, 503));
+        await expect(getProductByBarcode("1")).resolves.toBeNull();
+
+        fetchMock.mockResolvedValue(productResponse({ code: "1", product_name: "" }));
+        await expect(getProductByBarcode("1")).resolves.toBeNull();
+    });
+
+    // OFF allows 15 product reads a minute per IP; the scanner can burst past
+    // that without a human pacing it.
+    it("rate-limits product reads at 15 a minute, whatever they answered", async () => {
+        // A mix of found and not-found: a 404 is still a request OFF served.
+        fetchMock
+            .mockResolvedValueOnce(notFoundResponse())
+            .mockResolvedValue(productResponse({ code: "1", product_name: "Milch" }));
+        for (let i = 0; i < 15; i++) await getProductByBarcode(String(i));
+
+        await expect(getProductByBarcode("16")).rejects.toThrow("common.rateLimitedWait");
+        expect(fetchMock).toHaveBeenCalledTimes(15);
+
+        // …and frees up again once the sliding window has passed.
+        clock += 61_000;
+        jest.setSystemTime(clock);
+        await expect(getProductByBarcode("16")).resolves.toMatchObject({ code: "1" });
+    });
+
+    // The scanner tells the user how long to wait, which means telling a rate
+    // limit apart from a dead connection.
+    it("throws a rate-limit error the UI can recognize", async () => {
+        fetchMock.mockResolvedValue(productResponse({ code: "1", product_name: "Milch" }));
+        for (let i = 0; i < 15; i++) await getProductByBarcode(String(i));
+
+        const err = await getProductByBarcode("16").catch((e: unknown) => e);
+        expect(isRateLimitError(err)).toBe(true);
+        expect(isRateLimitError(new Error("Network request failed"))).toBe(false);
     });
 });

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -5,8 +5,10 @@ import {
     type NutritionSource,
     type OFFNutriments,
 } from "@/src/services/offNutriments";
+import { createRateLimiter } from "@/src/services/rateLimit";
 import logger from "@/src/utils/logger";
 import type { FoodUnit } from "@/src/utils/units";
+import Constants from "expo-constants";
 
 export { productNutrition } from "@/src/services/offNutriments";
 export type { OFFNutriments, ProductNutrition } from "@/src/services/offNutriments";
@@ -16,14 +18,21 @@ const BASE_URL = "https://world.openfoodfacts.org";
 // `/api/v2/search`) endpoint is rejected at OFF's edge with a 503 roughly half
 // the time, so search there failed for no reason a user could act on.
 const SEARCH_URL = "https://search.openfoodfacts.org/search";
-const USER_AGENT = "MacroFlow/1.0 (React Native; open-source nutrient tracker)";
 
-// Client-side rate limiter for search: OpenFoodFacts allows 10 req/min/IP.
-// Track request timestamps in a sliding 60 s window so users can burst a few
-// requests quickly (or space them out) as long as the window stays under the cap.
-const SEARCH_WINDOW_MS = 60_000;
-const SEARCH_MAX_PER_WINDOW = 10;
-const searchTimestamps: number[] = [];
+/** Where OFF can reach us about our traffic, as their User-Agent format asks. */
+const CONTACT_EMAIL = "info.macroflow@gmail.com";
+/**
+ * OFF asks every client to identify itself as `AppName/Version (ContactEmail)`
+ * and treats an anonymous one as grounds for blocking. The version comes from
+ * `app.json` rather than being written out here, where it went stale within a
+ * release of being added.
+ */
+const USER_AGENT = `MacroFlow/${Constants.expoConfig?.version ?? "0.0.0"} (${CONTACT_EMAIL})`;
+
+// One budget per class of endpoint OFF publishes a limit for: 10 req/min/IP for
+// search, 15 for product reads.
+const searchLimiter = createRateLimiter(10);
+const productLimiter = createRateLimiter(15);
 
 const SEARCH_PAGE_SIZE = 20;
 /** One retry is enough for the transient 5xx/network blips we see in practice. */
@@ -66,11 +75,21 @@ export interface OFFProduct extends NutritionSource {
     complete?: boolean;
 }
 
+/**
+ * The v3 product envelope. v3 reports the outcome twice — `status` as
+ * `"success"`/`"failure"` and `result.id` as `"product_found"` /
+ * `"product_not_found"` — where v2 sent a numeric `status`, and it answers a
+ * barcode it does not know with a 404 rather than a 200. `result.id` is the
+ * narrower of the two checks, so it is the one worth making.
+ */
 interface OFFProductResponse {
-    status: number;
-    code: string;
+    status?: string;
+    result?: { id?: string };
+    code?: string;
     product?: OFFProduct;
 }
+
+const PRODUCT_FOUND = "product_found";
 
 /**
  * A Search-a-licious result. Localized names come back as `product_name_de`,
@@ -389,51 +408,52 @@ export function productToFood(
     };
 }
 
+function productUrl(code: string): string {
+    return `${BASE_URL}/api/v3/product/${encodeURIComponent(code)}?fields=${fieldsParam(FIELDS)}`;
+}
+
+/**
+ * One product read, against the budget OFF allows for them. The slot is spent
+ * whatever the answer turns out to be — unlike a search, a lookup that comes
+ * back empty is still a request OFF served and counted.
+ *
+ * @throws {RateLimitError} when the window is full.
+ */
+function fetchProduct(code: string): Promise<Response> {
+    productLimiter.reserve();
+    return fetch(productUrl(code), { headers: { "User-Agent": USER_AGENT } });
+}
+
+/**
+ * The product behind a scanned barcode, or null if OFF has none worth
+ * importing.
+ *
+ * @throws {RateLimitError} when too many barcodes were scanned in a minute —
+ * the one failure the caller can do something about, so it is not folded into
+ * the null.
+ */
 export async function getProductByBarcode(
     barcode: string,
 ): Promise<OFFProduct | null> {
     logger.info("[API] Fetching product by barcode", { barcode });
 
-    const res = await fetch(
-        `${BASE_URL}/api/v2/product/${encodeURIComponent(barcode)}?fields=${fieldsParam(FIELDS)}`,
-        { headers: { "User-Agent": USER_AGENT } },
-    );
+    const res = await fetchProduct(barcode);
 
+    // A barcode OFF has never seen is a 404 on v3, and not an error worth logging as one.
+    if (res.status === 404) {
+        logger.info("[API] OFF does not know this barcode", { barcode });
+        return null;
+    }
     if (!res.ok) {
         logger.error("[API] Barcode lookup failed", { status: res.status });
         return null;
     }
 
     const data: OFFProductResponse = await res.json();
-    if (data.status !== 1 || !data.product || !localizedName(data.product)) return null;
+    if (data.result?.id !== PRODUCT_FOUND || !data.product || !localizedName(data.product)) {
+        return null;
+    }
     return { ...data.product, complete: true };
-}
-
-/**
- * Claim one of the requests the sliding window allows, or throw with the wait
- * time. A search that ends in an error must `release()` its slot again:
- * charging for a response that carried no products means a flaky upstream also
- * rate-limits the user.
- */
-function reserveSearchSlot(): { release: () => void } {
-    const now = Date.now();
-    // Drop timestamps that have aged out of the sliding window.
-    while (searchTimestamps.length && now - searchTimestamps[0] >= SEARCH_WINDOW_MS) {
-        searchTimestamps.shift();
-    }
-    if (searchTimestamps.length >= SEARCH_MAX_PER_WINDOW) {
-        const waitSec = Math.ceil(
-            (SEARCH_WINDOW_MS - (now - searchTimestamps[0])) / 1000,
-        );
-        throw new Error(i18n.t("common.rateLimitedWait", { seconds: waitSec }));
-    }
-    searchTimestamps.push(now);
-    return {
-        release: () => {
-            const i = searchTimestamps.indexOf(now);
-            if (i !== -1) searchTimestamps.splice(i, 1);
-        },
-    };
 }
 
 /** Retry a search once on a server-side failure; 4xx is our bug, not a blip. */
@@ -489,7 +509,10 @@ export async function searchProducts(
     query: string,
     page = 1,
 ): Promise<OFFProduct[]> {
-    const slot = reserveSearchSlot();
+    // A search that ends in an error releases its slot again: charging for a
+    // response that carried no products means a flaky upstream also rate-limits
+    // the user.
+    const slot = searchLimiter.reserve();
     let succeeded = false;
 
     try {
@@ -546,23 +569,22 @@ function mergeProduct(hit: OFFProduct, fetched: OFFProduct): OFFProduct {
  * Fill in everything a search result cannot carry — the serving fields, the
  * prepared/per-serving nutriments and `no_nutrition_data` — from the product
  * API. Best-effort and never throws: on failure the thinner search hit stands,
- * which is not worth failing a selection over.
+ * which is not worth failing a selection over. Being rate-limited is one such
+ * failure — a hydration is a product read like any other, and a user who has
+ * spent the budget elsewhere gets the hit rather than an error.
  */
 export async function hydrateProduct(product: OFFProduct): Promise<OFFProduct> {
     if (product.complete) return product;
 
     logger.info("[API] Hydrating product", { code: product.code });
     try {
-        const res = await fetch(
-            `${BASE_URL}/api/v2/product/${encodeURIComponent(product.code)}?fields=${fieldsParam(FIELDS)}`,
-            { headers: { "User-Agent": USER_AGENT } },
-        );
+        const res = await fetchProduct(product.code);
         if (!res.ok) {
             logger.warn("[API] Product hydration failed", { status: res.status });
             return product;
         }
         const data: OFFProductResponse = await res.json();
-        if (data.status !== 1 || !data.product) return product;
+        if (data.result?.id !== PRODUCT_FOUND || !data.product) return product;
         return { ...mergeProduct(product, data.product), complete: true };
     } catch (err) {
         logger.warn("[API] Product hydration errored", { error: String(err) });

--- a/src/services/rateLimit.ts
+++ b/src/services/rateLimit.ts
@@ -1,0 +1,73 @@
+import i18n from "@/src/i18n";
+
+/** Every limit we honour is published per minute; nothing else has needed a window yet. */
+const DEFAULT_WINDOW_MS = 60_000;
+
+/**
+ * Thrown when a request would spend more of an API's budget than it allows.
+ * Kept apart from a network failure so the UI can say how long the wait is
+ * instead of blaming the connection.
+ */
+export class RateLimitError extends Error {
+    /**
+     * Checked in place of `instanceof`, which a subclass of a built-in does not
+     * reliably survive transpilation.
+     */
+    readonly rateLimited = true;
+
+    constructor(public readonly waitSeconds: number) {
+        super(i18n.t("common.rateLimitedWait", { seconds: waitSeconds }));
+        this.name = "RateLimitError";
+    }
+}
+
+export function isRateLimitError(err: unknown): err is RateLimitError {
+    return err instanceof Error && (err as RateLimitError).rateLimited === true;
+}
+
+export interface RateLimiter {
+    /**
+     * Claim one of the requests the window allows, or throw with the wait time.
+     * A caller that must not be charged for a request which carried nothing
+     * back `release()`s its slot again.
+     *
+     * @throws {RateLimitError} when the window is full.
+     */
+    reserve(): { release: () => void };
+}
+
+/**
+ * A client-side sliding-window request budget, one per endpoint an API
+ * publishes a limit for. Request timestamps rather than a counter, so users can
+ * burst a few requests quickly (or space them out) as long as the window stays
+ * under the cap.
+ *
+ * This is a courtesy limiter, not an enforcement one: it keeps normal use well
+ * inside what the API asks for, since the alternative is the server rate-
+ * limiting — or banning — the user's IP.
+ */
+export function createRateLimiter(
+    maxPerWindow: number,
+    windowMs: number = DEFAULT_WINDOW_MS,
+): RateLimiter {
+    const timestamps: number[] = [];
+    return {
+        reserve() {
+            const now = Date.now();
+            // Drop timestamps that have aged out of the sliding window.
+            while (timestamps.length && now - timestamps[0] >= windowMs) {
+                timestamps.shift();
+            }
+            if (timestamps.length >= maxPerWindow) {
+                throw new RateLimitError(Math.ceil((windowMs - (now - timestamps[0])) / 1000));
+            }
+            timestamps.push(now);
+            return {
+                release: () => {
+                    const i = timestamps.indexOf(now);
+                    if (i !== -1) timestamps.splice(i, 1);
+                },
+            };
+        },
+    };
+}

--- a/src/shared/components/BarcodeScannerView.tsx
+++ b/src/shared/components/BarcodeScannerView.tsx
@@ -1,3 +1,4 @@
+import { isRateLimitError } from "@/src/services/rateLimit";
 import Button from "@/src/shared/atoms/Button";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import logger from "@/src/utils/logger";
@@ -64,10 +65,12 @@ export default function BarcodeScannerView<TFood>({
             }
             resetAndClose();
             onFoodFound(food);
-        } catch {
+        } catch (err) {
             setState({
                 status: "error",
-                message: t("log.barcodeNetworkError"),
+                // A lookup turned away by OFF's rate limit knows how long the
+                // wait is; everything else is a connection the user can only retry.
+                message: isRateLimitError(err) ? err.message : t("log.barcodeNetworkError"),
             });
         }
     }


### PR DESCRIPTION
Closes #403.

Three things in `src/services/openfoodfacts.ts` that were on the wrong side of OFF's documented guidance. None was user-visible; together they are what gets an app rate-limited or IP-banned as traffic grows.

### v2 → v3 product reads

`getProductByBarcode` and `hydrateProduct` now call `/api/v3/product/<code>`, the version OFF recommends for new integrations. The envelope differs: the success check becomes `result.id === "product_found"` instead of `status: 1`, and v3 answers an unknown barcode with a 404 rather than a 200 — so that case returns `null` without logging an error. Verified against the live API (`8076809513753` → `result.id: "product_found"` with the same projected fields; `0000000000000` → 404 with `product_not_found`).

### User-Agent

Now `MacroFlow/<app.json version> (info.macroflow@gmail.com)`, the format OFF documents. The version is read via `expo-constants` rather than the hard-coded `1.0`, which had been wrong since the first release.

### Product-read rate limit

Only search was limited (10/min). Barcode lookups were uncapped, and they are reachable from the scanner in two features and from the AI tool executors, which can burst without a human pacing them.

The sliding-window limiter moves to `src/services/rateLimit.ts` as `createRateLimiter(maxPerWindow)`, and product reads get the 15 req/min instance OFF documents. A product read spends its slot whatever the answer is — unlike a search, a lookup that comes back empty is still a request OFF served and counted.

Being turned away now throws a `RateLimitError`, which `BarcodeScannerView` tells apart from a dead connection: a user who scanned too fast sees "please wait n seconds" instead of "product not found". Hydration spends from the same budget but stays best-effort — running out leaves the thinner search hit standing rather than failing the selection.

### Not in scope

The `nutriments_estimated` / `nutrition_data_prepared_per` fields the issue mentions as free additions belong to the issues that need them (#399); `FIELDS` is unchanged here.

### Testing

- `src/services/__tests__/openfoodfacts.test.ts` gains a `getProductByBarcode` block (v3 envelope, User-Agent, 404, the 15/min cap, the typed error) and the hydration tests move to the v3 envelope — 87 tests pass.
- `npm run lint` and `npx tsc --noEmit` clean.
- Live-API check of both v3 responses, as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)