### PR TITLE
Label serving units in the unit their amount was stated in

### DIFF
--- a/src/features/share/services/__tests__/sharePayloads.test.ts
+++ b/src/features/share/services/__tests__/sharePayloads.test.ts
@@ -53,13 +53,16 @@ jest.mock("@/src/features/log/services/logDb", () => ({
 }));
 
 import {
+    buildFoodPayload,
     buildLogSelectionPayload,
+    findOrCreateFood,
     itemsSignature,
     recipeSignature,
     scaleRecipeItems,
     type LogSharePayload,
     type SharedLogItem,
 } from "@/src/features/share/services/sharePayloads";
+import * as templateDb from "@/src/features/templates/services/templateDb";
 
 function entry(id: number, foodRow: Food, grams: number): EntryWithFood {
     return {
@@ -134,5 +137,52 @@ describe("buildLogSelectionPayload edit detection", () => {
         const payload = buildLogSelectionPayload(allRows, new Set([1]), undefined) as LogSharePayload;
         expect(payload.items).toHaveLength(1);
         expect(payload.items[0].type).toBe("food");
+    });
+});
+
+// #415: a serving unit knows which unit its amount was stated in, and a share
+// has to carry that or the recipient's 250 ml can turns back into "250 g".
+describe("serving unit display_unit round-trip", () => {
+    const drinkUnits = [
+        { id: 5, food_id: 1, name: "serving", grams: 250, display_unit: "ml", uuid: null },
+        { id: 6, food_id: 1, name: "package", grams: 355, display_unit: null, uuid: null },
+    ];
+
+    function importedUnits() {
+        return jest.mocked(templateDb.addServingUnit).mock.calls.map((call) => call[0]);
+    }
+
+    it("sends a ml row's unit and writes it back on import", () => {
+        jest.clearAllMocks();
+        jest.mocked(templateDb.getServingUnits).mockReturnValueOnce(drinkUnits);
+        const payload = buildFoodPayload(mockChicken, "Marco");
+        // A grams row sends no unit at all: absent already reads as grams.
+        expect(payload.food.serving_units).toEqual([
+            { name: "serving", grams: 250, display_unit: "ml" },
+            { name: "package", grams: 355 },
+        ]);
+
+        jest.mocked(templateDb.addFood).mockReturnValueOnce({ ...mockChicken, id: 9 });
+        findOrCreateFood(payload.food);
+        expect(importedUnits()).toEqual([
+            { food_id: 9, name: "serving", grams: 250, display_unit: "ml" },
+            { food_id: 9, name: "package", grams: 355, display_unit: null },
+        ]);
+    });
+
+    it("falls back to grams for a missing or unrecognised unit", () => {
+        jest.clearAllMocks();
+        jest.mocked(templateDb.addFood).mockReturnValueOnce({ ...mockChicken, id: 9 });
+        findOrCreateFood({
+            ...mockChicken,
+            serving_units: [
+                { name: "scoop", grams: 30, display_unit: "handfuls" },
+                { name: "slice", grams: 25 },
+            ],
+        });
+        expect(importedUnits()).toEqual([
+            { food_id: 9, name: "scoop", grams: 30, display_unit: null },
+            { food_id: 9, name: "slice", grams: 25, display_unit: null },
+        ]);
     });
 });

--- a/src/features/share/services/sharePayloads.ts
+++ b/src/features/share/services/sharePayloads.ts
@@ -25,12 +25,19 @@ import {
     type Food,
     type ServingUnit,
 } from "@/src/features/templates/services/templateDb";
+import { isValidUnit } from "@/src/utils/units";
 
 // ── Payload shapes (version 1) ─────────────────────────────
 
 export interface SharedServingUnit {
     name: string;
     grams: number;
+    /**
+     * The unit `grams` is labelled in ("g" / "ml" — ml is 1:1 with grams, so
+     * the number is the same either way). Absent means grams, which is also how
+     * payloads from before this field read.
+     */
+    display_unit?: string | null;
 }
 
 export interface SharedFood {
@@ -95,6 +102,17 @@ export interface LogSharePayload {
 
 // ── Builders ───────────────────────────────────────────────
 
+/**
+ * A serving unit as it travels. `display_unit` is left out when the row is
+ * grams-labelled — the recipient reads an absent one as grams anyway, and
+ * omitting it keeps payloads for grams-only foods byte-identical to older ones.
+ */
+function toSharedServingUnit(unit: ServingUnit): SharedServingUnit {
+    return unit.display_unit
+        ? { name: unit.name, grams: unit.grams, display_unit: unit.display_unit }
+        : { name: unit.name, grams: unit.grams };
+}
+
 function toSharedFood(food: Food, units: ServingUnit[]): SharedFood {
     return {
         name: food.name,
@@ -106,7 +124,7 @@ function toSharedFood(food: Food, units: ServingUnit[]): SharedFood {
         openfoodfacts_id: food.openfoodfacts_id,
         default_unit: food.default_unit,
         serving_size: food.serving_size,
-        serving_units: units.map((u) => ({ name: u.name, grams: u.grams })),
+        serving_units: units.map(toSharedServingUnit),
     };
 }
 
@@ -271,7 +289,9 @@ function foodKey(shared: SharedFood): string {
             shared.fat_per_100g,
             shared.default_unit,
             shared.serving_size,
-            (shared.serving_units ?? []).map((u) => [u.name, u.grams]),
+            // `?? null` so a payload that predates `display_unit` keys the same
+            // as a grams-labelled row here.
+            (shared.serving_units ?? []).map((u) => [u.name, u.grams, u.display_unit ?? null]),
         ])
     );
 }
@@ -282,6 +302,18 @@ function recipeKey(payload: RecipeSharePayload): string {
         payload.servings ?? 1,
         payload.items.map((item) => [foodKey(item.food), item.quantity_grams, item.quantity_unit]),
     ]);
+}
+
+/**
+ * A shared serving unit's `display_unit`, kept only when it names a unit we
+ * know: it is rendered as a label, so an unrecognised one would show up raw.
+ * Anything else — including a payload from before the field existed — is null,
+ * i.e. grams.
+ */
+function sharedDisplayUnit(unit: SharedServingUnit): string | null {
+    return typeof unit.display_unit === "string" && isValidUnit(unit.display_unit)
+        ? unit.display_unit
+        : null;
 }
 
 /**
@@ -330,7 +362,7 @@ function lookupOrCreateFood(shared: SharedFood): Food {
         const grams = num(unit.grams);
         const name = String(unit.name ?? "").trim();
         if (!name || grams <= 0) continue;
-        addServingUnit({ food_id: created.id, name, grams });
+        addServingUnit({ food_id: created.id, name, grams, display_unit: sharedDisplayUnit(unit) });
     }
     return created;
 }

--- a/src/features/templates/components/FoodForm.tsx
+++ b/src/features/templates/components/FoodForm.tsx
@@ -58,7 +58,12 @@ export default function FoodForm({ foodId, initialName, initialBarcode, notice, 
                 setBarcode(food.barcode ?? "");
                 const units = getServingUnits(foodId);
                 setServingUnitRows(
-                    units.map((u) => ({ id: u.id, name: u.name, grams: String(u.grams) })),
+                    units.map((u) => ({
+                        id: u.id,
+                        name: u.name,
+                        grams: String(u.grams),
+                        displayUnit: u.display_unit,
+                    })),
                 );
             }
         });

--- a/src/features/templates/components/ServingUnitEditor.tsx
+++ b/src/features/templates/components/ServingUnitEditor.tsx
@@ -1,5 +1,6 @@
 import Input from "@/src/shared/atoms/Input";
 import { fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
+import { servingDisplayUnit, unitLabel, type FoodUnit } from "@/src/utils/units";
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { Ionicons } from "@expo/vector-icons";
 import React from "react";
@@ -10,11 +11,26 @@ export interface ServingUnitRow {
     id?: number;
     name: string;
     grams: string;
+    /**
+     * The row's `display_unit`: the unit the amount is stated in. The value in
+     * `grams` is grams whatever this says (ml is 1:1 with grams), so it only
+     * decides the field's label. Absent/null on a hand-added row, which means
+     * grams.
+     */
+    displayUnit?: string | null;
 }
 
 interface ServingUnitEditorProps {
     rows: ServingUnitRow[];
     onChange: (rows: ServingUnitRow[]) => void;
+}
+
+/**
+ * What the amount field is called. The stored number is grams either way, so
+ * this names the unit the row is stated in rather than promising a conversion.
+ */
+function amountLabelKey(unit: FoodUnit): string {
+    return unit === "ml" ? "templates.servingUnitMilliliters" : "templates.servingUnitGrams";
 }
 
 export default function ServingUnitEditor({ rows, onChange }: ServingUnitEditorProps) {
@@ -38,33 +54,36 @@ export default function ServingUnitEditor({ rows, onChange }: ServingUnitEditorP
 
     return (
         <View>
-            {rows.map((row, idx) => (
-                <View key={row.id ?? `new-${idx}`} style={styles.servingRow}>
-                    <Input
-                        label={t("templates.servingUnitName")}
-                        placeholder={t("templates.servingUnitNamePlaceholder")}
-                        value={row.name}
-                        onChangeText={(v) => updateRow(idx, { name: v })}
-                        containerStyle={styles.servingNameField}
-                    />
-                    <Input
-                        label={t("templates.servingUnitGrams")}
-                        placeholder="0"
-                        suffix="g"
-                        value={row.grams}
-                        onChangeText={(v) => updateRow(idx, { grams: v })}
-                        keyboardType="decimal-pad"
-                        containerStyle={styles.servingGramsField}
-                    />
-                    <Pressable
-                        onPress={() => removeRow(idx)}
-                        hitSlop={8}
-                        style={styles.servingDeleteBtn}
-                    >
-                        <Ionicons name="trash-outline" size={20} color={colors.danger} />
-                    </Pressable>
-                </View>
-            ))}
+            {rows.map((row, idx) => {
+                const unit = servingDisplayUnit(row.displayUnit);
+                return (
+                    <View key={row.id ?? `new-${idx}`} style={styles.servingRow}>
+                        <Input
+                            label={t("templates.servingUnitName")}
+                            placeholder={t("templates.servingUnitNamePlaceholder")}
+                            value={row.name}
+                            onChangeText={(v) => updateRow(idx, { name: v })}
+                            containerStyle={styles.servingNameField}
+                        />
+                        <Input
+                            label={t(amountLabelKey(unit))}
+                            placeholder="0"
+                            suffix={unitLabel(unit)}
+                            value={row.grams}
+                            onChangeText={(v) => updateRow(idx, { grams: v })}
+                            keyboardType="decimal-pad"
+                            containerStyle={styles.servingGramsField}
+                        />
+                        <Pressable
+                            onPress={() => removeRow(idx)}
+                            hitSlop={8}
+                            style={styles.servingDeleteBtn}
+                        >
+                            <Ionicons name="trash-outline" size={20} color={colors.danger} />
+                        </Pressable>
+                    </View>
+                );
+            })}
             <Pressable onPress={addRow} style={styles.addServingBtn}>
                 <Ionicons name="add-circle-outline" size={20} color={colors.primary} />
                 <Text style={styles.addServingText}>{t("templates.addServingUnit")}</Text>

--- a/src/features/templates/hooks/useRecipeEditor.ts
+++ b/src/features/templates/hooks/useRecipeEditor.ts
@@ -178,7 +178,12 @@ export function useRecipeEditor() {
         const { id: _id, uuid: _uuid, pendingServingUnits: _pending, ...values } = food;
         const created = addFood(values);
         for (const unit of servingUnits) {
-            addServingUnit({ food_id: created.id, name: unit.name, grams: unit.grams });
+            addServingUnit({
+                food_id: created.id,
+                name: unit.name,
+                grams: unit.grams,
+                display_unit: unit.display_unit,
+            });
         }
         logger.info("[DB] Created food for recipe", { id: created.id, name: created.name });
         return created.id;

--- a/src/features/templates/services/templateDb.ts
+++ b/src/features/templates/services/templateDb.ts
@@ -24,11 +24,16 @@ export function addFood(food: NewFood): Food {
  */
 export function addFoodWithServingUnits(
     food: NewFood,
-    units: { name: string; grams: number }[],
+    units: { name: string; grams: number; display_unit?: string | null }[],
 ): Food {
     const created = addFood(food);
     for (const unit of units) {
-        addServingUnit({ food_id: created.id, name: unit.name, grams: unit.grams });
+        addServingUnit({
+            food_id: created.id,
+            name: unit.name,
+            grams: unit.grams,
+            display_unit: unit.display_unit ?? null,
+        });
     }
     return created;
 }
@@ -85,7 +90,9 @@ export function duplicateFood(id: number, overrides: Partial<NewFood>): Food {
     // Copy serving units to the new food
     const units = getServingUnits(id);
     for (const u of units) {
-        db.insert(servingUnits).values({ food_id: created.id, name: u.name, grams: u.grams }).run();
+        db.insert(servingUnits)
+            .values({ food_id: created.id, name: u.name, grams: u.grams, display_unit: u.display_unit })
+            .run();
     }
     return created;
 }

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -326,6 +326,7 @@ const de = {
         servingUnitName: "Name",
         servingUnitNamePlaceholder: "z. B. Würstchen, Packung",
         servingUnitGrams: "Gramm",
+        servingUnitMilliliters: "Milliliter",
         addServingUnit: "Portionseinheit hinzufügen",
         barcode: "Barcode",
         barcodePlaceholder: "z. B. 4006381333931",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -328,6 +328,7 @@ const en = {
         servingUnitName: "Name",
         servingUnitNamePlaceholder: "e.g., sausage, pack",
         servingUnitGrams: "Grams",
+        servingUnitMilliliters: "Milliliters",
         addServingUnit: "Add Serving Unit",
         barcode: "Barcode",
         barcodePlaceholder: "e.g. 4006381333931",

--- a/src/services/__tests__/openfoodfacts.test.ts
+++ b/src/services/__tests__/openfoodfacts.test.ts
@@ -642,8 +642,8 @@ describe("productToFood serving units", () => {
                 product_quantity_unit: "g",
             }),
         ).toEqual([
-            { name: "common.offServingUnitServing", grams: 100 },
-            { name: "common.offServingUnitPackage", grams: 190 },
+            { name: "common.offServingUnitServing", grams: 100, display_unit: "g" },
+            { name: "common.offServingUnitPackage", grams: 190, display_unit: "g" },
         ]);
     });
 
@@ -657,15 +657,15 @@ describe("productToFood serving units", () => {
                 product_quantity: 330,
                 product_quantity_unit: "ml",
             }),
-        ).toEqual([{ name: "common.offServingUnitServing", grams: 330 }]);
+        ).toEqual([{ name: "common.offServingUnitServing", grams: 330, display_unit: "ml" }]);
     });
 
     it("derives only what the product carries", () => {
         // Alesto nuts: a serving, no pack size.
         expect(unitsFrom({ code: "20724696", serving_quantity: 30, serving_quantity_unit: "g" }))
-            .toEqual([{ name: "common.offServingUnitServing", grams: 30 }]);
+            .toEqual([{ name: "common.offServingUnitServing", grams: 30, display_unit: "g" }]);
         expect(unitsFrom({ code: "1", product_quantity: 500, product_quantity_unit: "g" }))
-            .toEqual([{ name: "common.offServingUnitPackage", grams: 500 }]);
+            .toEqual([{ name: "common.offServingUnitPackage", grams: 500, display_unit: "g" }]);
         expect(unitsFrom({ code: "1" })).toEqual([]);
     });
 
@@ -677,7 +677,44 @@ describe("productToFood serving units", () => {
     // OFF sends these as strings on plenty of products.
     it("reads a quantity that arrived as a string", () => {
         expect(unitsFrom({ code: "1", product_quantity: "190", product_quantity_unit: "g" }))
-            .toEqual([{ name: "common.offServingUnitPackage", grams: 190 }]);
+            .toEqual([{ name: "common.offServingUnitPackage", grams: 190, display_unit: "g" }]);
+    });
+
+    // #415: the amount stays grams (ml is 1:1), but the row remembers which
+    // unit it was stated in so a 250 ml can is not labelled "serving (250 g)".
+    it("keeps each quantity's own unit for labelling", () => {
+        // Red Bull: both quantities in ml.
+        expect(
+            unitsFrom({
+                code: "9002490100070",
+                serving_quantity: 250,
+                serving_quantity_unit: "ml",
+                product_quantity: 355,
+                product_quantity_unit: "ml",
+            }),
+        ).toEqual([
+            { name: "common.offServingUnitServing", grams: 250, display_unit: "ml" },
+            { name: "common.offServingUnitPackage", grams: 355, display_unit: "ml" },
+        ]);
+        // A syrup stating a serving in ml and a bottle in g keeps both.
+        expect(
+            unitsFrom({
+                code: "2",
+                serving_quantity: 30,
+                serving_quantity_unit: "ml",
+                product_quantity: 700,
+                product_quantity_unit: "g",
+            }),
+        ).toEqual([
+            { name: "common.offServingUnitServing", grams: 30, display_unit: "ml" },
+            { name: "common.offServingUnitPackage", grams: 700, display_unit: "g" },
+        ]);
+    });
+
+    // Older products carry a quantity and no unit; grams is what that reads as.
+    it("leaves the unit null when OFF names none", () => {
+        expect(unitsFrom({ code: "1", serving_quantity: 30 }))
+            .toEqual([{ name: "common.offServingUnitServing", grams: 30, display_unit: null }]);
     });
 
     // serving_units.grams is grams; ml rides on the app's ≈1 g/ml assumption,

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -223,6 +223,9 @@ export function initDB() {
     "ALTER TABLE goals ADD COLUMN exercise_timer_sound TEXT NOT NULL DEFAULT 'off'",
     "ALTER TABLE workout_exercises ADD COLUMN superset_group TEXT",
     "ALTER TABLE recipes ADD COLUMN servings INTEGER NOT NULL DEFAULT 1",
+    // Nullable, and null means grams: existing rows are all grams-labelled, so
+    // there is nothing to backfill.
+    "ALTER TABLE serving_units ADD COLUMN display_unit TEXT",
     // Sync: stable cross-device row identity (see SYNC.md)
     ...SYNC_TABLES.map((t) => `ALTER TABLE ${t.name} ADD COLUMN uuid TEXT`),
   ];

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -95,6 +95,11 @@ export const servingUnits = sqliteTable("serving_units", {
     food_id: integer("food_id").notNull().references(() => foods.id),
     name: text("name").notNull(),
     grams: real("grams").notNull(),
+    // The unit the amount was stated in, for labelling only — "250 ml" reads
+    // wrong as "250 g". `grams` stays grams either way: ml is 1:1 with grams
+    // app-wide (src/utils/units.ts), so nothing is converted. Null means grams,
+    // which is every row that predates this column and every hand-entered one.
+    display_unit: text("display_unit"),
     uuid: text("uuid"),
 });
 

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -234,6 +234,13 @@ function parseServingSize(product: OFFProduct): number | undefined {
 export interface DerivedServingUnit {
     name: string;
     grams: number;
+    /**
+     * The unit the amount was stated in, for labelling only — a 250 ml can reads
+     * wrong as "serving (250 g)". `grams` is unaffected: OFF's two units are the
+     * same number of grams either way. Null when OFF named no unit at all, which
+     * reads as grams.
+     */
+    display_unit: string | null;
 }
 
 /** A normalized OFF quantity as grams, or undefined if there is none to store. */
@@ -251,6 +258,21 @@ function quantityGrams(
 }
 
 /**
+ * One derived row, or undefined when the quantity is not one we can store.
+ * `display_unit` is OFF's *normalized* unit rather than its raw text, so it is
+ * only ever `"g"`, `"ml"`, or null for a quantity that named no unit.
+ */
+function derivedServingUnit(
+    name: string,
+    value: number | string | undefined,
+    unit: string | undefined,
+): DerivedServingUnit | undefined {
+    const grams = quantityGrams(value, unit);
+    if (grams === undefined) return undefined;
+    return { name, grams, display_unit: storableUnit(unit) ?? null };
+}
+
+/**
  * The serving units OFF's two quantities imply: one serving, and the whole
  * package. Scan a jar of pesto and both "1 serving" and "1 package (190 g)" are
  * there, rather than the user hand-building a fact OFF already published.
@@ -264,14 +286,18 @@ function quantityGrams(
  */
 function servingUnitsFromProduct(product: OFFProduct): DerivedServingUnit[] {
     const units: DerivedServingUnit[] = [];
-    const serving = quantityGrams(product.serving_quantity, product.serving_quantity_unit);
-    if (serving !== undefined) {
-        units.push({ name: i18n.t("common.offServingUnitServing"), grams: serving });
-    }
-    const pack = quantityGrams(product.product_quantity, product.product_quantity_unit);
-    if (pack !== undefined && pack !== serving) {
-        units.push({ name: i18n.t("common.offServingUnitPackage"), grams: pack });
-    }
+    const serving = derivedServingUnit(
+        i18n.t("common.offServingUnitServing"),
+        product.serving_quantity,
+        product.serving_quantity_unit,
+    );
+    if (serving) units.push(serving);
+    const pack = derivedServingUnit(
+        i18n.t("common.offServingUnitPackage"),
+        product.product_quantity,
+        product.product_quantity_unit,
+    );
+    if (pack && pack.grams !== serving?.grams) units.push(pack);
     return units;
 }
 

--- a/src/shared/components/UnitPicker.tsx
+++ b/src/shared/components/UnitPicker.tsx
@@ -1,6 +1,6 @@
 import { useThemeColors } from "@/src/shared/providers/ThemeProvider";
 import { borderRadius, fontSize, spacing, type ThemeColors } from "@/src/utils/theme";
-import { unitLabel, type FoodUnit } from "@/src/utils/units";
+import { formatQuantity, servingDisplayUnit, unitLabel, type FoodUnit } from "@/src/utils/units";
 import { Ionicons } from "@expo/vector-icons";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -17,6 +17,8 @@ export interface ServingUnit {
     id: number;
     name: string;
     grams: number;
+    /** Unit the amount is labelled in; null/absent means grams. */
+    display_unit?: string | null;
 }
 
 interface UnitPickerProps<TUnit extends ServingUnit = ServingUnit> {
@@ -97,7 +99,7 @@ export default function UnitPicker<TUnit extends ServingUnit = ServingUnit>({
                                 selectedServingUnit?.id === su.id && styles.unitChipTextActive,
                             ]}
                         >
-                            {su.name} ({su.grams}g)
+                            {su.name} ({formatQuantity(su.grams, servingDisplayUnit(su.display_unit))})
                         </Text>
                     </Pressable>
                 ))}

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -82,6 +82,17 @@ export function isValidUnit(s: string): s is FoodUnit {
 }
 
 /**
+ * The unit a serving unit's stored amount should be *labelled* in, from its
+ * `display_unit` column. The amount itself is always grams — a 250 ml can is
+ * stored as 250 because ml is 1:1 with grams here — so this only picks the name
+ * to print. Null/unknown means grams: that is every row written before the
+ * column existed, and every hand-entered one.
+ */
+export function servingDisplayUnit(displayUnit: string | null | undefined): FoodUnit {
+    return displayUnit && isValidUnit(displayUnit) ? displayUnit : "g";
+}
+
+/**
  * Format an entry's stored quantity_grams + quantity_unit for display.
  * Handles both standard units and custom serving unit names.
  */


### PR DESCRIPTION
Closes #415.

## What

A 250 ml can of Red Bull showed up in the unit picker as `serving (250g)`. OFF publishes the unit — `serving_quantity_unit` / `product_quantity_unit`, normalized to exactly `"g"` or `"ml"` — and `guessUnit` already reads it for `foods.default_unit`, but it was dropped on the way to `serving_units` (which had only a `grams` column) and `UnitPicker` hard-coded the `g`.

- `serving_units` gains a **nullable `display_unit`** text column, set in `servingUnitsFromProduct` from the unit each of OFF's two quantities was stated in (serving row ← `serving_quantity_unit`, package row ← `product_quantity_unit`). Only the *normalized* storable unit is stored, never OFF's raw text, so the column only ever holds `"g"`, `"ml"` or null.
- **Null means grams.** That is every pre-existing row and every hand-entered one, so there is no backfill.
- Carried through the write paths: `addFoodWithServingUnits`, `duplicateFood`, `materializeFood` (recipe editor), the share importer.
- The label now comes from the row's own unit via the new `servingDisplayUnit()` + the existing `formatQuantity()` — in the picker chips (`serving (250 ml)`) and in `ServingUnitEditor`, whose amount field was hard-labelled "Grams" with a `g` suffix. New key `templates.servingUnitMilliliters` added to both `en.ts` and `de.ts`.

## No data conversion

`ml` is 1:1 with grams app-wide (`src/utils/units.ts`), so the stored `250` is already the right number under either name. `grams` stays grams; this changes only what the number is *called*. The upside over deriving the label from the food's `default_unit` is a food that mixes the two — a syrup with `serving (30 ml)` and `bottle (700 g)` — and a food whose `default_unit` the user later changes.

## Migration

One statement appended to the migrations list in `initDB()` (nothing earlier rewritten or reordered):

```
ALTER TABLE serving_units ADD COLUMN display_unit TEXT
```

## Share / backup / sync

Shares serialize serving units field by field, so `SharedServingUnit` carries `display_unit` too. It is omitted when the row is grams-labelled — an absent one already reads as grams, and payloads for grams-only foods stay byte-identical to older ones. A value that names no unit we know is dropped to grams on import rather than rendered raw. `foodKey` includes it (normalized with `?? null`, so an older payload keys identically to a grams row). The backup (`importExport.ts`) and sync (`syncEngine.ts`) paths copy whole rows (`SELECT *` / `PRAGMA table_info`), so they needed no change.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run lint` — clean.
- `npm test` — 4 suites, 91 tests passing. Existing OFF serving-unit expectations updated for the new field, plus new cases for a ml-labelled product (Red Bull `9002490100070`), a food mixing ml and g rows, and a quantity OFF states with no unit (→ null). Two new share tests cover the `display_unit` round-trip through `buildFoodPayload` → `findOrCreateFood`, including the unrecognised-unit fallback.
- Not verified on a device: the migration and the rendered chips were not exercised against a real SQLite install / running app.

Out of scope, deliberately: pre-selecting the serving unit and the `kind` column (#414, stacked on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)