### PR TITLE
Open a first-time OFF food's amount form on one serving (closes #414)

### DIFF
--- a/src/features/log/hooks/useEntryForm.ts
+++ b/src/features/log/hooks/useEntryForm.ts
@@ -1,5 +1,6 @@
 import { getServingUnits, updateFood, type Food, type ServingUnit } from "@/src/features/templates/services/templateDb";
 import { cancelMealReminderIfLogged } from "@/src/services/notifications";
+import { servingUnitToPreselect } from "@/src/services/servingUnits";
 import { useAppStore } from "@/src/shared/store/useAppStore";
 import { type MealType } from "@/src/shared/types";
 import logger from "@/src/utils/logger";
@@ -69,6 +70,9 @@ export function useEntryForm({ food, defaultMealType, entry, onClose, onSaved }:
                 }
             } else {
                 const sUnits = food.id ? getServingUnits(food.id) : [];
+                // Undefined for a food that has been logged before, so the
+                // remembered unit below keeps precedence.
+                const preselect = servingUnitToPreselect(food, sUnits);
                 if (food.last_logged_amount != null && food.last_logged_unit != null) {
                     const lastUnit = food.last_logged_unit;
                     const matchServing = sUnits.find((s) => s.name === lastUnit);
@@ -80,6 +84,13 @@ export function useEntryForm({ food, defaultMealType, entry, onClose, onSaved }:
                         setUnit(lastUnit as FoodUnit);
                     }
                     setQuantity(String(food.last_logged_amount));
+                } else if (preselect) {
+                    // Never logged, but OpenFoodFacts told us what one serving
+                    // of it is: open on that chip at 1, which is the amount the
+                    // derived row exists to offer.
+                    setCustomServingUnit(preselect);
+                    setUnit("g");
+                    setQuantity("1");
                 } else {
                     const defaultUnit = (food.default_unit ?? "g") as FoodUnit;
                     setUnit(defaultUnit);

--- a/src/features/share/services/__tests__/sharePayloads.test.ts
+++ b/src/features/share/services/__tests__/sharePayloads.test.ts
@@ -143,9 +143,11 @@ describe("buildLogSelectionPayload edit detection", () => {
 // #415: a serving unit knows which unit its amount was stated in, and a share
 // has to carry that or the recipient's 250 ml can turns back into "250 g".
 describe("serving unit display_unit round-trip", () => {
+    // `kind: null` here so this stays a test about display_unit alone; the kind
+    // marker gets its own round-trip below.
     const drinkUnits = [
-        { id: 5, food_id: 1, name: "serving", grams: 250, display_unit: "ml", uuid: null },
-        { id: 6, food_id: 1, name: "package", grams: 355, display_unit: null, uuid: null },
+        { id: 5, food_id: 1, name: "serving", grams: 250, display_unit: "ml", kind: null, uuid: null },
+        { id: 6, food_id: 1, name: "package", grams: 355, display_unit: null, kind: null, uuid: null },
     ];
 
     function importedUnits() {
@@ -165,8 +167,8 @@ describe("serving unit display_unit round-trip", () => {
         jest.mocked(templateDb.addFood).mockReturnValueOnce({ ...mockChicken, id: 9 });
         findOrCreateFood(payload.food);
         expect(importedUnits()).toEqual([
-            { food_id: 9, name: "serving", grams: 250, display_unit: "ml" },
-            { food_id: 9, name: "package", grams: 355, display_unit: null },
+            { food_id: 9, name: "serving", grams: 250, display_unit: "ml", kind: null },
+            { food_id: 9, name: "package", grams: 355, display_unit: null, kind: null },
         ]);
     });
 
@@ -181,8 +183,70 @@ describe("serving unit display_unit round-trip", () => {
             ],
         });
         expect(importedUnits()).toEqual([
-            { food_id: 9, name: "scoop", grams: 30, display_unit: null },
-            { food_id: 9, name: "slice", grams: 25, display_unit: null },
+            { food_id: 9, name: "scoop", grams: 30, display_unit: null, kind: null },
+            { food_id: 9, name: "slice", grams: 25, display_unit: null, kind: null },
         ]);
+    });
+});
+
+// #414: the kind marker is what makes the OFF serving row identifiable, so a
+// shared food has to carry it — otherwise the recipient's copy loses the
+// pre-selection that the sender's had.
+describe("serving unit kind round-trip", () => {
+    const offUnits = [
+        { id: 5, food_id: 1, name: "Portion", grams: 30, display_unit: "g", kind: "serving", uuid: null },
+        { id: 6, food_id: 1, name: "Packung", grams: 500, display_unit: "g", kind: "package", uuid: null },
+        { id: 7, food_id: 1, name: "handful", grams: 20, display_unit: null, kind: null, uuid: null },
+    ];
+
+    function importedUnits() {
+        return jest.mocked(templateDb.addServingUnit).mock.calls.map((call) => call[0]);
+    }
+
+    it("sends each row's kind and writes it back on import", () => {
+        jest.clearAllMocks();
+        jest.mocked(templateDb.getServingUnits).mockReturnValueOnce(offUnits);
+        const payload = buildFoodPayload(mockChicken, "Marco");
+        // The hand-added row sends no kind: absent already reads as "not OFF's".
+        expect(payload.food.serving_units).toEqual([
+            { name: "Portion", grams: 30, display_unit: "g", kind: "serving" },
+            { name: "Packung", grams: 500, display_unit: "g", kind: "package" },
+            { name: "handful", grams: 20 },
+        ]);
+
+        jest.mocked(templateDb.addFood).mockReturnValueOnce({ ...mockChicken, id: 9 });
+        findOrCreateFood(payload.food);
+        expect(importedUnits()).toEqual([
+            { food_id: 9, name: "Portion", grams: 30, display_unit: "g", kind: "serving" },
+            { food_id: 9, name: "Packung", grams: 500, display_unit: "g", kind: "package" },
+            { food_id: 9, name: "handful", grams: 20, display_unit: null, kind: null },
+        ]);
+    });
+
+    it("drops a kind it does not recognise, and a missing one", () => {
+        jest.clearAllMocks();
+        jest.mocked(templateDb.addFood).mockReturnValueOnce({ ...mockChicken, id: 9 });
+        findOrCreateFood({
+            ...mockChicken,
+            serving_units: [
+                { name: "scoop", grams: 30, kind: "whole-shelf" },
+                { name: "slice", grams: 25 },
+            ],
+        });
+        expect(importedUnits()).toEqual([
+            { food_id: 9, name: "scoop", grams: 30, display_unit: null, kind: null },
+            { food_id: 9, name: "slice", grams: 25, display_unit: null, kind: null },
+        ]);
+    });
+
+    // A payload for a plain grams-only food must stay exactly as it was before
+    // either column existed, or every recipient sees "not yet imported".
+    it("leaves a payload without either marker byte-identical", () => {
+        jest.clearAllMocks();
+        jest.mocked(templateDb.getServingUnits).mockReturnValueOnce([
+            { id: 5, food_id: 1, name: "slice", grams: 25, display_unit: null, kind: null, uuid: null },
+        ]);
+        expect(JSON.stringify(buildFoodPayload(mockChicken).food.serving_units))
+            .toBe('[{"name":"slice","grams":25}]');
     });
 });

--- a/src/features/share/services/sharePayloads.ts
+++ b/src/features/share/services/sharePayloads.ts
@@ -25,6 +25,7 @@ import {
     type Food,
     type ServingUnit,
 } from "@/src/features/templates/services/templateDb";
+import { isServingUnitKind, type ServingUnitKind } from "@/src/services/servingUnits";
 import { isValidUnit } from "@/src/utils/units";
 
 // ── Payload shapes (version 1) ─────────────────────────────
@@ -38,6 +39,12 @@ export interface SharedServingUnit {
      * payloads from before this field read.
      */
     display_unit?: string | null;
+    /**
+     * Which OpenFoodFacts quantity the row came from ("serving" / "package").
+     * Absent on a hand-added row, and on every payload built before this field
+     * existed — both of which read as "not an OFF-derived row".
+     */
+    kind?: string | null;
 }
 
 export interface SharedFood {
@@ -103,14 +110,18 @@ export interface LogSharePayload {
 // ── Builders ───────────────────────────────────────────────
 
 /**
- * A serving unit as it travels. `display_unit` is left out when the row is
- * grams-labelled — the recipient reads an absent one as grams anyway, and
- * omitting it keeps payloads for grams-only foods byte-identical to older ones.
+ * A serving unit as it travels. `display_unit` and `kind` are each left out when
+ * null — the recipient reads an absent `display_unit` as grams and an absent
+ * `kind` as a hand-added row anyway, and omitting them keeps payloads for plain
+ * grams-only foods byte-identical to older ones.
  */
 function toSharedServingUnit(unit: ServingUnit): SharedServingUnit {
-    return unit.display_unit
-        ? { name: unit.name, grams: unit.grams, display_unit: unit.display_unit }
-        : { name: unit.name, grams: unit.grams };
+    return {
+        name: unit.name,
+        grams: unit.grams,
+        ...(unit.display_unit ? { display_unit: unit.display_unit } : {}),
+        ...(unit.kind ? { kind: unit.kind } : {}),
+    };
 }
 
 function toSharedFood(food: Food, units: ServingUnit[]): SharedFood {
@@ -289,9 +300,14 @@ function foodKey(shared: SharedFood): string {
             shared.fat_per_100g,
             shared.default_unit,
             shared.serving_size,
-            // `?? null` so a payload that predates `display_unit` keys the same
-            // as a grams-labelled row here.
-            (shared.serving_units ?? []).map((u) => [u.name, u.grams, u.display_unit ?? null]),
+            // `?? null` so a payload that predates `display_unit` / `kind` keys
+            // the same as a grams-labelled, hand-added row here.
+            (shared.serving_units ?? []).map((u) => [
+                u.name,
+                u.grams,
+                u.display_unit ?? null,
+                u.kind ?? null,
+            ]),
         ])
     );
 }
@@ -314,6 +330,16 @@ function sharedDisplayUnit(unit: SharedServingUnit): string | null {
     return typeof unit.display_unit === "string" && isValidUnit(unit.display_unit)
         ? unit.display_unit
         : null;
+}
+
+/**
+ * A shared serving unit's `kind`, kept only when it names one we know. It
+ * decides whether an amount form opens pre-selected on the row, so an
+ * unrecognised value is dropped to null (a plain, never-pre-selected row) rather
+ * than trusted — as is a payload from before the field existed.
+ */
+function sharedKind(unit: SharedServingUnit): ServingUnitKind | null {
+    return isServingUnitKind(unit.kind) ? unit.kind : null;
 }
 
 /**
@@ -362,7 +388,13 @@ function lookupOrCreateFood(shared: SharedFood): Food {
         const grams = num(unit.grams);
         const name = String(unit.name ?? "").trim();
         if (!name || grams <= 0) continue;
-        addServingUnit({ food_id: created.id, name, grams, display_unit: sharedDisplayUnit(unit) });
+        addServingUnit({
+            food_id: created.id,
+            name,
+            grams,
+            display_unit: sharedDisplayUnit(unit),
+            kind: sharedKind(unit),
+        });
     }
     return created;
 }

--- a/src/features/templates/hooks/useRecipeEditor.ts
+++ b/src/features/templates/hooks/useRecipeEditor.ts
@@ -1,3 +1,4 @@
+import { servingUnitToPreselect } from "@/src/services/servingUnits";
 import logger from "@/src/utils/logger";
 import type { FoodUnit } from "@/src/utils/units";
 import { fromGrams, isValidUnit, toGrams } from "@/src/utils/units";
@@ -86,16 +87,22 @@ export function useRecipeEditor() {
     /** A food was picked in the search sheet: open the amount sheet for it. */
     function openDraftForFood(food: UnsavedFood) {
         const foodUnit = (food.default_unit ?? "g") as FoodUnit;
+        // A food that is not in the library yet has no rows to read, but an
+        // OpenFoodFacts import may have derived some for it already.
+        const servingUnits = food.id ? getServingUnits(food.id) : food.pendingServingUnits ?? [];
+        // A first-time OFF food opens on "1 serving" rather than on its default
+        // unit, since that is the amount the derived row exists to offer. The
+        // sheet matches the unit back by name (see RecipeItemModal), so one
+        // serving is 1 × its grams.
+        const preselect = servingUnitToPreselect(food, servingUnits);
         setEditing({
             isNew: true,
             draft: {
                 key: nextDraftKey(),
                 food,
-                quantityGrams: toGrams(food.serving_size ?? 100, foodUnit),
-                quantityUnit: foodUnit,
-                // A food that is not in the library yet has no rows to read, but
-                // an OpenFoodFacts import may have derived some for it already.
-                servingUnits: food.id ? getServingUnits(food.id) : food.pendingServingUnits ?? [],
+                quantityGrams: preselect ? preselect.grams : toGrams(food.serving_size ?? 100, foodUnit),
+                quantityUnit: preselect ? preselect.name : foodUnit,
+                servingUnits,
             },
         });
     }
@@ -183,6 +190,7 @@ export function useRecipeEditor() {
                 name: unit.name,
                 grams: unit.grams,
                 display_unit: unit.display_unit,
+                kind: unit.kind,
             });
         }
         logger.info("[DB] Created food for recipe", { id: created.id, name: created.name });

--- a/src/features/templates/services/templateDb.ts
+++ b/src/features/templates/services/templateDb.ts
@@ -24,7 +24,7 @@ export function addFood(food: NewFood): Food {
  */
 export function addFoodWithServingUnits(
     food: NewFood,
-    units: { name: string; grams: number; display_unit?: string | null }[],
+    units: { name: string; grams: number; display_unit?: string | null; kind?: string | null }[],
 ): Food {
     const created = addFood(food);
     for (const unit of units) {
@@ -33,6 +33,7 @@ export function addFoodWithServingUnits(
             name: unit.name,
             grams: unit.grams,
             display_unit: unit.display_unit ?? null,
+            kind: unit.kind ?? null,
         });
     }
     return created;
@@ -91,7 +92,13 @@ export function duplicateFood(id: number, overrides: Partial<NewFood>): Food {
     const units = getServingUnits(id);
     for (const u of units) {
         db.insert(servingUnits)
-            .values({ food_id: created.id, name: u.name, grams: u.grams, display_unit: u.display_unit })
+            .values({
+                food_id: created.id,
+                name: u.name,
+                grams: u.grams,
+                display_unit: u.display_unit,
+                kind: u.kind,
+            })
             .run();
     }
     return created;

--- a/src/services/__tests__/openfoodfacts.test.ts
+++ b/src/services/__tests__/openfoodfacts.test.ts
@@ -642,8 +642,8 @@ describe("productToFood serving units", () => {
                 product_quantity_unit: "g",
             }),
         ).toEqual([
-            { name: "common.offServingUnitServing", grams: 100, display_unit: "g" },
-            { name: "common.offServingUnitPackage", grams: 190, display_unit: "g" },
+            { name: "common.offServingUnitServing", grams: 100, display_unit: "g", kind: "serving" },
+            { name: "common.offServingUnitPackage", grams: 190, display_unit: "g", kind: "package" },
         ]);
     });
 
@@ -657,15 +657,15 @@ describe("productToFood serving units", () => {
                 product_quantity: 330,
                 product_quantity_unit: "ml",
             }),
-        ).toEqual([{ name: "common.offServingUnitServing", grams: 330, display_unit: "ml" }]);
+        ).toEqual([{ name: "common.offServingUnitServing", grams: 330, display_unit: "ml", kind: "serving" }]);
     });
 
     it("derives only what the product carries", () => {
         // Alesto nuts: a serving, no pack size.
         expect(unitsFrom({ code: "20724696", serving_quantity: 30, serving_quantity_unit: "g" }))
-            .toEqual([{ name: "common.offServingUnitServing", grams: 30, display_unit: "g" }]);
+            .toEqual([{ name: "common.offServingUnitServing", grams: 30, display_unit: "g", kind: "serving" }]);
         expect(unitsFrom({ code: "1", product_quantity: 500, product_quantity_unit: "g" }))
-            .toEqual([{ name: "common.offServingUnitPackage", grams: 500, display_unit: "g" }]);
+            .toEqual([{ name: "common.offServingUnitPackage", grams: 500, display_unit: "g", kind: "package" }]);
         expect(unitsFrom({ code: "1" })).toEqual([]);
     });
 
@@ -677,7 +677,7 @@ describe("productToFood serving units", () => {
     // OFF sends these as strings on plenty of products.
     it("reads a quantity that arrived as a string", () => {
         expect(unitsFrom({ code: "1", product_quantity: "190", product_quantity_unit: "g" }))
-            .toEqual([{ name: "common.offServingUnitPackage", grams: 190, display_unit: "g" }]);
+            .toEqual([{ name: "common.offServingUnitPackage", grams: 190, display_unit: "g", kind: "package" }]);
     });
 
     // #415: the amount stays grams (ml is 1:1), but the row remembers which
@@ -693,8 +693,8 @@ describe("productToFood serving units", () => {
                 product_quantity_unit: "ml",
             }),
         ).toEqual([
-            { name: "common.offServingUnitServing", grams: 250, display_unit: "ml" },
-            { name: "common.offServingUnitPackage", grams: 355, display_unit: "ml" },
+            { name: "common.offServingUnitServing", grams: 250, display_unit: "ml", kind: "serving" },
+            { name: "common.offServingUnitPackage", grams: 355, display_unit: "ml", kind: "package" },
         ]);
         // A syrup stating a serving in ml and a bottle in g keeps both.
         expect(
@@ -706,15 +706,46 @@ describe("productToFood serving units", () => {
                 product_quantity_unit: "g",
             }),
         ).toEqual([
-            { name: "common.offServingUnitServing", grams: 30, display_unit: "ml" },
-            { name: "common.offServingUnitPackage", grams: 700, display_unit: "g" },
+            { name: "common.offServingUnitServing", grams: 30, display_unit: "ml", kind: "serving" },
+            { name: "common.offServingUnitPackage", grams: 700, display_unit: "g", kind: "package" },
         ]);
     });
 
     // Older products carry a quantity and no unit; grams is what that reads as.
     it("leaves the unit null when OFF names none", () => {
         expect(unitsFrom({ code: "1", serving_quantity: 30 }))
-            .toEqual([{ name: "common.offServingUnitServing", grams: 30, display_unit: null }]);
+            .toEqual([{ name: "common.offServingUnitServing", grams: 30, display_unit: null, kind: "serving" }]);
+    });
+
+    // #414: an amount form pre-selects the serving row, so it has to be findable
+    // — by this marker rather than by name, since names are translated at import
+    // time and frozen in the DB ("Portion" for a German import).
+    it("marks which of OFF's two quantities each row came from", () => {
+        expect(
+            unitsFrom({
+                code: "20724696",
+                serving_quantity: 30,
+                serving_quantity_unit: "g",
+                product_quantity: 500,
+                product_quantity_unit: "g",
+            }).map((u) => u.kind),
+        ).toEqual(["serving", "package"]);
+        // Only a pack size: a "package" row and no "serving" one, so there is
+        // nothing for the amount form to pre-select.
+        expect(
+            unitsFrom({ code: "1", product_quantity: 500, product_quantity_unit: "g" })
+                .map((u) => u.kind),
+        ).toEqual(["package"]);
+        // The can whose package is exactly one serving keeps the serving row.
+        expect(
+            unitsFrom({
+                code: "5449000000996",
+                serving_quantity: 330,
+                serving_quantity_unit: "ml",
+                product_quantity: 330,
+                product_quantity_unit: "ml",
+            }).map((u) => u.kind),
+        ).toEqual(["serving"]);
     });
 
     // serving_units.grams is grams; ml rides on the app's ≈1 g/ml assumption,

--- a/src/services/__tests__/servingUnits.test.ts
+++ b/src/services/__tests__/servingUnits.test.ts
@@ -1,0 +1,71 @@
+// #414: which serving unit an amount form opens pre-selected. Pure logic over
+// rows that are passed in, so it needs no DB and no mocks.
+
+import { describe, expect, it } from "@jest/globals";
+import { isServingUnitKind, servingUnitToPreselect } from "@/src/services/servingUnits";
+
+const neverLogged = { last_logged_amount: null, last_logged_unit: null };
+
+// Named as a German import would be, to make the point that nothing here reads
+// the name: names are translated once at import and then frozen in the DB.
+const offServing = { name: "Portion", grams: 30, kind: "serving" };
+const offPackage = { name: "Packung", grams: 500, kind: "package" };
+const handAdded = { name: "handful", grams: 20, kind: null };
+
+describe("servingUnitToPreselect", () => {
+    it("picks the OFF serving row for a food that has never been logged", () => {
+        expect(servingUnitToPreselect(neverLogged, [offServing, offPackage])).toBe(offServing);
+        // Order in the list is not what makes it the serving row.
+        expect(servingUnitToPreselect(neverLogged, [offPackage, offServing])).toBe(offServing);
+    });
+
+    // Defaulting a 1 kg bag of rice to logging the whole bag would be worse than
+    // defaulting it to 100 g.
+    it("never picks the package row", () => {
+        expect(servingUnitToPreselect(neverLogged, [offPackage])).toBeUndefined();
+    });
+
+    // The rule is "the OFF serving row", not "the first serving unit" — a row we
+    // did not derive says nothing about what one serving is.
+    it("ignores a hand-added row", () => {
+        expect(servingUnitToPreselect(neverLogged, [handAdded])).toBeUndefined();
+        expect(servingUnitToPreselect(neverLogged, [handAdded, offServing])).toBe(offServing);
+    });
+
+    // Every row that predates the kind column reads as hand-added, which is the
+    // safe way round: those foods keep behaving exactly as they did.
+    it("ignores a row whose kind is absent or unrecognised", () => {
+        expect(servingUnitToPreselect(neverLogged, [{ name: "slice", grams: 25 }])).toBeUndefined();
+        expect(
+            servingUnitToPreselect(neverLogged, [{ name: "slice", grams: 25, kind: "shelf" }]),
+        ).toBeUndefined();
+    });
+
+    it("keeps out of the way of a food the user has logged before", () => {
+        const logged = { last_logged_amount: 250, last_logged_unit: "ml" };
+        expect(servingUnitToPreselect(logged, [offServing, offPackage])).toBeUndefined();
+        // Both halves of the remembered choice have to be there to count, which
+        // is the same condition the entry form has always used.
+        expect(
+            servingUnitToPreselect({ last_logged_amount: 250, last_logged_unit: null }, [offServing]),
+        ).toBe(offServing);
+        expect(
+            servingUnitToPreselect({ last_logged_amount: null, last_logged_unit: "ml" }, [offServing]),
+        ).toBe(offServing);
+    });
+
+    it("has nothing to offer a food with no serving units", () => {
+        expect(servingUnitToPreselect(neverLogged, [])).toBeUndefined();
+    });
+});
+
+describe("isServingUnitKind", () => {
+    it("accepts only the two markers we write", () => {
+        expect(isServingUnitKind("serving")).toBe(true);
+        expect(isServingUnitKind("package")).toBe(true);
+        expect(isServingUnitKind(null)).toBe(false);
+        expect(isServingUnitKind(undefined)).toBe(false);
+        expect(isServingUnitKind("Portion")).toBe(false);
+        expect(isServingUnitKind(1)).toBe(false);
+    });
+});

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -226,6 +226,10 @@ export function initDB() {
     // Nullable, and null means grams: existing rows are all grams-labelled, so
     // there is nothing to backfill.
     "ALTER TABLE serving_units ADD COLUMN display_unit TEXT",
+    // Nullable, and null is correct for every existing row: they were written
+    // before the marker existed and there is no way to tell now which of them
+    // came from OFF's serving quantity, so there is nothing to backfill.
+    "ALTER TABLE serving_units ADD COLUMN kind TEXT",
     // Sync: stable cross-device row identity (see SYNC.md)
     ...SYNC_TABLES.map((t) => `ALTER TABLE ${t.name} ADD COLUMN uuid TEXT`),
   ];

--- a/src/services/db/schema.ts
+++ b/src/services/db/schema.ts
@@ -100,6 +100,12 @@ export const servingUnits = sqliteTable("serving_units", {
     // app-wide (src/utils/units.ts), so nothing is converted. Null means grams,
     // which is every row that predates this column and every hand-entered one.
     display_unit: text("display_unit"),
+    // Which OpenFoodFacts quantity the row was derived from ("serving" /
+    // "package", see src/services/servingUnits.ts), so the two can be told apart
+    // without reading the name — names are translated at import time and frozen
+    // here, so a German import says "Portion". Null on every hand-added row and
+    // on every row that predates this column.
+    kind: text("kind"),
     uuid: text("uuid"),
 });
 

--- a/src/services/openfoodfacts.ts
+++ b/src/services/openfoodfacts.ts
@@ -6,6 +6,11 @@ import {
     type OFFNutriments,
 } from "@/src/services/offNutriments";
 import { createRateLimiter } from "@/src/services/rateLimit";
+import {
+    SERVING_UNIT_KIND_PACKAGE,
+    SERVING_UNIT_KIND_SERVING,
+    type ServingUnitKind,
+} from "@/src/services/servingUnits";
 import logger from "@/src/utils/logger";
 import type { FoodUnit } from "@/src/utils/units";
 import Constants from "expo-constants";
@@ -241,6 +246,13 @@ export interface DerivedServingUnit {
      * reads as grams.
      */
     display_unit: string | null;
+    /**
+     * Which of OFF's two quantities this row is. Stored so a consumer can tell
+     * "one serving" from "the whole package" without reading the name, which is
+     * translated here and then frozen in the DB. Only the serving row is ever
+     * pre-selected in an amount form (#414).
+     */
+    kind: ServingUnitKind;
 }
 
 /** A normalized OFF quantity as grams, or undefined if there is none to store. */
@@ -263,13 +275,14 @@ function quantityGrams(
  * only ever `"g"`, `"ml"`, or null for a quantity that named no unit.
  */
 function derivedServingUnit(
+    kind: ServingUnitKind,
     name: string,
     value: number | string | undefined,
     unit: string | undefined,
 ): DerivedServingUnit | undefined {
     const grams = quantityGrams(value, unit);
     if (grams === undefined) return undefined;
-    return { name, grams, display_unit: storableUnit(unit) ?? null };
+    return { name, grams, display_unit: storableUnit(unit) ?? null, kind };
 }
 
 /**
@@ -287,12 +300,14 @@ function derivedServingUnit(
 function servingUnitsFromProduct(product: OFFProduct): DerivedServingUnit[] {
     const units: DerivedServingUnit[] = [];
     const serving = derivedServingUnit(
+        SERVING_UNIT_KIND_SERVING,
         i18n.t("common.offServingUnitServing"),
         product.serving_quantity,
         product.serving_quantity_unit,
     );
     if (serving) units.push(serving);
     const pack = derivedServingUnit(
+        SERVING_UNIT_KIND_PACKAGE,
         i18n.t("common.offServingUnitPackage"),
         product.product_quantity,
         product.product_quantity_unit,

--- a/src/services/servingUnits.ts
+++ b/src/services/servingUnits.ts
@@ -1,0 +1,79 @@
+// The `serving_units.kind` marker and the one rule that reads it: which serving
+// unit an amount form opens with selected. Logging an entry and adding a recipe
+// ingredient ask the same question, so the answer lives here — an app-wide
+// service both features may import — rather than once in each feature's hook.
+
+/**
+ * Which of OpenFoodFacts' two quantities a derived serving unit came from,
+ * stored in `serving_units.kind` at import time.
+ *
+ * Deliberately not the row's *name*: names are translated once, at import
+ * (`i18n.t("common.offServingUnitServing")`), and then frozen in the DB, so a
+ * food imported in German carries "Portion" and matching an English string
+ * would silently never fire. Also not the `grams === food.serving_size`
+ * heuristic, which holds for OFF imports by construction but misfires on a
+ * hand-added row of the same size.
+ */
+export type ServingUnitKind = "serving" | "package";
+
+/** One serving of the product, from OFF's `serving_quantity`. */
+export const SERVING_UNIT_KIND_SERVING: ServingUnitKind = "serving";
+
+/** The whole package, from OFF's `product_quantity`. */
+export const SERVING_UNIT_KIND_PACKAGE: ServingUnitKind = "package";
+
+/**
+ * Whether a value that came back from the DB or off a share payload names a
+ * kind we know. Null — every hand-added row, and every row written before the
+ * column existed — is not one.
+ */
+export function isServingUnitKind(value: unknown): value is ServingUnitKind {
+    return value === SERVING_UNIT_KIND_SERVING || value === SERVING_UNIT_KIND_PACKAGE;
+}
+
+/** The part of a `serving_units` row the rule below reads. */
+interface KindedServingUnit {
+    name: string;
+    grams: number;
+    kind?: string | null;
+}
+
+/** The part of a `foods` row the rule below reads. */
+interface PreviouslyLoggedFood {
+    last_logged_amount?: number | null;
+    last_logged_unit?: string | null;
+}
+
+/**
+ * True once the food has been logged, i.e. once the user has made a choice of
+ * unit and amount that is worth restoring over any guess of ours.
+ */
+function hasLoggingHistory(food: PreviouslyLoggedFood): boolean {
+    return food.last_logged_amount != null && food.last_logged_unit != null;
+}
+
+/**
+ * The serving unit an amount form should open with selected — always at amount
+ * `1`, which is the number a user thinks in — or undefined to keep the existing
+ * default of `default_unit` + `serving_size`.
+ *
+ * The rule, narrowly:
+ *
+ * - A food with logging history gets nothing: `last_logged_unit` wins, as it
+ *   already did. This only ever changes the first-time case.
+ * - Only the OFF *serving* row is offered. The package row never is —
+ *   pre-selecting it would default a 1 kg bag of rice to logging the whole bag.
+ * - A row with no `kind` is not the OFF serving row, so a hand-added serving
+ *   unit does not trigger this. That is the honest reading of "the derived
+ *   serving unit"; widening it to "the first serving unit" is a separate
+ *   decision (see #414).
+ * - A food with no derived serving row therefore keeps today's behaviour
+ *   exactly.
+ */
+export function servingUnitToPreselect<T extends KindedServingUnit>(
+    food: PreviouslyLoggedFood,
+    units: T[],
+): T | undefined {
+    if (hasLoggingHistory(food)) return undefined;
+    return units.find((unit) => unit.kind === SERVING_UNIT_KIND_SERVING);
+}


### PR DESCRIPTION
> **Stacked on #416** (`415-serving-unit-display-unit`) and based on it, not `main` — please merge #416 first; GitHub will retarget this to `main` automatically once it lands. The diff shown against the parent branch is only this PR's work.

closes #414

## The problem

`servingUnitsFromProduct` derives the serving units an OpenFoodFacts product implies, `addFoodWithServingUnits` writes them, and `UnitPicker` lists them first because "they are the ones most likely to be picked for that food" — but nothing ever *selected* one. Search "Red Bull Energy Drink", tap the result: the `ml` chip was active with amount 250 and the `serving` chip sat unselected beside it. The numbers happen to agree for that can; for a product whose serving is a fraction of the package, the pre-filled amount is simply not the one the user is going to log.

## What changes

Both entry paths — `useEntryForm` (log an entry) and `useRecipeEditor.openDraftForFood` (add a recipe ingredient) — now open a food **with no logging history** on its derived serving row at amount **`1`**, instead of `default_unit` + `serving_size`. `1` rather than `serving_size` because the whole point of the chip is that `1` is the number a user thinks in; the two would otherwise disagree ("250 servings").

Precedence, first match wins:

1. Editing an existing entry → that entry's own unit and amount (unchanged).
2. `last_logged_unit` + `last_logged_amount` → **still wins**. A food the user has logged before stays on whatever they chose. This PR only ever changes the first-time case.
3. The OFF `kind: "serving"` row → selected, amount `1`.
4. Otherwise → `default_unit` + `serving_size`, serving unit cleared, exactly as today.

## The `kind` column

Finding "the serving row" needs a marker on the row.

- **Not the name.** Names come from `i18n.t("common.offServingUnitServing")` and are frozen in the DB at import time, so a German-imported food carries `Portion` and matching the English string silently never fires.
- **Not `grams === food.serving_size`.** Holds for OFF imports by construction, but misfires on a user-added row of the same size.

So `serving_units` gains a nullable `kind`, holding `"serving"` or `"package"` for the two OFF-derived rows and `null` for every hand-added one. It is set in `servingUnitsFromProduct` beside the `display_unit` the parent branch added, and threaded through the same write paths: `addFoodWithServingUnits`, `duplicateFood`, `materializeFood`, and the share payload serializers.

Migration, appended after the `display_unit` entry in `src/services/db/index.ts` (nothing rewritten or reordered):

```
ALTER TABLE serving_units ADD COLUMN kind TEXT
```

**No backfill.** `null` is the correct value for every existing row: they predate the marker and there is no way to know now which of them came from OFF's serving quantity. Those foods therefore keep behaving exactly as they do today.

## Decisions taken, so they can be revisited deliberately

- **Only `kind === "serving"` is ever pre-selected, never `"package"`.** Pre-selecting the package row would default a 1 kg bag of rice to logging the whole bag — worse than defaulting it to 100 g.
- **The rule is "the OFF serving row", not "the first serving unit".** A user-added row (`kind` null) does **not** trigger pre-selection. The issue flags this as arguable; this is the narrow, honest reading — a row we did not derive says nothing about what one serving of the product is. Widening it later needs no further migration, only a change to `servingUnitToPreselect`.
- **Foods with no derived serving unit are untouched.**

## Where the logic lives

`src/services/servingUnits.ts` — a new app-wide service holding the `kind` vocabulary (`ServingUnitKind`, the two constants, `isServingUnitKind`) and the single rule `servingUnitToPreselect(food, units)`. Both entry paths call it, so the rule is stated once; an app-wide service is the layer both a `log` hook and a `templates` hook may import (feature-UI-to-feature-UI is not), and `openfoodfacts.ts` and `sharePayloads.ts` read the same vocabulary from it. It is pure — no DB, no i18n, no React — so it is directly testable.

## Sharing

Shares serialize serving units field by field, so the payload carries `kind` too, following the pattern the parent branch established for `display_unit`: **omitted when null**, so a payload for a plain grams-only food stays byte-identical to one built before either column existed, and `foodKey` normalizes it with `?? null` so old and new payloads key the same. An unrecognised `kind` off a payload is dropped to null rather than trusted. The backup and sync paths copy whole rows (`SELECT *` / `PRAGMA table_info`), so they needed no change.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run lint` — clean (including the `eslint-plugin-boundaries` layering rules for the new service).
- `npm test` — 5 suites, 102 tests, all passing.

New/extended tests:

- `src/services/__tests__/servingUnits.test.ts` (new) — the selection rule: picks the OFF serving row regardless of its position or its (deliberately German) name; never the package row; ignores a hand-added row, an absent `kind` and an unrecognised one; yields nothing once the food has both halves of a logging history, but still fires when only one half is set (the same condition the entry form has always used); nothing for a food with no serving units. Plus `isServingUnitKind`.
- `src/services/__tests__/openfoodfacts.test.ts` — a case asserting which OFF quantity each derived row is marked as, including that a pack-size-only product yields a `package` row and so nothing to pre-select, and that a can whose package is exactly one serving keeps the `serving` row. Existing serving-unit assertions updated to carry the new field.
- `src/features/share/services/__tests__/sharePayloads.test.ts` — a `kind` round-trip (send + write back on import) across a serving row, a package row and a hand-added row; unrecognised and missing kinds dropped to null; and an explicit `JSON.stringify` assertion that a payload with neither marker is byte-identical to the pre-#415 shape.

Not verified: I could not run the app on a device, so the visual result — the `serving (250 ml)` chip active with `1` in the amount field on a fresh Red Bull import, and the `ml`/`g` chips inactive — is reasoned from `UnitPicker`'s active-state logic (`selectedUnit === u && !selectedServingUnit` for plain units) and `RecipeItemModal`'s name-matching of `draft.quantityUnit`, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
